### PR TITLE
Catalyst Exodus Database

### DIFF
--- a/packages/seacas/libraries/ioss/src/visualization/catalyst/ioss2catalyst/IossApplication.cxx
+++ b/packages/seacas/libraries/ioss/src/visualization/catalyst/ioss2catalyst/IossApplication.cxx
@@ -298,14 +298,14 @@ void IossApplication::setOutputCopyOfInputDatabase(bool status) { copyDatabase =
 
 bool IossApplication::outputCatalystMeshOneFileON() { return writeCatalystMeshOneFile; }
 
-bool IossApplication::setOutputCatalystMeshOneFile(bool status)
+void IossApplication::setOutputCatalystMeshOneFile(bool status)
 {
   writeCatalystMeshOneFile = status;
 }
 
 bool IossApplication::outputCatalystMeshFilePerProcON() { return writeCatalystMeshFilePerProc; }
 
-bool IossApplication::setOutputCatalystMeshFilePerProc(bool status)
+void IossApplication::setOutputCatalystMeshFilePerProc(bool status)
 {
   writeCatalystMeshFilePerProc = status;
 }
@@ -372,11 +372,11 @@ void IossApplication::setCatalystStopTimeStep(int timeStep)
 
 bool IossApplication::forceCGNSOutputON() { return forceCGNSOutput; }
 
-bool IossApplication::setForceCGNSOutput(bool status) { forceCGNSOutput = status; }
+void IossApplication::setForceCGNSOutput(bool status) { forceCGNSOutput = status; }
 
 bool IossApplication::forceExodusOutputON() { return forceExodusOutput; }
 
-bool IossApplication::setForceExodusOutput(bool status) { forceExodusOutput = status; }
+void IossApplication::setForceExodusOutput(bool status) { forceExodusOutput = status; }
 
 bool IossApplication::useIOSSInputDBTypeON() { return useIOSSInputDBType; }
 

--- a/packages/seacas/libraries/ioss/src/visualization/catalyst/ioss2catalyst/IossApplication.h
+++ b/packages/seacas/libraries/ioss/src/visualization/catalyst/ioss2catalyst/IossApplication.h
@@ -35,16 +35,16 @@ public:
   void setOutputCopyOfInputDatabase(bool status);
 
   bool outputCatalystMeshOneFileON();
-  bool setOutputCatalystMeshOneFile(bool status);
+  void setOutputCatalystMeshOneFile(bool status);
 
   bool outputCatalystMeshFilePerProcON();
-  bool setOutputCatalystMeshFilePerProc(bool status);
+  void setOutputCatalystMeshFilePerProc(bool status);
 
   bool forceCGNSOutputON();
-  bool setForceCGNSOutput(bool status);
+  void setForceCGNSOutput(bool status);
 
   bool forceExodusOutputON();
-  bool setForceExodusOutput(bool status);
+  void setForceExodusOutput(bool status);
 
   bool        useIOSSInputDBTypeON();
   std::string getIOSSInputDBType();

--- a/packages/seacas/libraries/ioss/src/visualization/exodus/Iovs_exodus_DatabaseIO.C
+++ b/packages/seacas/libraries/ioss/src/visualization/exodus/Iovs_exodus_DatabaseIO.C
@@ -38,8 +38,8 @@ namespace Iovs_exodus {
       : Ioss::DatabaseIO(region,
                          Iovs::Utils::getInstance().getDatabaseOutputFilePath(filename, props),
                          db_usage, communicator, props),
-        isInput(false), singleProcOnly(false), doLogging(false),
-        nodeBlockCount(0), elementBlockCount(0)
+        isInput(false), singleProcOnly(false), doLogging(false), nodeBlockCount(0),
+        elementBlockCount(0)
   {
 
     Iovs::Utils::DatabaseInfo dbinfo;
@@ -65,7 +65,7 @@ namespace Iovs_exodus {
 
     if (state == Ioss::STATE_MODEL) {
       CatalystExodusMeshBase::ElementBlockIdNameList ebinList;
-      Ioss::ElementBlockContainer const &ebc = region->get_element_blocks();
+      Ioss::ElementBlockContainer const             &ebc = region->get_element_blocks();
       for (auto i : ebc) {
         ebinList.emplace_back(get_id(i, &ids_), i->name());
       }
@@ -131,11 +131,9 @@ namespace Iovs_exodus {
     for (I = element_blocks.begin(); I != element_blocks.end(); ++I) {
       int     bid       = get_id((*I), &ids_);
       int64_t eb_offset = (*I)->get_offset();
-      this->catExoMesh->CreateElementVariable("ids", 1, bid,
-                                              &this->elemMap.map()[eb_offset + 1]);
+      this->catExoMesh->CreateElementVariable("ids", 1, bid, &this->elemMap.map()[eb_offset + 1]);
       std::vector<int> object_id((*I)->entity_count(), bid);
-      this->catExoMesh->CreateElementVariable("object_id", 1, bid,
-                                              object_id.data());
+      this->catExoMesh->CreateElementVariable("object_id", 1, bid, object_id.data());
     }
     this->catExoMesh->CreateNodalVariable("ids", 1, &this->nodeMap.map()[1]);
 
@@ -226,9 +224,9 @@ namespace Iovs_exodus {
         }
       }
       else if (role == Ioss::Field::TRANSIENT) {
-        Ioss::Field::BasicType ioss_type = field.get_type();
-        int         comp_count = field.get_component_count(Ioss::Field::InOut::OUTPUT);
-        std::string field_name = field.get_name();
+        Ioss::Field::BasicType ioss_type  = field.get_type();
+        int                    comp_count = field.get_component_count(Ioss::Field::InOut::OUTPUT);
+        std::string            field_name = field.get_name();
 
         if (ioss_type == Ioss::Field::COMPLEX) {
           comp_count *= 2;
@@ -312,10 +310,10 @@ namespace Iovs_exodus {
         /* TODO */
       }
       else if (role == Ioss::Field::TRANSIENT) {
-        Ioss::Field::BasicType ioss_type = field.get_type();
-        int         comp_count = field.get_component_count(Ioss::Field::InOut::OUTPUT);
-        int         bid        = get_id(eb, &ids_);
-        std::string field_name = field.get_name();
+        Ioss::Field::BasicType ioss_type  = field.get_type();
+        int                    comp_count = field.get_component_count(Ioss::Field::InOut::OUTPUT);
+        int                    bid        = get_id(eb, &ids_);
+        std::string            field_name = field.get_name();
 
         if (ioss_type == Ioss::Field::COMPLEX) {
           comp_count *= 2;
@@ -566,6 +564,73 @@ namespace Iovs_exodus {
     Ioss::WarnOut() << ge->type() << " '" << ge->name() << "'. Unknown " << inout << " field '"
                     << field.get_name() << "'";
     return -4;
+  }
+
+  int64_t DatabaseIO::put_field_internal(const Ioss::EdgeBlock * /*eb*/, const Ioss::Field &field,
+                                         void * /*data*/, size_t data_size) const
+  {
+    return get_num_to_get(field, data_size);
+  }
+  int64_t DatabaseIO::put_field_internal(const Ioss::FaceBlock * /*fb*/, const Ioss::Field &field,
+                                         void * /*data*/, size_t data_size) const
+  {
+    return get_num_to_get(field, data_size);
+  }
+  int64_t DatabaseIO::put_field_internal(const Ioss::SideBlock * /*sb*/, const Ioss::Field &field,
+                                         void * /*data*/, size_t data_size) const
+  {
+    return get_num_to_get(field, data_size);
+  }
+  int64_t DatabaseIO::put_field_internal(const Ioss::NodeSet * /*ns*/, const Ioss::Field &field,
+                                         void * /*data*/, size_t data_size) const
+  {
+    return get_num_to_get(field, data_size);
+  }
+  int64_t DatabaseIO::put_field_internal(const Ioss::EdgeSet * /*es*/, const Ioss::Field &field,
+                                         void * /*data*/, size_t data_size) const
+  {
+    return get_num_to_get(field, data_size);
+  }
+  int64_t DatabaseIO::put_field_internal(const Ioss::FaceSet * /*fs*/, const Ioss::Field &field,
+                                         void * /*data*/, size_t data_size) const
+  {
+    return get_num_to_get(field, data_size);
+  }
+  int64_t DatabaseIO::put_field_internal(const Ioss::ElementSet * /*es*/, const Ioss::Field &field,
+                                         void * /*data*/, size_t data_size) const
+  {
+    return get_num_to_get(field, data_size);
+  }
+  int64_t DatabaseIO::put_field_internal(const Ioss::SideSet * /*ss*/, const Ioss::Field &field,
+                                         void * /*data*/, size_t data_size) const
+  {
+    return get_num_to_get(field, data_size);
+  }
+  int64_t DatabaseIO::put_field_internal(const Ioss::CommSet * /*cs*/, const Ioss::Field &field,
+                                         void * /*data*/, size_t data_size) const
+  {
+    return get_num_to_get(field, data_size);
+  }
+  int64_t DatabaseIO::put_field_internal(const Ioss::StructuredBlock * /*sb*/,
+                                         const Ioss::Field &field, void * /*data*/,
+                                         size_t             data_size) const
+  {
+    return get_num_to_get(field, data_size);
+  }
+  int64_t DatabaseIO::put_field_internal(const Ioss::Assembly * /*as*/, const Ioss::Field &field,
+                                         void * /*data*/, size_t data_size) const
+  {
+    return get_num_to_get(field, data_size);
+  }
+  int64_t DatabaseIO::put_field_internal(const Ioss::Blob * /*bl*/, const Ioss::Field &field,
+                                         void * /*data*/, size_t data_size) const
+  {
+    return get_num_to_get(field, data_size);
+  }
+  size_t DatabaseIO::get_num_to_get(const Ioss::Field &field, size_t data_size) const
+  {
+    size_t num_to_get = field.verify(data_size);
+    return num_to_get;
   }
 } // namespace Iovs_exodus
 

--- a/packages/seacas/libraries/ioss/src/visualization/exodus/Iovs_exodus_DatabaseIO.C
+++ b/packages/seacas/libraries/ioss/src/visualization/exodus/Iovs_exodus_DatabaseIO.C
@@ -26,6 +26,7 @@ namespace { // Internal helper functions
   int64_t get_id(const Ioss::GroupingEntity *entity, Iovs_exodus::EntityIdSet *idset);
   bool    set_id(const Ioss::GroupingEntity *entity, Iovs_exodus::EntityIdSet *idset);
   int64_t extract_id(const std::string &name_id);
+  size_t  get_num_to_get(const Ioss::Field &field, size_t data_size);
 } // End anonymous namespace
 
 namespace Iovs_exodus {
@@ -627,14 +628,15 @@ namespace Iovs_exodus {
   {
     return get_num_to_get(field, data_size);
   }
-  size_t DatabaseIO::get_num_to_get(const Ioss::Field &field, size_t data_size) const
+} // namespace Iovs_exodus
+
+namespace {
+
+  size_t get_num_to_get(const Ioss::Field &field, size_t data_size)
   {
     size_t num_to_get = field.verify(data_size);
     return num_to_get;
   }
-} // namespace Iovs_exodus
-
-namespace {
 
   int64_t get_id(const Ioss::GroupingEntity *entity, Iovs_exodus::EntityIdSet *idset)
   {

--- a/packages/seacas/libraries/ioss/src/visualization/exodus/Iovs_exodus_DatabaseIO.h
+++ b/packages/seacas/libraries/ioss/src/visualization/exodus/Iovs_exodus_DatabaseIO.h
@@ -174,7 +174,6 @@ namespace Iovs_exodus {
                                size_t data_size) const override;
 
     void write_meta_data();
-    size_t get_num_to_get(const Ioss::Field &field, size_t data_size) const;
 
     int64_t handle_node_ids(void *ids, int64_t num_to_get);
     int64_t handle_element_ids(const Ioss::ElementBlock *eb, void *ids, size_t num_to_get);

--- a/packages/seacas/libraries/ioss/src/visualization/exodus/Iovs_exodus_DatabaseIO.h
+++ b/packages/seacas/libraries/ioss/src/visualization/exodus/Iovs_exodus_DatabaseIO.h
@@ -47,10 +47,7 @@ namespace Iovs_exodus {
     // unsigned int with the supported Ioss::EntityTypes or'ed
     // together. If "return_value & Ioss::EntityType" is set, then the
     // database supports that type (e.g. return_value & Ioss::FACESET)
-    unsigned entity_field_support() const override
-    {
-      return Ioss::NODEBLOCK | Ioss::ELEMENTBLOCK;
-    }
+    unsigned entity_field_support() const override { return Ioss::NODEBLOCK | Ioss::ELEMENTBLOCK; }
 
     // static int parseCatalystFile(const std::string &filepath, std::string &json_result);
 
@@ -147,74 +144,37 @@ namespace Iovs_exodus {
 
     int64_t put_field_internal(const Ioss::Region *reg, const Ioss::Field &field, void *data,
                                size_t data_size) const override;
-
-    int64_t put_field_internal(const Ioss::NodeBlock * nb, const Ioss::Field & field,
-                               void * data, size_t data_size) const override;
-    int64_t put_field_internal(const Ioss::EdgeBlock * /*eb*/, const Ioss::Field & /*field*/,
-                               void * /*data*/, size_t /* data_size */) const override
-    {
-      return 0;
-    }
-    int64_t put_field_internal(const Ioss::FaceBlock * /*fb*/, const Ioss::Field & /*field*/,
-                               void * /*data*/, size_t /* data_size */) const override
-    {
-      return 0;
-    }
+    int64_t put_field_internal(const Ioss::NodeBlock *nb, const Ioss::Field &field, void *data,
+                               size_t data_size) const override;
+    int64_t put_field_internal(const Ioss::EdgeBlock *eb, const Ioss::Field &field, void *data,
+                               size_t data_size) const override;
+    int64_t put_field_internal(const Ioss::FaceBlock *fb, const Ioss::Field &field, void *data,
+                               size_t data_size) const override;
     int64_t put_field_internal(const Ioss::ElementBlock *eb, const Ioss::Field &field, void *data,
                                size_t data_size) const override;
-    int64_t put_field_internal(const Ioss::SideBlock * /*sb*/, const Ioss::Field & /*field*/,
-                               void * /*data*/, size_t /*data_size*/) const override
-    {
-      return 0;
-    }
-    int64_t put_field_internal(const Ioss::NodeSet * /*ns*/, const Ioss::Field & /*field*/,
-                               void * /*data*/, size_t /*data_size*/) const override
-    {
-      return 0;
-    }
-    int64_t put_field_internal(const Ioss::EdgeSet * /*es*/, const Ioss::Field & /*field*/,
-                               void * /*data*/, size_t /* data_size */) const override
-    {
-      return 0;
-    }
-    int64_t put_field_internal(const Ioss::FaceSet * /*fs*/, const Ioss::Field & /*field*/,
-                               void * /*data*/, size_t /* data_size */) const override
-    {
-      return 0;
-    }
-    int64_t put_field_internal(const Ioss::ElementSet * /*es*/, const Ioss::Field & /*field*/,
-                               void * /*data*/, size_t /* data_size */) const override
-    {
-      return 0;
-    }
-    int64_t put_field_internal(const Ioss::SideSet * /*ss*/, const Ioss::Field & /*field*/,
-                               void * /*data*/, size_t /*data_size*/) const override
-    {
-      return 0;
-    }
-    int64_t put_field_internal(const Ioss::CommSet * /*cs*/, const Ioss::Field & /*field*/,
-                               void * /*data*/, size_t /* data_size */) const override
-    {
-      return 0;
-    }
-    int64_t put_field_internal(const Ioss::StructuredBlock * /*sb*/, const Ioss::Field & /*field*/,
-                               void * /*data*/, size_t /* data_size */) const override
-    {
-      return 0;
-    }
-    int64_t put_field_internal(const Ioss::Assembly * /*as*/, const Ioss::Field & /*field*/,
-                               void * /*data*/, size_t /*data_size*/) const override
-    {
-      return 0;
-    }
-
-    int64_t put_field_internal(const Ioss::Blob * /*bl*/, const Ioss::Field & /*field*/,
-                               void * /*data*/, size_t /*data_size*/) const override
-    {
-      return 0;
-    }
+    int64_t put_field_internal(const Ioss::SideBlock *sb, const Ioss::Field &field, void *data,
+                               size_t data_size) const override;
+    int64_t put_field_internal(const Ioss::NodeSet *ns, const Ioss::Field &field, void *data,
+                               size_t data_size) const override;
+    int64_t put_field_internal(const Ioss::EdgeSet *es, const Ioss::Field &field, void *data,
+                               size_t data_size) const override;
+    int64_t put_field_internal(const Ioss::FaceSet *fs, const Ioss::Field &field, void *data,
+                               size_t data_size) const override;
+    int64_t put_field_internal(const Ioss::ElementSet *es, const Ioss::Field &field, void *data,
+                               size_t data_size) const override;
+    int64_t put_field_internal(const Ioss::SideSet *ss, const Ioss::Field &field, void *data,
+                               size_t data_size) const override;
+    int64_t put_field_internal(const Ioss::CommSet *cs, const Ioss::Field &field, void *data,
+                               size_t data_size) const override;
+    int64_t put_field_internal(const Ioss::StructuredBlock *sb, const Ioss::Field &field,
+                               void *data, size_t data_size) const override;
+    int64_t put_field_internal(const Ioss::Assembly *as, const Ioss::Field &field, void *data,
+                               size_t data_size) const override;
+    int64_t put_field_internal(const Ioss::Blob *bl, const Ioss::Field &field, void *data,
+                               size_t data_size) const override;
 
     void write_meta_data();
+    size_t get_num_to_get(const Ioss::Field &field, size_t data_size) const;
 
     int64_t handle_node_ids(void *ids, int64_t num_to_get);
     int64_t handle_element_ids(const Ioss::ElementBlock *eb, void *ids, size_t num_to_get);


### PR DESCRIPTION
Provide implementations for all put_field_internal methods for unsupported IOSS entity types. These
implementations return num_to_get.

Fix return types in ioss2catalyst test code.