### PR TITLE
IOSS: Make assembly member invalid reference on input to be a warning…

### DIFF
--- a/packages/seacas/libraries/ioss/src/Ioss_Utils.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Utils.C
@@ -1071,6 +1071,31 @@ std::string Ioss::Utils::shape_to_string(const Ioss::ElementShape &shape)
   return std::string("Invalid shape [") + std::to_string(unsigned(shape)) + std::string("]");
 }
 
+std::string Ioss::Utils::entity_type_to_string(const Ioss::EntityType &type)
+{
+  switch (type) {
+      case Ioss::EntityType::NODEBLOCK: return std::string("NODEBLOCK");
+      case Ioss::EntityType::EDGEBLOCK: return std::string("EDGEBLOCK");
+      case Ioss::EntityType::FACEBLOCK: return std::string("FACEBLOCK");
+      case Ioss::EntityType::ELEMENTBLOCK: return std::string("ELEMENTBLOCK");
+      case Ioss::EntityType::NODESET: return std::string("NODESET");
+      case Ioss::EntityType::EDGESET: return std::string("EDGESET");
+      case Ioss::EntityType::FACESET: return std::string("FACESET");
+      case Ioss::EntityType::ELEMENTSET: return std::string("ELEMENTSET");
+      case Ioss::EntityType::SIDESET: return std::string("SIDESET");
+      case Ioss::EntityType::SURFACE: return std::string("SURFACE");
+      case Ioss::EntityType::COMMSET: return std::string("COMMSET");
+      case Ioss::EntityType::SIDEBLOCK: return std::string("SIDEBLOCK");
+      case Ioss::EntityType::REGION: return std::string("REGION");
+      case Ioss::EntityType::SUPERELEMENT: return std::string("SUPERELEMENT");
+      case Ioss::EntityType::STRUCTUREDBLOCK: return std::string("STRUCTUREDBLOCK");
+      case Ioss::EntityType::ASSEMBLY: return std::string("ASSEMBLY");
+      case Ioss::EntityType::BLOB: return std::string("BLOB");
+      case Ioss::EntityType::INVALID_TYPE: return std::string("INVALID_TYPE");
+  }
+  return std::string("Invalid entity type [") + std::to_string(unsigned(type)) + std::string("]");
+}
+
 unsigned int Ioss::Utils::hash(const std::string &name)
 {
   // Hash function from Aho, Sethi, Ullman "Compilers: Principles,

--- a/packages/seacas/libraries/ioss/src/Ioss_Utils.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Utils.h
@@ -8,6 +8,7 @@
 
 #include <Ioss_CodeTypes.h>
 #include <Ioss_ElementTopology.h>
+#include <Ioss_EntityType.h>
 #include <Ioss_Field.h>
 #include <Ioss_Property.h>
 #include <Ioss_Sort.h>
@@ -495,6 +496,8 @@ namespace Ioss {
                                            size_t copies, size_t max_var_len);
 
     static std::string shape_to_string(const Ioss::ElementShape &shape);
+
+    static std::string entity_type_to_string(const Ioss::EntityType &type);
 
     /** \brief Create a nominal mesh for use in history databases.
      *

--- a/packages/seacas/libraries/ioss/src/exodus/Ioex_BaseDatabaseIO.C
+++ b/packages/seacas/libraries/ioss/src/exodus/Ioex_BaseDatabaseIO.C
@@ -748,11 +748,10 @@ namespace Ioex {
         for (int j = 0; j < assembly.entity_count; j++) {
           auto *ge = get_region()->get_entity(assembly.entity_list[j], type);
           if (ge == nullptr) {
-            std::ostringstream errmsg;
-            fmt::print(errmsg,
+            fmt::print(Ioss::WarnOut(),
                        "Error: Failed to find entity of type {} with id {} for assembly {}.\n",
-                       type, assembly.entity_list[j], assem->name());
-            IOSS_ERROR(errmsg);
+                       Ioss::Utils::entity_type_to_string(type), assembly.entity_list[j], assem->name());
+            continue;
           }
 
           if (!Ioss::Utils::block_is_omitted(ge)) {


### PR DESCRIPTION
… with a clearer message, instead of a fatal error. This sometimes happens when element blocks are filtered but the exodus assembly still tries to reference it internally