### PR TITLE
Adding fortran wrapper for ex_put_partial_var

### DIFF
--- a/packages/seacas/libraries/exoIIv2for32/src/exo_jack_32.c
+++ b/packages/seacas/libraries/exoIIv2for32/src/exo_jack_32.c
@@ -2072,7 +2072,6 @@ void F2C(expnv, EXPNV)(int *idexo, int *time_step, int *nodal_var_index, void_in
   else {
     nnodes = *(int *)num_nodes;
   }
-
   *ierr = ex_put_var(*idexo, *time_step, EX_NODAL, *nodal_var_index, 1, nnodes, nodal_var_vals);
 }
 
@@ -3745,5 +3744,33 @@ void F2C(expecm, EXPECM)(int *idne, entity_id *map_id, void_int *elem_ids, void_
     snprintf(errmsg, MAX_ERR_LENGTH, "Error: failed to write elemental comm map to file id %d",
              *idne);
     ex_err_fn(*idne, __func__, errmsg, EX_MSG);
+  }
+}
+
+/*
+ * writes the values of a single variable for a partial block at one time
+ * step to the database; assume the first time step and variable index
+ * are 1
+ * \sa ex_put_partial_var()
+ */
+void F2C(exppv, EXPPV)(int *idexo, int *time_step, int *var_type, int *var_index, 
+                       entity_id *obj_id, void_int *start_index, void_int *num_entities, 
+                       real *var_vals, int *ierr)
+{
+  int64_t start_index64, num_entities64;
+  if (ex_int64_status(*idexo) & EX_BULK_INT64_API) {
+    start_index64  = *(int64_t *) start_index;
+    num_entities64 = *(int64_t *) num_entities;
+  }
+  else {
+    start_index64 = *(int *) start_index;
+    num_entities64 = *(int *) num_entities;
+  }
+  if ((*ierr = ex_put_partial_var(*idexo, *time_step, (ex_entity_type)*var_type, *var_index,
+                       *obj_id, start_index64, num_entities64, var_vals)) != 0) {
+    char errmsg[MAX_ERR_LENGTH];
+    snprintf(errmsg, MAX_ERR_LENGTH, "Error: failed to write variable slab to file id %d",
+             * idexo);
+    ex_err_fn(* idexo, __func__, errmsg, EX_MSG);
   }
 }

--- a/packages/seacas/libraries/exoIIv2for32/src/exo_jack_32.c
+++ b/packages/seacas/libraries/exoIIv2for32/src/exo_jack_32.c
@@ -3747,6 +3747,85 @@ void F2C(expecm, EXPECM)(int *idne, entity_id *map_id, void_int *elem_ids, void_
   }
 }
 
