### PR TITLE
Fix out of bounds error in get_max_time

### DIFF
--- a/packages/seacas/libraries/ioss/src/Ioss_Region.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Region.C
@@ -907,8 +907,8 @@ namespace Ioss {
     DatabaseIO *db = get_database();
     db->get_step_times();
 
-    int    step     = 0;
-    double max_time = stateTimes[0];
+    int    step     = stateTimes.empty() ? -1 : 0;
+    double max_time = stateTimes.empty() ? -1 : stateTimes[0];
     for (int i = 1; i < static_cast<int>(stateTimes.size()); i++) {
       if (stateTimes[i] > max_time) {
         step     = i;


### PR DESCRIPTION
The recent patch for negative time support worked well, but it segfaults when the dataset does not have times.