### PR TITLE
EXODUS.PY: Add a test for the copy_file method

### DIFF
--- a/packages/seacas/scripts/tests/test_exodus3.py
+++ b/packages/seacas/scripts/tests/test_exodus3.py
@@ -169,6 +169,20 @@ class TestAssemblies(unittest.TestCase):
         with exo.exodus(self.temp_exo_path) as temp_exofile:
             self.assertEqual(new, temp_exofile.get_qa_records())
 
+    def test_copy_file(self):
+        new = [("name","1.2.3-4","20220801","12:34:56")]
+        with exo.exodus(self.temp_exo_path) as exofile:
+            qa_recs = exofile.get_qa_records()
+        new_path = self.temp_exo_path.split(".exo")
+        new_path.extend(["_new", ".exo"])
+        new_path = "".join(new_path)
+        with exo.exodus(new_path, mode='w+') as exofile:
+            QA = qa_recs + new
+            exofile.put_qa_records(QA)
+            with exo.exodus(self.temp_exo_path) as orig:
+                orig.copy_file(exofile.fileId, include_transient=True)
+                self.assertIn(new[0], exofile.get_qa_records())
+
     def test_put_assembly(self):
         new = exo.assembly(name='Unit_test', type=exo.ex_entity_type.EX_ASSEMBLY, id=444)
         new.entity_list = [100, 222]

--- a/packages/seacas/scripts/tests/test_exodus3.py
+++ b/packages/seacas/scripts/tests/test_exodus3.py
@@ -171,14 +171,11 @@ class TestAssemblies(unittest.TestCase):
 
     def test_copy_file(self):
         new = [("name","1.2.3-4","20220801","12:34:56")]
+        new_path = os.path.join(self.tempdir.name, "temp-test-assembly_new.exo")
         with exo.exodus(self.temp_exo_path) as exofile:
             qa_recs = exofile.get_qa_records()
-        new_path = self.temp_exo_path.split(".exo")
-        new_path.extend(["_new", ".exo"])
-        new_path = "".join(new_path)
         with exo.exodus(new_path, mode='w+') as exofile:
-            QA = qa_recs + new
-            exofile.put_qa_records(QA)
+            exofile.put_qa_records(qa_recs + new)
             with exo.exodus(self.temp_exo_path) as orig:
                 orig.copy_file(exofile.fileId, include_transient=True)
                 self.assertIn(new[0], exofile.get_qa_records())


### PR DESCRIPTION
The interface for copy_file was exposed as part of merge request #325. This adds a test for it to the unittests.