+/*!
+ * reads the coordinates of some of the nodes in the model for the specified component
+ * \sa ex_get_partial_coord_component
+ */
+void F2C(exgpcc,EXGPCC)(int *exoid, void_int *start_node_num, void_int *num_nodes,
+                      int *component, real *coor, int *ierr)
+{
+  int64_t start_node_num64, num_nodes64;
+  if (ex_int64_status(*exoid) & EX_BULK_INT64_API) {
+    start_node_num64  = *(int64_t *) start_node_num;
+    num_nodes64 = *(int64_t *) num_nodes;
+  }
+  else {
+    start_node_num64 = *(int *) start_node_num;
+    num_nodes64 = *(int *) num_nodes;
+  }
+  if ((*ierr = ex_get_partial_coord_component(*exoid, start_node_num64, num_nodes64,
+                                   *component, coor)) != 0) {
+    char errmsg[MAX_ERR_LENGTH];
+    snprintf(errmsg, MAX_ERR_LENGTH, "Error: failed to read coordinate component  slab to file id %d",
+             * exoid);
+    ex_err_fn(* exoid, __func__, errmsg, EX_MSG);
+  }
+}
+
+/*!
+ * writes the coordinates of some of the nodes in the model for the specified component
+ * \sa ex_put_partial_coord_component
+ */
+
+void F2C(exppcc,EXPPCC)(int *exoid, void_int *start_node_num, void_int *num_nodes,
+                        int *component, real *coor, int *ierr)
+{
+  int64_t start_node_num64, num_nodes64;
+  if (ex_int64_status(*exoid) & EX_BULK_INT64_API) {
+    start_node_num64  = *(int64_t *) start_node_num;
+    num_nodes64 = *(int64_t *) num_nodes;
+  }
+  else {
+    start_node_num64 = *(int *) start_node_num;
+    num_nodes64 = *(int *) num_nodes;
+  }
+  if ((*ierr = ex_put_partial_coord_component(*exoid, start_node_num64, num_nodes64,
+                                   *component, coor)) != 0) {
+    char errmsg[MAX_ERR_LENGTH];
+    snprintf(errmsg, MAX_ERR_LENGTH, "Error: failed to write coordinate component  slab to file id %d",
+             * exoid);
+    ex_err_fn(* exoid, __func__, errmsg, EX_MSG);
+  }
+}
+
+/*
+ * read the values of a single variable for a partial block at one time
+ * step to the database; assume the first time step and variable index
+ * are 1
+ * \sa ex_get_partial_var()
+ */
+void F2C(exgpv, EXGPV)(int *idexo, int *time_step, int *var_type, int *var_index, 
+                       entity_id *obj_id, void_int *start_index, void_int *num_entities, 
+                       real *var_vals, int *ierr)
+{
+  int64_t start_index64, num_entities64;
+  if (ex_int64_status(*idexo) & EX_BULK_INT64_API) {
+    start_index64  = *(int64_t *) start_index;
+    num_entities64 = *(int64_t *) num_entities;
+  }
+  else {
+    start_index64 = *(int *) start_index;
+    num_entities64 = *(int *) num_entities;
+  }
+  if ((*ierr = ex_get_partial_var(*idexo, *time_step, (ex_entity_type)*var_type, *var_index,
+                       *obj_id, start_index64, num_entities64, var_vals)) != 0) {
+    char errmsg[MAX_ERR_LENGTH];
+    snprintf(errmsg, MAX_ERR_LENGTH, "Error: failed to write variable slab to file id %d",
+             * idexo);
+    ex_err_fn(* idexo, __func__, errmsg, EX_MSG);
+  }
+}
+
 /*
  * writes the values of a single variable for a partial block at one time
  * step to the database; assume the first time step and variable index

--- a/packages/seacas/libraries/exodus_for/src/addrwrap.F
+++ b/packages/seacas/libraries/exodus_for/src/addrwrap.F
@@ -4034,18 +4034,16 @@ C> writes the values of a single variable for a partial block at one time
         INTEGER*4 time_step4    ! (R)
         INTEGER*4 var_type4     ! (R)
         INTEGER*4 var_index4    ! (R)
-        INTEGER*4 obj_id4       ! (R)
         INTEGER*4 ierr4         ! (W)
 
 		idexo4        = idexo
 		time_step4    = time_step
 		var_type4     = var_type
 		var_index4    = var_index
-		obj_id4       = obj_id
 		ierr4         = ierr
 
         CALL EXGPV4(idexo4, time_step4, var_type4, var_index4, 
-     &                  obj_id4, start_index, num_entities, 
+     &                  obj_id, start_index, num_entities, 
      &                  var_vals, ierr4)
         IERR = IERR4
         END
@@ -4074,7 +4072,6 @@ C> writes the values of a single variable for a partial block at one time
         INTEGER*4 time_step4    ! (R)
         INTEGER*4 var_type4     ! (R)
         INTEGER*4 var_index4    ! (R)
-        INTEGER*4 obj_id4       ! (R)
         INTEGER*4 ierr4         ! (W)
 
 		idexo4        = idexo
@@ -4085,7 +4082,7 @@ C> writes the values of a single variable for a partial block at one time
 		ierr4         = ierr
 
         CALL EXPPV4(idexo4, time_step4, var_type4, var_index4, 
-     &                  obj_id4, start_index, num_entities, 
+     &                  obj_id, start_index, num_entities, 
      &                  var_vals, ierr4)
         IERR = IERR4
         END

--- a/packages/seacas/libraries/exodus_for/src/addrwrap.F
+++ b/packages/seacas/libraries/exodus_for/src/addrwrap.F
@@ -3977,8 +3977,6 @@ C> writes the values of a single variable for a partial block at one time
         INTEGER*4 var_type4     ! (R)
         INTEGER*4 var_index4    ! (R)
         INTEGER*4 obj_id4       ! (R)
-        INTEGER*4 start_index4  ! (R)
-        INTEGER*4 num_entities4 ! (R)
         INTEGER*4 ierr4         ! (W)
 
 		idexo4        = idexo
@@ -3986,13 +3984,11 @@ C> writes the values of a single variable for a partial block at one time
 		var_type4     = var_type
 		var_index4    = var_index
 		obj_id4       = obj_id
-		start_index4  = start_index
-		num_entities4 = num_entities
 		ierr4         = ierr
 
-        CALL exppv4(idexo, time_step, var_type, var_index, 
-     &                  obj_id, start_index, num_entities, 
-     &                  var_vals, ierr)
+        CALL exppv4(idexo4, time_step4, var_type4, var_index4, 
+     &                  obj_id4, start_index, num_entities, 
+     &                  var_vals, ierr4)
         IERR = IERR4
         END
 

--- a/packages/seacas/libraries/exodus_for/src/addrwrap.F
+++ b/packages/seacas/libraries/exodus_for/src/addrwrap.F
@@ -3954,8 +3954,66 @@ C> ex_put_elem_cmap()
 
 C-----------------------------------------------------------------------
 
-C> \sa ex_put_partial_var()
-       subroutine exppv(idexo, time_step, var_type, var_index,
+C> \sa ex_get_partial_coord_component()
+       SUBROUTINE EXGPCC(exoid, start_node_num, num_nodes, component,
+     & coor, ierr)
+C> writes the coordinates of some of the nodes in the model for the specified component
+
+       IMPLICIT NONE
+       INCLUDE 'exodusII.inc'
+       INTEGER exoid           ! (R)
+       INTEGER start_node_num  ! (R)
+       INTEGER num_nodes       ! (R)
+       INTEGER component       ! (R)
+       REAL coor(*)            ! (R)
+       INTEGER ierr            ! (W)
+
+       INTEGER*4 exoid4        ! (R)
+       INTEGER*4 component4    ! (R)
+       INTEGER*4 ierr4         ! (W)
+
+       exoid4        = exoid
+       component4    = component
+       ierr4         = ierr
+
+       CALL EXGPCC4(exoid4, start_node_num, num_nodes, component4, 
+     & coor, ierr4)
+       IERR = IERR4
+       END
+
+C-----------------------------------------------------------------------
+
+C> \sa ex_put_partial_coord_component()
+       SUBROUTINE EXPPCC(exoid, start_node_num, num_nodes, component,
+     & coor, ierr)
+C> writes the coordinates of some of the nodes in the model for the specified component
+
+       IMPLICIT NONE
+       INCLUDE 'exodusII.inc'
+       INTEGER exoid           ! (R)
+       INTEGER start_node_num  ! (R)
+       INTEGER num_nodes       ! (R)
+       INTEGER component       ! (R)
+       REAL coor(*)            ! (R)
+       INTEGER ierr            ! (W)
+
+       INTEGER*4 exoid4        ! (R)
+       INTEGER*4 component4    ! (R)
+       INTEGER*4 ierr4         ! (W)
+
+       exoid4        = exoid
+       component4    = component
+       ierr4         = ierr
+
+       CALL EXPPCC4(exoid4, start_node_num, num_nodes, component4, 
+     & coor, ierr4)
+       IERR = IERR4
+       END
+
+C-----------------------------------------------------------------------
+
+C> \sa ex_get_partial_var()
+       SUBROUTINE EXGPV(idexo, time_step, var_type, var_index,
      &                  obj_id, start_index, num_entities,
      &                  var_vals, ierr)
 C> writes the values of a single variable for a partial block at one time
@@ -3969,7 +4027,7 @@ C> writes the values of a single variable for a partial block at one time
         INTEGER obj_id          ! (R)
         INTEGER start_index     ! (R)
         INTEGER num_entities    ! (R)
-        REAL    var_vals(*)      ! (W)
+        REAL    var_vals(*)     ! (W)
         INTEGER ierr            ! (W)
 
         INTEGER*4 idexo4        ! (R)
@@ -3986,7 +4044,47 @@ C> writes the values of a single variable for a partial block at one time
 		obj_id4       = obj_id
 		ierr4         = ierr
 
-        CALL exppv4(idexo4, time_step4, var_type4, var_index4, 
+        CALL EXGPV4(idexo4, time_step4, var_type4, var_index4, 
+     &                  obj_id4, start_index, num_entities, 
+     &                  var_vals, ierr4)
+        IERR = IERR4
+        END
+
+C-----------------------------------------------------------------------
+
+C> \sa ex_put_partial_var()
+       SUBROUTINE EXPPV(idexo, time_step, var_type, var_index,
+     &                  obj_id, start_index, num_entities,
+     &                  var_vals, ierr)
+C> writes the values of a single variable for a partial block at one time
+
+        IMPLICIT NONE
+        INCLUDE 'exodusII.inc'
+        INTEGER idexo           ! (R)
+        INTEGER time_step       ! (R)
+        INTEGER var_type        ! (R)
+        INTEGER var_index       ! (R)
+        INTEGER obj_id          ! (R)
+        INTEGER start_index     ! (R)
+        INTEGER num_entities    ! (R)
+        REAL    var_vals(*)     ! (W)
+        INTEGER ierr            ! (W)
+
+        INTEGER*4 idexo4        ! (R)
+        INTEGER*4 time_step4    ! (R)
+        INTEGER*4 var_type4     ! (R)
+        INTEGER*4 var_index4    ! (R)
+        INTEGER*4 obj_id4       ! (R)
+        INTEGER*4 ierr4         ! (W)
+
+		idexo4        = idexo
+		time_step4    = time_step
+		var_type4     = var_type
+		var_index4    = var_index
+		obj_id4       = obj_id
+		ierr4         = ierr
+
+        CALL EXPPV4(idexo4, time_step4, var_type4, var_index4, 
      &                  obj_id4, start_index, num_entities, 
      &                  var_vals, ierr4)
         IERR = IERR4

--- a/packages/seacas/libraries/exodus_for/src/addrwrap.F
+++ b/packages/seacas/libraries/exodus_for/src/addrwrap.F
@@ -3950,7 +3950,52 @@ C> ex_put_elem_cmap()
      $  proc_ids, processor4, ierr4)
       ierr = ierr4
 
-         end
+      end
+
+C-----------------------------------------------------------------------
+
+C> \sa ex_put_partial_var()
+       subroutine exppv(idexo, time_step, var_type, var_index,
+     &                  obj_id, start_index, num_entities,
+     &                  var_vals, ierr)
+C> writes the values of a single variable for a partial block at one time
+
+        IMPLICIT NONE
+        INCLUDE 'exodusII.inc'
+        INTEGER idexo           ! (R)
+        INTEGER time_step       ! (R)
+        INTEGER var_type        ! (R)
+        INTEGER var_index       ! (R)
+        INTEGER obj_id          ! (R)
+        INTEGER start_index     ! (R)
+        INTEGER num_entities    ! (R)
+        REAL    var_vals(*)      ! (W)
+        INTEGER ierr            ! (W)
+
+        INTEGER*4 idexo4        ! (R)
+        INTEGER*4 time_step4    ! (R)
+        INTEGER*4 var_type4     ! (R)
+        INTEGER*4 var_index4    ! (R)
+        INTEGER*4 obj_id4       ! (R)
+        INTEGER*4 start_index4  ! (R)
+        INTEGER*4 num_entities4 ! (R)
+        INTEGER*4 ierr4         ! (W)
+
+		idexo4        = idexo
+		time_step4    = time_step
+		var_type4     = var_type
+		var_index4    = var_index
+		obj_id4       = obj_id
+		start_index4  = start_index
+		num_entities4 = num_entities
+		ierr4         = ierr
+
+        CALL exppv4(idexo, time_step, var_type, var_index, 
+     &                  obj_id, start_index, num_entities, 
+     &                  var_vals, ierr)
+        IERR = IERR4
+        END
+
 C-----------------------------------------------------------------------
 
         SUBROUTINE I8I4 (N, I8, PI4)

--- a/packages/seacas/libraries/exodus_for/src/addrwrap.F
+++ b/packages/seacas/libraries/exodus_for/src/addrwrap.F
@@ -4078,7 +4078,6 @@ C> writes the values of a single variable for a partial block at one time
 		time_step4    = time_step
 		var_type4     = var_type
 		var_index4    = var_index
-		obj_id4       = obj_id
 		ierr4         = ierr
 
         CALL EXPPV4(idexo4, time_step4, var_type4, var_index4, 

--- a/packages/seacas/libraries/exodus_for/src/exo_jack.c
+++ b/packages/seacas/libraries/exodus_for/src/exo_jack.c
@@ -3748,6 +3748,86 @@ void F2C(expecm, EXPECM)(int *idne, entity_id *map_id, void_int *elem_ids, void_
   }
 }
 
+/*
+ * read the values of a single variable for a partial block at one time
+ * step to the database; assume the first time step and variable index
+ * are 1
+ * \sa ex_get_partial_var()
+ */
+void F2C(exgpv, EXGPV)(int *idexo, int *time_step, int *var_type, int *var_index, 
+                       entity_id *obj_id, void_int *start_index, void_int *num_entities, 
+                       real *var_vals, int *ierr)
+{
+  int64_t start_index64, num_entities64;
+  if (ex_int64_status(*idexo) & EX_BULK_INT64_API) {
+    start_index64  = *(int64_t *) start_index;
+    num_entities64 = *(int64_t *) num_entities;
+  }
+  else {
+    start_index64 = *(int *) start_index;
+    num_entities64 = *(int *) num_entities;
+  }
+  if ((*ierr = ex_get_partial_var(*idexo, *time_step, (ex_entity_type)*var_type, *var_index,
+                       *obj_id, start_index64, num_entities64, var_vals)) != 0) {
+    char errmsg[MAX_ERR_LENGTH];
+    snprintf(errmsg, MAX_ERR_LENGTH, "Error: failed to write variable slab to file id %d",
+             * idexo);
+    ex_err_fn(* idexo, __func__, errmsg, EX_MSG);
+  }
+}
+
+
+/*!
+ * reads the coordinates of some of the nodes in the model for the specified component
+ * \sa ex_get_partial_coord_component
+ */
+void F2C(exgpcc,EXGPCC)(int *exoid, void_int *start_node_num, void_int *num_nodes,
+                      int *component, real *coor, int *ierr)
+{
+  int64_t start_node_num64, num_nodes64;
+  if (ex_int64_status(*exoid) & EX_BULK_INT64_API) {
+    start_node_num64  = *(int64_t *) start_node_num;
+    num_nodes64 = *(int64_t *) num_nodes;
+  }
+  else {
+    start_node_num64 = *(int *) start_node_num;
+    num_nodes64 = *(int *) num_nodes;
+  }
+  if ((*ierr = ex_get_partial_coord_component(*exoid, start_node_num64, num_nodes64,
+                                   *component, coor)) != 0) {
+    char errmsg[MAX_ERR_LENGTH];
+    snprintf(errmsg, MAX_ERR_LENGTH, "Error: failed to read coordinate component  slab to file id %d",
+             * exoid);
+    ex_err_fn(* exoid, __func__, errmsg, EX_MSG);
+  }
+}
+
+/*!
+ * writes the coordinates of some of the nodes in the model for the specified component
+ * \sa ex_put_partial_coord_component
+ */
+
+void F2C(exppcc,EXPPCC)(int *exoid, void_int *start_node_num, void_int *num_nodes,
+                        int *component, real *coor, int *ierr)
+{
+  int64_t start_node_num64, num_nodes64;
+  if (ex_int64_status(*exoid) & EX_BULK_INT64_API) {
+    start_node_num64  = *(int64_t *) start_node_num;
+    num_nodes64 = *(int64_t *) num_nodes;
+  }
+  else {
+    start_node_num64 = *(int *) start_node_num;
+    num_nodes64 = *(int *) num_nodes;
+  }
+  if ((*ierr = ex_put_partial_coord_component(*exoid, start_node_num64, num_nodes64,
+                                   *component, coor)) != 0) {
+    char errmsg[MAX_ERR_LENGTH];
+    snprintf(errmsg, MAX_ERR_LENGTH, "Error: failed to write coordinate component  slab to file id %d",
+             * exoid);
+    ex_err_fn(* exoid, __func__, errmsg, EX_MSG);
+  }
+}
+
 
 /*!
  * writes the values of a single variable for a partial block at one time

--- a/packages/seacas/libraries/exodus_for/src/exo_jack.c
+++ b/packages/seacas/libraries/exodus_for/src/exo_jack.c
@@ -3747,3 +3747,32 @@ void F2C(expecm, EXPECM)(int *idne, entity_id *map_id, void_int *elem_ids, void_
     ex_err_fn(*idne, __func__, errmsg, EX_MSG);
   }
 }
+
+
+/*!
+ * writes the values of a single variable for a partial block at one time
+ * step to the database; assume the first time step and variable index
+ * are 1
+ * \sa ex_put_partial_var()
+ */
+void F2C(exppv, EXPPV)(int *idexo, int *time_step, int *var_type, int *var_index, 
+                       entity_id *obj_id, int64_t *start_index, int64_t *num_entities, 
+                       real *var_vals, int *ierr)
+{
+  int64_t start_index64, num_entities64;
+  if (ex_int64_status(*idexo) & EX_BULK_INT64_API) {
+    start_index64  = *(int64_t *) start_index;
+    num_entities64 = *(int64_t *) num_entities;
+  }
+  else {
+    start_index64 = *(int *) start_index;
+    num_entities64 = *(int *) num_entities;
+  }
+  if ((*ierr = ex_put_partial_var(*idexo, *time_step, (ex_entity_type)*var_type, *var_index,
+                       *obj_id, *start_index, *num_entities, var_vals)) != 0) {
+    char errmsg[MAX_ERR_LENGTH];
+    snprintf(errmsg, MAX_ERR_LENGTH, "Error: failed to write variable slab to file id %d",
+             * idexo);
+    ex_err_fn(* idexo, __func__, errmsg, EX_MSG);
+  }
+}

