### PR TITLE
Ioss_FileInfo.C: use unistd.h instead of sys/unistd.h

### DIFF
--- a/packages/seacas/libraries/ioss/src/Ioss_FileInfo.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_FileInfo.C
@@ -26,7 +26,7 @@
 #define S_ISDIR(m) (((m)&_S_IFMT) == _S_IFDIR)
 #endif
 #else
-#include <sys/unistd.h>
+#include <unistd.h>
 #if defined(__APPLE__) && defined(__MACH__)
 #include <sys/param.h>
 #include <sys/mount.h>
@@ -41,9 +41,6 @@
 
 #include <cstdio>
 #include <sys/stat.h>
-#ifndef _MSC_VER
-#include <unistd.h>
-#endif
 
 namespace {
   bool internal_access(const std::string &name, int mode);


### PR DESCRIPTION
Build fails on musl-based Linux distributions.

As for glibc, `sys/unistd.h` contains `#include <unistd.h>`, thus pointing to `unistd.h`.

Reference: void-linux/void-packages#40423 (https://github.com/void-linux/void-packages/actions/runs/3432806790/jobs/5722449115):

```
/builddir/vtk-9.2.2/ThirdParty/ioss/vtkioss/Ioss_FileInfo.C:29:10: fatal error: sys/unistd.h: No such file or directory
   29 | #include <sys/unistd.h>
      |          ^~~~~~~~~~~~~~
compilation terminated.
[8820/10163] Building CXX object ThirdParty/ioss/vtkioss/CMakeFiles/ioss.dir/Ioss_FieldManager.C.o
ninja: build stopped: subcommand failed.
=> ERROR: vtk-9.2.2_1: do_build: '${make_cmd} ${makejobs} ${make_build_args} ${make_build_target}' exited with 1
=> ERROR:   in do_build() at common/build-style/cmake.sh:93
Error: Process completed with exit code 1.
```