### PR TITLE
Avoid Real[N] in registry if ignoring such fields

### DIFF
--- a/packages/seacas/libraries/ioss/src/Ioss_VariableType.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_VariableType.C
@@ -186,6 +186,10 @@ namespace Ioss {
     bool match = false;
     for (const auto &vtype : registry()) {
       auto *tst_ivt = vtype.second;
+      if (ignore_realn_fields && Ioss::Utils::substr_equal("Real", tst_ivt->name()))
+      {
+        continue;
+      }
       if (tst_ivt->suffix_count() == static_cast<int>(size)) {
         if (tst_ivt->match(suffices)) {
           ivt   = tst_ivt;


### PR DESCRIPTION
The state of `ignore_realn_fields` is not considered when handing out a variable from the factory registry. Fix #314