--- a/packages/seacas/libraries/exodus_for/test/testpart.f90
+++ b/packages/seacas/libraries/exodus_for/test/testpart.f90
@@ -1,0 +1,76 @@
+Program TestExoRead_Part
+#include "exodusII.inc"
+   !Use exodusIIF90
+
+   Integer                      :: exoid,cpu_ws,io_ws,mod_sz,ierr
+   Integer                      :: num_dim,num_nodes,num_elem,num_elem_blk,num_node_sets,num_side_sets
+   Integer                      :: time_step = 1,var_index = 3,i,nparts
+   Integer                      :: istart,iend,len
+   Real,dimension(:),Pointer    :: var_values
+   character*(MXLNLN)           :: titl
+   Real                         :: vers
+
+
+   cpu_ws = 0
+   io_ws = 0
+
+   exoid = exopen ("test.exo", EXWRIT, cpu_ws, io_ws, vers, ierr)
+   write (*, '("after exopen, error = ",i3)') ierr
+
+   write (*, '("test.exo is an EXODUSII file; version ", f4.2)') vers
+   write (*, '("  I/O word size",i2)') io_ws
+   write (*, '("  CPU word size",i2)') cpu_ws
+   mod_sz = exlgmd(exoid)
+   write (*, '("  Model Size",i2)') mod_sz
+
+   call exgini (exoid, titl, num_dim, num_nodes, num_elem,num_elem_blk, num_node_sets, num_side_sets, ierr)
+   write (*, '("after exgini, error = ", i3)' ) ierr
+
+   write (*, '("database parameters")')
+   write (*, '("   title = ",a81)') titl
+   write (*, '("   num_dim = ", i3 )') num_dim
+   write (*, '("   num_nodes = ", i3 )') num_nodes
+   write (*, '("   num_elem = ", i3 )') num_elem
+   write (*, '("   num_elem_blk = ", i3 )') num_elem_blk
+   write (*, '("   num_node_sets = ", i3 )') num_node_sets
+   write (*, '("   num_side_sets = ", i3)') num_side_sets
+
+   Allocate(var_values(num_nodes))
+   call exgnv (exoid, time_step, var_index, num_nodes, var_values,ierr)
+   write (*, '("after exgnv, error = ", i3)' ) ierr
+   write(*,*) var_values
+   
+   call expnv (exoid, time_step, var_index, num_nodes, var_values,ierr)
+   DeAllocate(var_values)
+
+   nparts=4
+   Do i = 1, nparts
+      istart = (i-1)*num_nodes/nparts+1
+      iend   = i*num_nodes/nparts
+      len    = iend - istart + 1
+      write(*,'("   chunk ",i3," -- ",i3, ":")') istart,iend
+      Allocate(var_values(len))
+      call exgpv(exoid, time_step, EX_NODAL,var_index,0,istart,len,var_values,ierr)
+      write(*,*) '   *', var_values
+      var_values = var_values + 1
+      call exppv(exoid,time_step,EX_NODAL,var_index,0,istart,len,var_values,ierr)
+      call exupda(exoid,ierr)
+      DeAllocate(var_values)
+   End Do
+
+   Do i = 1, nparts
+      istart = (i-1)*num_nodes/nparts+1
+      iend   = i*num_nodes/nparts
+      len    = iend - istart + 1
+      write(*,'("   chunk ",i3," -- ",i3, ":")') istart,iend
+      Allocate(var_values(len))
+      call exgpcc(exoid,istart,len,1,var_values,ierr)
+      write(*,*) '   coord', var_values
+      var_values = var_values + 1
+      call exppcc(exoid,istart,len,1,var_values,ierr)
+      DeAllocate(var_values)
+   End Do
+
+   call exclos (exoid, ierr)
+   write (*, '("after exclos, error = ", i3)' ) ierr
+End Program TestExoRead_Part


### PR DESCRIPTION
This is not ready for inclusion. @gsjaardema can you help me figure out why the wrapper expo does not show up in `libexoIIv2for.a`?