### PR TITLE
Iopg_DatabaseIO.h: Add missing Assemlby get_field_internal macro

### DIFF
--- a/packages/seacas/libraries/ioss/src/pamgen/Iopg_DatabaseIO.h
+++ b/packages/seacas/libraries/ioss/src/pamgen/Iopg_DatabaseIO.h
@@ -127,6 +127,7 @@ namespace Iopg {
     NOOP_GFI(Ioss::ElementSet)
     NOOP_GFI(Ioss::SideSet)
     NOOP_GFI(Ioss::Blob)
+    NOOP_GFI(Ioss::Assembly)
 
     // Input only database -- these will never be called...
     NOOP_PFI(Ioss::Region)


### PR DESCRIPTION
GCC 10 would fail to compile pamgen due to a pure virtual method not being overridden. This adds the missing override.