### PR TITLE
Add an option to disable doxygen

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,8 @@ SET(${PROJECT_NAME}_EXCLUDE_DISABLED_SUBPACKAGES_FROM_DISTRIBUTION_DEFAULT FALSE
 
 SET(TPL_ENABLE_Pthread OFF CACHE BOOL "")
 
+OPTION(SEACASProj_ENABLE_DOXYGEN "Enable Doxygen documentation creation." ON)
+
 # Do all of the processing for this Tribits project
 TRIBITS_PROJECT()
 

--- a/packages/seacas/libraries/exodus/CMakeLists.txt
+++ b/packages/seacas/libraries/exodus/CMakeLists.txt
@@ -55,14 +55,16 @@ if (${CMAKE_PROJECT_NAME} STREQUAL "SEACASProj")
    InstallSymLink(libexodus.a ${CMAKE_INSTALL_PREFIX}/lib/libexoIIv2c.a)
 
    # add a target to generate API documentation with Doxygen
-   find_package(Doxygen)
-   if(DOXYGEN_FOUND)
-     add_custom_command(TARGET exodus POST_BUILD
-        COMMAND ${DOXYGEN_EXECUTABLE} ARGS ${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-        COMMENT "Generating Exodus API documentation with Doxygen" VERBATIM
-        )
-   endif(DOXYGEN_FOUND)
+   if(SEACASProj_ENABLE_DOXYGEN)
+     find_package(Doxygen)
+     if(DOXYGEN_FOUND)
+       add_custom_command(TARGET exodus POST_BUILD
+          COMMAND ${DOXYGEN_EXECUTABLE} ARGS ${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile
+          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+          COMMENT "Generating Exodus API documentation with Doxygen" VERBATIM
+          )
+     endif(DOXYGEN_FOUND)
+   endif()
 endif()
 
 TRIBITS_ADD_TEST_DIRECTORIES(test)

--- a/packages/seacas/libraries/ioss/src/CMakeLists.txt
+++ b/packages/seacas/libraries/ioss/src/CMakeLists.txt
@@ -63,14 +63,16 @@ TRIBITS_ADD_LIBRARY(
 
 if (${CMAKE_PROJECT_NAME} STREQUAL "SEACASProj")
    # add a target to generate API documentation with Doxygen
-   find_package(Doxygen)
-   if(DOXYGEN_FOUND)
-     add_custom_command(TARGET Ioss
-        COMMAND ${DOXYGEN_EXECUTABLE} ARGS Doxyfile
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/..
-        COMMENT "Generating IOSS API documentation with Doxygen" VERBATIM
-      )     
-   endif(DOXYGEN_FOUND)
+   if(SEACASProj_ENABLE_DOXYGEN)
+     find_package(Doxygen)
+     if(DOXYGEN_FOUND)
+       add_custom_command(TARGET Ioss
+          COMMAND ${DOXYGEN_EXECUTABLE} ARGS Doxyfile
+          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/..
+          COMMENT "Generating IOSS API documentation with Doxygen" VERBATIM
+        )     
+     endif(DOXYGEN_FOUND)
+   endif()
 endif()
 
 IF (${PACKAGE_NAME}_ENABLE_SEACASExodus)


### PR DESCRIPTION
Fixes #114

Add an option SEACASProj_ENABLE_DOXYGEN that allows the doxygen to be
enabled or disabled at configure time. The default is ON which preserves
the existing behavior.