### PR TITLE
EXODUS.PY: Proposed refactor in create/copy api to make things easier

### DIFF
--- a/packages/seacas/scripts/exodus3.in.py
+++ b/packages/seacas/scripts/exodus3.in.py
@@ -864,20 +864,23 @@ class exodus:
     def copy_file(self, file_id, include_transient=False):
         """
         Copies exodus database to the database pointed to by `fileId`
-        Does not return anything.
+        Returns the passed in `file_id`.
 
-        >>> exofile = exodus.exodus(file_name, mode='w')
-        >>> exo_copy = exo.copy_file(exofile.fileId, include_transient=True)
-        >>> exo_copy.close()
+        >>> with exodus.exodus(file_name, mode='w') as exofile:
+        >>>     with exo.copy_file(exofile.fileId, include_transient=True) as exo_copy:
+        >>>         exo_copy.close()
 
         Parameters
         ----------
         fileId : str
             name of exodus file to open
+        include_transient: bool
+            should the transient data in the original file also be copied to the output file
+            or just the mesh (non-transient) portion.
 
         Returns
         -------
-        file_id: The file_id of to copied to file
+        file_id: The file_id of the copied to file
         
         """
         EXODUS_LIB.ex_copy(self.fileId, file_id)

--- a/packages/seacas/scripts/exodus3.in.py
+++ b/packages/seacas/scripts/exodus3.in.py
@@ -1,5 +1,5 @@
 """
-exodus.py v 1.20.13 (seacas-py3) is a python wrapper of some of the exodus library
+exodus.py v 1.20.14 (seacas-py3) is a python wrapper of some of the exodus library
 (Python 3 Version)
 
 Exodus is a common database for multiple application codes (mesh
@@ -70,12 +70,12 @@ from enum import Enum
 
 EXODUS_PY_COPYRIGHT_AND_LICENSE = __doc__
 
-EXODUS_PY_VERSION = "1.20.13 (seacas-py3)"
+EXODUS_PY_VERSION = "1.20.14 (seacas-py3)"
 
 EXODUS_PY_COPYRIGHT = """
-You are using exodus.py v 1.20.13 (seacas-py3), a python wrapper of some of the exodus library.
+You are using exodus.py v 1.20.14 (seacas-py3), a python wrapper of some of the exodus library.
 
-Copyright (c) 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022 National Technology &
+Copyright (c) 2013-2022 National Technology &
 Engineering Solutions of Sandia, LLC (NTESS).  Under the terms of
 Contract DE-NA0003525 with NTESS, the U.S. Government retains certain
 rights in this software.
@@ -697,8 +697,8 @@ class exodus:
 
                 info = [title, numDims, numNodes, numElems, numBlocks,
                         numNodeSets, numSideSets]
-                assert None not in info
-                self.__ex_put_info(info)
+                if None not in info:
+                    self.__ex_put_info(info)
 
             self.numTimes = ctypes.c_int(0)
         else:
@@ -851,11 +851,40 @@ class exodus:
                                           ctypes.byref(self.io_ws),
                                           EX_API_VERSION_NODOT)
 
-        self.__copy_file(fileId, include_transient)
+        self.copy_file(fileId, include_transient)
         EXODUS_LIB.ex_close(fileId)
 
         return exodus(fileName, mode)
 
+
+    #
+    # copy to a new already created database
+    #
+    # --------------------------------------------------------------------
+    def copy_file(self, file_id, include_transient=False):
+        """
+        Copies exodus database to the database pointed to by `fileId`
+        Does not return anything.
+
+        >>> exofile = exodus.exodus(file_name, mode='w')
+        >>> exo_copy = exo.copy_file(exofile.fileId, include_transient=True)
+        >>> exo_copy.close()
+
+        Parameters
+        ----------
+        fileId : str
+            name of exodus file to open
+
+        Returns
+        -------
+        file_id: The file_id of to copied to file
+        
+        """
+        EXODUS_LIB.ex_copy(self.fileId, file_id)
+        if include_transient:
+            EXODUS_LIB.ex_copy_transient(self.fileId, file_id)
+
+        return file_id;
 
     #
     # general info
@@ -4859,15 +4888,6 @@ class exodus:
                                                ctypes.byref(self.comp_ws),
                                                ctypes.byref(self.io_ws),
                                                EX_API_VERSION_NODOT)
-
-    # --------------------------------------------------------------------
-
-    def __copy_file(self, fileId, include_transient=False):
-        if include_transient:
-            EXODUS_LIB.ex_copy(self.fileId, fileId)
-            EXODUS_LIB.ex_copy_transient(self.fileId, fileId)
-        else:
-            EXODUS_LIB.ex_copy(self.fileId, fileId)
 
     # --------------------------------------------------------------------
 


### PR DESCRIPTION
 A couple modifications to make an easier workflow for:

- Create an empty exodus file
- Add some qa / info records to the created file
- Copy an existing file onto the end of the created file

With the current api, it does not seem possible to create an empty file (with mode 'w' or 'w+') since there is an assertion that the `info` does not contain any None items.

This refactor removes that assertion and only outputs the initial parameters (ex_put_init call) if there is valid data.

It also exposes the `copy_file` function which takes the `file_id` of an already opened file instead of a filename.
This makes it posssible to append qa records to a file using:
```
original = exodus.exodus(ORIG_PATH)
qa_recs = original.get_qa_records()

with exodus.exodus(COPY_PATH, mode='w+') as exofile:
    QA = qa_recs + [("copy_script","0.1.2-3","20220801","12:34:56")]
    exofile.put_qa_records(QA)
    original.copy_file(exofile.fileId, include_transient=True)
```

Previously, needed to do something like:
```
original = exodus.exodus(ORIG_PATH)

title = "Copy of the base_ioshell.g".encode('ascii')
ex_pars = exodus.ex_init_params(title=title,
                                num_dim=original.num_dimensions(),
                                num_nodes=original.num_nodes(),
                                num_elem=original.num_elems(),
                                num_elem_blk=original.num_blks(),
                                num_node_sets=original.num_node_sets(),
                                num_side_sets=original.num_side_sets(),
                                num_assembly=original.num_assembly(),
                                num_blob=original.num_blob())

qa_recs = original.get_qa_records()

with exodus.exodus(COPY_PATH, mode='w+') as exofile:
    QA = qa_recs + [("copy_script","0.1.2-3","20220801","12:34:56")]
    exofile.put_qa_records(QA)
    exodus.copy_file(exofile.fileId)
    exodus.EXODUS_LIB.ex_copy(original.fileId, exofile.fileId)
    exodus.EXODUS_LIB.ex_copy_transient(original.fileId, exofile.fileId)
```
