### PR TITLE
Nem vector refactor

### DIFF
--- a/install-tpl.sh
+++ b/install-tpl.sh
@@ -526,7 +526,7 @@ then
         git clone https://github.com/Unidata/netcdf-c netcdf-c
     fi
 
-   net_version="v4.9.0"
+   net_version="v4.9.1"
 #   net_version="v4.8.1"
 #   net_version="master"
 

--- a/packages/seacas/applications/conjoin/CJ_ExodusEntity.h
+++ b/packages/seacas/applications/conjoin/CJ_ExodusEntity.h
@@ -1,4 +1,4 @@
-// Copyright(C) 1999-2020, 2022 National Technology & Engineering Solutions
+// Copyright(C) 1999-2020, 2022, 2023 National Technology & Engineering Solutions
 // of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
 // NTESS, the U.S. Government retains certain rights in this software.
 //
@@ -7,6 +7,7 @@
 
 #define NO_NETCDF_2
 #include "CJ_ObjectType.h"
+#include <array>
 #include <copy_string_cpp.h>
 #include <cstring>
 #include <exodusII.h>
@@ -55,14 +56,14 @@ namespace Excn {
 
   struct Block
   {
-    Block() { copy_string(elType, ""); }
+    Block() = default;
 
     Block(const Block &other)
         : truthTable(other.truthTable), attributeNames(other.attributeNames), name_(other.name_),
           id(other.id), elementCount(other.elementCount), nodesPerElement(other.nodesPerElement),
-          attributeCount(other.attributeCount), offset_(other.offset_), position_(other.position_)
+          attributeCount(other.attributeCount), offset_(other.offset_), position_(other.position_),
+          elType(other.elType)
     {
-      copy_string(elType, other.elType);
     }
 
     ~Block() = default;
@@ -78,7 +79,7 @@ namespace Excn {
     size_t                   attributeCount{0};
     size_t                   offset_{0};
     size_t                   position_{0};
-    char                     elType[MAX_STR_LENGTH + 1]{};
+    std::string              elType{};
 
     Block &operator=(const Block &other)
     {
@@ -91,8 +92,8 @@ namespace Excn {
       attributeNames  = other.attributeNames;
       offset_         = other.offset_;
       position_       = other.position_;
-      copy_string(elType, other.elType);
-      name_ = other.name_;
+      elType          = other.elType;
+      name_           = other.name_;
       return *this;
     }
   };

--- a/packages/seacas/applications/conjoin/CJ_ExodusFile.h
+++ b/packages/seacas/applications/conjoin/CJ_ExodusFile.h
@@ -17,6 +17,7 @@ namespace Excn {
   public:
     explicit ExodusFile(size_t which);
     ~ExodusFile();
+
     ExodusFile(const ExodusFile &)           = delete;
     ExodusFile operator=(const ExodusFile &) = delete;
 

--- a/packages/seacas/applications/conjoin/CJ_Internals.C
+++ b/packages/seacas/applications/conjoin/CJ_Internals.C
@@ -578,8 +578,8 @@ int Excn::Internals::put_metadata(const std::vector<Block> &blocks)
 
     // store element type as attribute of connectivity variable
     status = nc_put_att_text(exodusFilePtr, connid, ATT_NAME_ELB,
-                             static_cast<int>(std::strlen(blocks[iblk].elType)) + 1,
-                             blocks[iblk].elType);
+                             static_cast<int>(std::strlen(blocks[iblk].elType.c_str())) + 1,
+                             blocks[iblk].elType.c_str());
     if (status != NC_NOERR) {
       ex_opts(EX_VERBOSE);
       errmsg = fmt::format("Error: failed to store element type name {} in file id {}",

--- a/packages/seacas/applications/conjoin/CJ_SystemInterface.C
+++ b/packages/seacas/applications/conjoin/CJ_SystemInterface.C
@@ -1,4 +1,4 @@
-// Copyright(C) 1999-2022 National Technology & Engineering Solutions
+// Copyright(C) 1999-2023 National Technology & Engineering Solutions
 // of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
 // NTESS, the U.S. Government retains certain rights in this software.
 //
@@ -161,7 +161,8 @@ bool Excn::SystemInterface::parse_options(int argc, char **argv)
   if (options_.retrieve("help") != nullptr) {
     options_.usage();
     fmt::print("\n\tCan also set options via CONJOIN_OPTIONS environment variable.\n"
-	       "\n\tDocumentation: https://sandialabs.github.io/seacas-docs/sphinx/html/index.html#conjoin\n"
+               "\n\tDocumentation: "
+               "https://sandialabs.github.io/seacas-docs/sphinx/html/index.html#conjoin\n"
                "\n\t->->-> Send email to gdsjaar@sandia.gov for conjoin support.<-<-<-\n");
     exit(EXIT_SUCCESS);
   }
@@ -318,13 +319,13 @@ namespace {
         StringVector name_id  = SLIB::tokenize(*I, ":");
         std::string  var_name = LowerCase(name_id[0]);
         if (name_id.size() == 1) {
-          (*variable_list).push_back(std::make_pair(var_name, 0));
+          (*variable_list).emplace_back(var_name, 0);
         }
         else {
           for (size_t i = 1; i < name_id.size(); i++) {
             // Convert string to integer...
             int id = std::stoi(name_id[i]);
-            (*variable_list).push_back(std::make_pair(var_name, id));
+            (*variable_list).emplace_back(var_name, id);
           }
         }
         ++I;

--- a/packages/seacas/applications/conjoin/Conjoin.C
+++ b/packages/seacas/applications/conjoin/Conjoin.C
@@ -1198,7 +1198,7 @@ namespace {
           blocks[p][b].nodesPerElement = block_param.num_nodes_per_entry;
           blocks[p][b].attributeCount  = block_param.num_attribute;
           blocks[p][b].offset_         = block_param.num_entry;
-          copy_string(blocks[p][b].elType, block_param.topology);
+          blocks[p][b].elType          = block_param.topology;
 
           // NOTE: This is not correct, but fixed below.
           glob_blocks[b].elementCount += block_param.num_entry;
@@ -1212,7 +1212,7 @@ namespace {
           }
 
           glob_blocks[b].position_ = b;
-          copy_string(glob_blocks[b].elType, block_param.topology);
+          glob_blocks[b].elType    = block_param.topology;
         }
 
         if (block_param.num_attribute > 0 && glob_blocks[b].attributeNames.empty()) {

--- a/packages/seacas/applications/conjoin/Conjoin.C
+++ b/packages/seacas/applications/conjoin/Conjoin.C
@@ -76,7 +76,9 @@ struct NodeInfo
   NodeInfo() = default;
   NodeInfo(size_t id_, double x_, double y_, double z_) : id(id_), x(x_), y(y_), z(z_) {}
   size_t id{0};
-  double x{0.0}, y{0.0}, z{0.0};
+  double x{0.0};
+  double y{0.0};
+  double z{0.0};
 
   bool operator==(const NodeInfo &other) const
   {
@@ -396,7 +398,7 @@ int          main(int argc, char *argv[])
 
     time_t end_time = time(nullptr);
     add_to_log(argv[0], end_time - begin_time);
-    return (error);
+    return error;
   }
   catch (std::exception &e) {
     fmt::print(stderr, "ERROR: Standard exception: {}\n", e.what());
@@ -408,8 +410,8 @@ int conjoin(Excn::SystemInterface &interFace, T /* dummy */, INT /* dummy int */
 {
   SMART_ASSERT(sizeof(T) == Excn::ExodusFile::io_word_size());
 
-  const double alive      = interFace.alive_value();
-  size_t       part_count = interFace.inputFiles_.size();
+  const T alive      = interFace.alive_value();
+  size_t  part_count = interFace.inputFiles_.size();
 
   auto mytitle = new char[MAX_LINE_LENGTH + 1];
   memset(mytitle, '\0', MAX_LINE_LENGTH + 1);
@@ -936,7 +938,7 @@ int conjoin(Excn::SystemInterface &interFace, T /* dummy */, INT /* dummy int */
     fmt::print("{}", time_stamp(tsFormat));
   }
   fmt::print("******* END *******\n");
-  return (error);
+  return error;
 }
 
 namespace {
@@ -2567,10 +2569,10 @@ namespace {
 
     std::string var_name;
     int         out_position = -1;
-    for (auto &variable_name : variable_names) {
-      if (variable_name.second > 0) {
-        if (var_name != variable_name.first) {
-          var_name = variable_name.first;
+    for (auto [v_name, v_blkid] : variable_names) {
+      if (v_blkid > 0) {
+        if (var_name != v_name) {
+          var_name = v_name;
           // Find which exodus variable matches this name
           out_position = -1;
           for (size_t j = 0; j < exo_names.size(); j++) {
@@ -2582,7 +2584,7 @@ namespace {
           if (out_position < 0) {
             fmt::print(stderr,
                        "ERROR: Variable '{}' does not exist on any block in this database.\n",
-                       variable_name.first);
+                       v_name);
             exit(EXIT_FAILURE);
           }
 
@@ -2592,10 +2594,10 @@ namespace {
           // variable truly exists for the block that the user specified.
           found_it = false;
           for (size_t b = 0; b < global.count(vars.objectType); b++) {
-            if (glob_blocks[b].id == variable_name.second) {
+            if (glob_blocks[b].id == v_blkid) {
               if (glob_blocks[b].truthTable[out_position] == 0) {
-                fmt::print(stderr, "ERROR: Variable '{}' does not exist on block {}.\n",
-                           variable_name.first, variable_name.second);
+                fmt::print(stderr, "ERROR: Variable '{}' does not exist on block {}.\n", v_name,
+                           v_blkid);
                 exit(EXIT_FAILURE);
               }
               else {
@@ -2612,7 +2614,7 @@ namespace {
           if (!found_it) {
             fmt::print(stderr,
                        "ERROR: User-specified block id of {} for variable '{}' does not exist.\n",
-                       variable_name.second, variable_name.first);
+                       v_blkid, v_name);
             exit(EXIT_FAILURE);
           }
         }
@@ -2699,7 +2701,7 @@ namespace {
     const char *c2 = s2.c_str();
     for (;;) {
       if (::toupper(*c1) != ::toupper(*c2)) {
-        return (::toupper(*c1) - ::toupper(*c2));
+        return ::toupper(*c1) - ::toupper(*c2);
       }
       if (*c1 == '\0') {
         return 0;
@@ -2722,7 +2724,7 @@ namespace {
   inline bool is_whitespace(char c)
   {
     static char white_space[] = {' ', '\t', '\n', '\r', ',', '\0'};
-    return (std::strchr(white_space, c) != nullptr);
+    return std::strchr(white_space, c) != nullptr;
   }
 
   void compress_white_space(char *str)

--- a/packages/seacas/applications/cpup/CP_SystemInterface.C
+++ b/packages/seacas/applications/cpup/CP_SystemInterface.C
@@ -1,5 +1,5 @@
 /*
- * Copyright(C) 1999-2022 National Technology & Engineering Solutions
+ * Copyright(C) 1999-2023 National Technology & Engineering Solutions
  * of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
  * NTESS, the U.S. Government retains certain rights in this software.
  *
@@ -470,17 +470,13 @@ void Cpup::SystemInterface::parse_step_option(const char *tokens)
     if (strchr(tokens, ':') != nullptr) {
       // The string contains a separator
 
-      int vals[3];
-      vals[0] = stepMin_;
-      vals[1] = stepMax_;
-      vals[2] = stepInterval_;
+      std::array<int, 3> vals{stepMin_, stepMax_, stepInterval_};
 
       int j = 0;
       for (auto &val : vals) {
         // Parse 'i'th field
         char tmp_str[128];
-        ;
-        int k = 0;
+        int  k = 0;
 
         while (tokens[j] != '\0' && tokens[j] != ':') {
           tmp_str[k++] = tokens[j++];

--- a/packages/seacas/applications/cpup/cpup.C
+++ b/packages/seacas/applications/cpup/cpup.C
@@ -1,4 +1,4 @@
-// Copyright(C) 1999-2022 National Technology & Engineering Solutions
+// Copyright(C) 1999-2023 National Technology & Engineering Solutions
 // of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
 // NTESS, the U.S. Government retains certain rights in this software.
 //
@@ -78,12 +78,10 @@ namespace {
     // At this point, the variable_list contains one or more entries
     // of fields that should be output on combined file.  Run through
     // list and see if `field_name` is in the list.
-    for (const auto &valid : variable_list) {
-      if (Ioss::Utils::str_equal(valid, field_name) == 0) {
-        return true;
-      }
-    }
-    return false;
+    return std::any_of(variable_list.begin(), variable_list.end(),
+                       [&field_name](const auto &valid) {
+                         return Ioss::Utils::str_equal(valid, field_name) == 0;
+                       });
   }
 
   int verify_timestep_count(const PartVector &part_mesh)

--- a/packages/seacas/applications/ejoin/EJ_SystemInterface.C
+++ b/packages/seacas/applications/ejoin/EJ_SystemInterface.C
@@ -1,4 +1,4 @@
-// Copyright(C) 1999-2022 National Technology & Engineering Solutions
+// Copyright(C) 1999-2023 National Technology & Engineering Solutions
 // of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
 // NTESS, the U.S. Government retains certain rights in this software.
 //
@@ -212,9 +212,11 @@ bool SystemInterface::parse_options(int argc, char **argv)
 
   if (options_.retrieve("help") != nullptr) {
     options_.usage();
-    fmt::print(stderr, "\n\tCan also set options via EJOIN_OPTIONS environment variable.\n"
-	       "\n\tDocumentation: https://sandialabs.github.io/seacas-docs/sphinx/html/index.html#ejoin\n"
-	       "\n\t->->-> Send email to gdsjaar@sandia.gov for ejoin support.<-<-<-\n");
+    fmt::print(
+        stderr,
+        "\n\tCan also set options via EJOIN_OPTIONS environment variable.\n"
+        "\n\tDocumentation: https://sandialabs.github.io/seacas-docs/sphinx/html/index.html#ejoin\n"
+        "\n\t->->-> Send email to gdsjaar@sandia.gov for ejoin support.<-<-<-\n");
     exit(EXIT_SUCCESS);
   }
 
@@ -465,17 +467,13 @@ void SystemInterface::parse_step_option(const char *tokens)
     if (strchr(tokens, ':') != nullptr) {
       // The string contains a separator
 
-      int vals[3];
-      vals[0] = stepMin_;
-      vals[1] = stepMax_;
-      vals[2] = stepInterval_;
+      std::array<int, 3> vals{stepMin_, stepMax_, stepInterval_};
 
       int j = 0;
       for (auto &val : vals) {
         // Parse 'i'th field
         char tmp_str[128];
-        ;
-        int k = 0;
+        int  k = 0;
 
         while (tokens[j] != '\0' && tokens[j] != ':') {
           tmp_str[k++] = tokens[j++];

--- a/packages/seacas/applications/ejoin/EJ_mapping.C
+++ b/packages/seacas/applications/ejoin/EJ_mapping.C
@@ -1,4 +1,4 @@
-// Copyright(C) 1999-2022 National Technology & Engineering Solutions
+// Copyright(C) 1999-2023 National Technology & Engineering Solutions
 // of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
 // NTESS, the U.S. Government retains certain rights in this software.
 //
@@ -19,7 +19,7 @@
 #include <utility> // for make_pair, pair
 
 namespace {
-  bool entity_is_omitted(Ioss::GroupingEntity *block)
+  bool entity_is_omitted(const Ioss::GroupingEntity *block)
   {
     bool omitted = block->get_optional_property("omitted", 0) == 1;
     return omitted;
@@ -35,8 +35,8 @@ void eliminate_omitted_nodes(RegionVector &part_mesh, std::vector<INT> &global_n
   size_t part_count = part_mesh.size();
   for (size_t p = 0; p < part_count; p++) {
     bool has_omissions        = part_mesh[p]->get_property("block_omission_count").get_int() > 0;
-    Ioss::NodeBlock *nb       = part_mesh[p]->get_node_blocks()[0];
-    size_t           loc_size = nb->entity_count();
+    const Ioss::NodeBlock *nb = part_mesh[p]->get_node_blocks()[0];
+    size_t                 loc_size = nb->entity_count();
     if (has_omissions) {
       // If there are any omitted element blocks for this part, don't
       // map the nodes that are only connected to omitted element
@@ -93,8 +93,8 @@ void build_reverse_node_map(Ioss::Region & /*global*/, RegionVector &part_mesh,
 
   size_t tot_size = 0;
   for (size_t p = 0; p < part_count; p++) {
-    Ioss::NodeBlock *nb       = part_mesh[p]->get_node_blocks()[0];
-    size_t           loc_size = nb->entity_count();
+    const Ioss::NodeBlock *nb       = part_mesh[p]->get_node_blocks()[0];
+    size_t                 loc_size = nb->entity_count();
     tot_size += loc_size;
     global_nodes[p].resize(loc_size);
   }
@@ -103,7 +103,7 @@ void build_reverse_node_map(Ioss::Region & /*global*/, RegionVector &part_mesh,
   size_t offset            = 0;
   bool   any_omitted_nodes = false;
   for (size_t p = 0; p < part_count; p++) {
-    Ioss::NodeBlock *nb = part_mesh[p]->get_node_blocks()[0];
+    const Ioss::NodeBlock *nb = part_mesh[p]->get_node_blocks()[0];
     nb->get_field_data("ids", global_nodes[p]);
 
     // If there are any omitted element blocks for this part, set

--- a/packages/seacas/applications/ejoin/EJ_match_xyz.C
+++ b/packages/seacas/applications/ejoin/EJ_match_xyz.C
@@ -1,4 +1,4 @@
-// Copyright(C) 1999-2020 National Technology & Engineering Solutions
+// Copyright(C) 1999-2020, 2023 National Technology & Engineering Solutions
 // of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
 // NTESS, the U.S. Government retains certain rights in this software.
 //
@@ -34,7 +34,7 @@ namespace {
     return max;
   }
 
-  void find_range(std::vector<double> &coord, vector3d &min, vector3d &max)
+  void find_range(const std::vector<double> &coord, vector3d &min, vector3d &max)
   {
     if (!coord.empty()) {
       min.set(coord[0], coord[1], coord[2]);
@@ -68,7 +68,7 @@ namespace {
   }
 
   template <typename INT>
-  void find_in_range(std::vector<double> coord, vector3d &min, vector3d &max,
+  void find_in_range(const std::vector<double> &coord, const vector3d &min, const vector3d &max,
                      std::vector<INT> &in_range)
   {
     if (!coord.empty()) {

--- a/packages/seacas/applications/nem_slice/elb.h
+++ b/packages/seacas/applications/nem_slice/elb.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(C) 1999-2020, 2022 National Technology & Engineering Solutions
+ * Copyright(C) 1999-2020, 2022, 2023 National Technology & Engineering Solutions
  * of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
  * NTESS, the U.S. Government retains certain rights in this software.
  *
@@ -184,8 +184,8 @@ template <typename INT> struct Mesh_Description
   size_t              max_np_elem{0};
   size_t              ns_list_len{0};
   char                title[MAX_LINE_LENGTH + 1]{};
-  float              *coords{nullptr};
-  E_Type             *elem_type{nullptr};
+  std::vector<float>  coords{};
+  std::vector<E_Type> elem_type{};
   INT               **connect;
 
   Mesh_Description() : connect(nullptr) {}

--- a/packages/seacas/applications/nem_slice/elb_exo_util.C
+++ b/packages/seacas/applications/nem_slice/elb_exo_util.C
@@ -1,5 +1,5 @@
 /*
- * Copyright(C) 1999-2022 National Technology & Engineering Solutions
+ * Copyright(C) 1999-2023 National Technology & Engineering Solutions
  * of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
  * NTESS, the U.S. Government retains certain rights in this software.
  *
@@ -316,9 +316,9 @@ int read_mesh(const std::string &exo_file, Problem_Description *problem,
 
   if (problem->read_coords == ELB_TRUE) {
     switch (mesh->num_dims) {
-    case 3: zptr = (mesh->coords) + 2 * (mesh->num_nodes); FALL_THROUGH;
-    case 2: yptr = (mesh->coords) + (mesh->num_nodes); FALL_THROUGH;
-    case 1: xptr = mesh->coords;
+    case 3: zptr = mesh->coords.data() + 2 * (mesh->num_nodes); FALL_THROUGH;
+    case 2: yptr = mesh->coords.data() + (mesh->num_nodes); FALL_THROUGH;
+    case 1: xptr = mesh->coords.data();
     }
 
     if (ex_get_coord(exoid, xptr, yptr, zptr) < 0) {

--- a/packages/seacas/applications/nem_slice/elb_loadbal.C
+++ b/packages/seacas/applications/nem_slice/elb_loadbal.C
@@ -135,10 +135,13 @@ int generate_loadbal(Machine_Description *machine, Problem_Description *problem,
   int glob_method = 0;
   int start_proc  = 0;
 
-  INT             *tmp_start = nullptr, *tmp_adj = nullptr;
+  INT             *tmp_start = nullptr;
+  INT             *tmp_adj   = nullptr;
   int             *tmp_vwgts = nullptr;
   size_t           tmp_nv;
-  std::vector<int> nprocg, nelemg, nadjg;
+  std::vector<int> nprocg;
+  std::vector<int> nelemg;
+  std::vector<int> nadjg;
   size_t           max_vtx;
   size_t           max_adj;
   int              group;
@@ -149,9 +152,15 @@ int generate_loadbal(Machine_Description *machine, Problem_Description *problem,
   int              tmp_lev;
   int             *tmp_v2p = nullptr;
 
-  float             *x_node_ptr = nullptr, *y_node_ptr = nullptr, *z_node_ptr = nullptr;
-  std::vector<float> x_elem_ptr, y_elem_ptr, z_elem_ptr;
-  float             *tmp_x = nullptr, *tmp_y = nullptr, *tmp_z = nullptr;
+  float             *x_node_ptr = nullptr;
+  float             *y_node_ptr = nullptr;
+  float             *z_node_ptr = nullptr;
+  std::vector<float> x_elem_ptr;
+  std::vector<float> y_elem_ptr;
+  std::vector<float> z_elem_ptr;
+  float             *tmp_x     = nullptr;
+  float             *tmp_y     = nullptr;
+  float             *tmp_z     = nullptr;
   float             *tmp_ewgts = nullptr;
 
   long    seed = 1;

--- a/packages/seacas/applications/nem_slice/elb_loadbal.C
+++ b/packages/seacas/applications/nem_slice/elb_loadbal.C
@@ -572,7 +572,7 @@ int generate_loadbal(Machine_Description *machine, Problem_Description *problem,
               for (int cnt = graph->start[ecnt]; cnt < graph->start[ecnt + 1]; cnt++) {
                 if (elem_map[graph->adj[cnt] - 1] > 0) {
                   tmp_adj[adjp] = elem_map[graph->adj[cnt] - 1];
-                  if (!weight->edges.empty()) {
+                  if (!weight->edges.empty() && tmp_ewgts != nullptr) {
                     tmp_ewgts[adjp] = weight->edges[cnt];
                   }
                   adjp++;
@@ -580,7 +580,7 @@ int generate_loadbal(Machine_Description *machine, Problem_Description *problem,
               }
               tmp_start[elemp + 1] = adjp;
             }
-            if (!weight->vertices.empty()) {
+            if (!weight->vertices.empty() && tmp_vwgts != nullptr) {
               tmp_vwgts[elemp] = weight->vertices[ecnt];
             }
 

--- a/packages/seacas/applications/nem_slice/elb_loadbal.C
+++ b/packages/seacas/applications/nem_slice/elb_loadbal.C
@@ -208,19 +208,19 @@ int generate_loadbal(Machine_Description *machine, Problem_Description *problem,
 
     switch (mesh->num_dims) {
     case 3:
-      x_node_ptr = (mesh->coords);
-      y_node_ptr = (mesh->coords) + (mesh->num_nodes);
-      z_node_ptr = (mesh->coords) + 2 * (mesh->num_nodes);
+      x_node_ptr = mesh->coords.data();
+      y_node_ptr = mesh->coords.data() + (mesh->num_nodes);
+      z_node_ptr = mesh->coords.data() + 2 * (mesh->num_nodes);
       break;
 
     case 2:
-      x_node_ptr = (mesh->coords);
-      y_node_ptr = (mesh->coords) + (mesh->num_nodes);
+      x_node_ptr = mesh->coords.data();
+      y_node_ptr = mesh->coords.data() + (mesh->num_nodes);
       z_node_ptr = (float *)calloc(mesh->num_nodes, sizeof(float));
       break;
 
     case 1:
-      x_node_ptr = (mesh->coords);
+      x_node_ptr = mesh->coords.data();
       y_node_ptr = (float *)calloc(mesh->num_nodes, sizeof(float));
       z_node_ptr = (float *)calloc(mesh->num_nodes, sizeof(float));
       break;

--- a/packages/seacas/applications/nem_slice/elb_main.C
+++ b/packages/seacas/applications/nem_slice/elb_main.C
@@ -1,5 +1,5 @@
 /*
- * Copyright(C) 1999-2021 National Technology & Engineering Solutions
+ * Copyright(C) 1999-2021, 2023 National Technology & Engineering Solutions
  * of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
  * NTESS, the U.S. Government retains certain rights in this software.
  *
@@ -325,20 +325,12 @@ template <typename INT> int internal_main(int argc, char *argv[], INT /* dummy *
 
   if (problem.read_coords == ELB_TRUE) {
     size_t mem_req = (size_t)(mesh.num_dims) * (mesh.num_nodes) * sizeof(float);
-    mesh.coords    = reinterpret_cast<float *>(malloc(mem_req));
-    if (!(mesh.coords)) {
-      Gen_Error(0, "fatal: insufficient memory for coordinates");
-      error_report();
-      exit(1);
-    }
-  }
-  else {
-    mesh.coords = nullptr;
+    mesh.coords.resize(mem_req);
   }
 
-  mesh.elem_type = static_cast<E_Type *>(array_alloc(1, mesh.num_elems, sizeof(E_Type)));
+  mesh.elem_type.resize(mesh.num_elems);
   mesh.connect = static_cast<INT **>(array_alloc(2, mesh.num_elems, mesh.max_np_elem, sizeof(INT)));
-  if (!(mesh.elem_type) || !(mesh.connect)) {
+  if (!(mesh.connect)) {
     Gen_Error(0, "fatal: insufficient memory");
     error_report();
     exit(1);
@@ -436,10 +428,10 @@ template <typename INT> int internal_main(int argc, char *argv[], INT /* dummy *
 
   /* Free up memory no longer needed */
   if (problem.read_coords == ELB_TRUE) {
-    free(mesh.coords);
+    mesh.coords.clear();
   }
 
-  free(mesh.elem_type);
+  mesh.elem_type.clear();
   free(mesh.connect);
 
   if (!graph.sur_elem.empty()) {

--- a/packages/seacas/applications/nem_slice/elb_output.C
+++ b/packages/seacas/applications/nem_slice/elb_output.C
@@ -1,5 +1,5 @@
 /*
- * Copyright(C) 1999-2021 National Technology & Engineering Solutions
+ * Copyright(C) 1999-2021, 2023 National Technology & Engineering Solutions
  * of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
  * NTESS, the U.S. Government retains certain rights in this software.
  *
@@ -551,9 +551,9 @@ int write_vis(std::string &nemI_out_file, std::string &exoII_inp_file, Machine_D
     float *yptr = nullptr;
     float *zptr = nullptr;
     switch (mesh->num_dims) {
-    case 3: zptr = (mesh->coords) + 2 * mesh->num_nodes; FALL_THROUGH;
-    case 2: yptr = (mesh->coords) + mesh->num_nodes; FALL_THROUGH;
-    case 1: xptr = mesh->coords;
+    case 3: zptr = mesh->coords.data() + 2 * mesh->num_nodes; FALL_THROUGH;
+    case 2: yptr = mesh->coords.data() + mesh->num_nodes; FALL_THROUGH;
+    case 1: xptr = mesh->coords.data();
     }
     if (ex_put_coord(exid_vis, xptr, yptr, zptr) < 0) {
       Gen_Error(0, "fatal: unable to output coords to vis file");

--- a/packages/seacas/applications/nem_slice/fix_column_partitions.C
+++ b/packages/seacas/applications/nem_slice/fix_column_partitions.C
@@ -10,6 +10,7 @@
 #include "elb_elem.h"
 #include "elb_err.h"
 #include "fix_column_partitions.h"
+#include <array>
 #include <cmath>
 #include <iostream>
 #include <map>
@@ -18,7 +19,7 @@
 namespace {
   // Opposite side IDs in a hex according to Exodus II convention
 
-  int hex_opp_side[6] = {3, 4, 1, 2, 6, 5};
+  std::array<int, 6> hex_opp_side{3, 4, 1, 2, 6, 5};
 
   /*! @brief Given an element and a side, find the adjacent element to that side
     @param cur_elem  Current element under consideration
@@ -39,17 +40,17 @@ namespace {
 
     // Get nodes of this side (face) of the element
 
-    int nsnodes       = is_hex(etype) ? 4 : 3;
-    INT side_nodes[9] = {0}; // SHELL9 has 9 nodes on a face.
+    int                nsnodes = is_hex(etype) ? 4 : 3;
+    std::array<INT, 9> side_nodes{}; // SHELL9 has 9 nodes on a face.
 
     INT *elnodes = mesh->connect[cur_elem];
-    ss_to_node_list(etype, elnodes, side_id, side_nodes);
+    ss_to_node_list(etype, elnodes, side_id, side_nodes.data());
 
     // How would these side's nodes be if they were viewed from the
     // adjacent element
 
-    INT side_nodes_flipped[9] = {0}; // Realistically: 4, max possible: 9
-    get_ss_mirror(etype, side_nodes, side_id, side_nodes_flipped);
+    std::array<INT, 9> side_nodes_flipped{0}; // Realistically: 4, max possible: 9
+    get_ss_mirror(etype, side_nodes.data(), side_id, side_nodes_flipped.data());
 
     for (int i = 0; i < nadj; i++) {
       INT    adj_elem_id = adj[i] - 1; // Adjacency graph entries start from 1
@@ -64,8 +65,8 @@ namespace {
 
       int skip_check  = 2;
       int partial_adj = 1;
-      *adj_side =
-          get_side_id(etype2, elnodes2, nsnodes, side_nodes_flipped, skip_check, partial_adj);
+      *adj_side = get_side_id(etype2, elnodes2, nsnodes, side_nodes_flipped.data(), skip_check,
+                              partial_adj);
 
       if (*adj_side > 0) {
         *adj_elem = adj_elem_id;
@@ -139,8 +140,8 @@ int fix_column_partitions(LB_Description<INT> *lb, Mesh_Description<INT> const *
 
     int count = 0;
     for (int j = 0; j < nelfaces; j++) {
-      INT fnodes[9] = {
-          0}; // Should only need 4, but ss_to_node_list can potentially access 9 (SHELL9).
+      std::array<INT, 9>
+          fnodes{}; // Should only need 4, but ss_to_node_list can potentially access 9 (SHELL9).
 
       int nfn = 4;
       if (is_wedge(etype)) {
@@ -153,10 +154,10 @@ int fix_column_partitions(LB_Description<INT> *lb, Mesh_Description<INT> const *
       }
 
       // Nodes of the side/face
-      ss_to_node_list(etype, mesh->connect[i], j + 1, fnodes);
+      ss_to_node_list(etype, mesh->connect[i], j + 1, fnodes.data());
 
       // Translate global IDs of side nodes to local IDs in element
-      int fnodes_loc[9] = {0};
+      std::array<int, 9> fnodes_loc{0};
       for (int k = 0; k < nfn; k++) {
         bool found = false;
         for (int k2 = 0; k2 < nelnodes; k2++) {
@@ -170,10 +171,10 @@ int fix_column_partitions(LB_Description<INT> *lb, Mesh_Description<INT> const *
           Gen_Error(0, "FATAL: side/face node not found in element node list?");
       }
 
-      double normal[3] = {0.0, 0.0, 0.0};
+      std::array<double, 3> normal{0.0, 0.0, 0.0};
       if (nfn == 3) {
-        double v0[3];
-        double v1[3];
+        std::array<double, 3> v0;
+        std::array<double, 3> v1;
         for (int d = 0; d < 3; d++) {
           v0[d] = elcoord[fnodes_loc[1]][d] - elcoord[fnodes_loc[0]][d];
           v1[d] = elcoord[fnodes_loc[nfn - 1]][d] - elcoord[fnodes_loc[0]][d];
@@ -186,8 +187,8 @@ int fix_column_partitions(LB_Description<INT> *lb, Mesh_Description<INT> const *
       }
       else {
         for (int k = 0; k < nfn; k++) {
-          double v0[3];
-          double v1[3];
+          std::array<double, 3> v0;
+          std::array<double, 3> v1;
           for (int d = 0; d < 3; d++) {
             v0[d] = elcoord[fnodes_loc[(k + 1) % nfn]][d] - elcoord[fnodes_loc[k]][d];
             v1[d] = elcoord[fnodes_loc[(k - 1 + nfn) % nfn]][d] - elcoord[fnodes_loc[k]][d];

--- a/packages/seacas/applications/nem_spread/el_exoII_io.C
+++ b/packages/seacas/applications/nem_spread/el_exoII_io.C
@@ -1,5 +1,5 @@
 /*
- * Copyright(C) 1999-2022 National Technology & Engineering Solutions
+ * Copyright(C) 1999-2023 National Technology & Engineering Solutions
  * of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
  * NTESS, the U.S. Government retains certain rights in this software.
  *
@@ -697,16 +697,9 @@ template <typename T, typename INT> void NemSpread<T, INT>::load_mesh()
     if (globals.Proc_SS_Dist_Fact[iproc]) {
       safe_free((void **)&(globals.Proc_SS_Dist_Fact[iproc]));
     }
-
-    if (globals.N_Comm_Map[iproc]) {
-      safe_free((void **)&(globals.N_Comm_Map[iproc]));
-    }
-    if (globals.E_Comm_Map[iproc]) {
-      safe_free((void **)&(globals.E_Comm_Map[iproc]));
-    }
   }
-  free(globals.N_Comm_Map);
-  free(globals.E_Comm_Map);
+  globals.N_Comm_Map.clear();
+  globals.E_Comm_Map.clear();
   fmt::print("\n");
 
 } /* END of routine load_mesh () *********************************************/
@@ -1130,7 +1123,7 @@ template <typename T, typename INT> void NemSpread<T, INT>::extract_elem_blk()
     /* Sort globals.GElems so that each element block is monotonic */
     size_t j = 0;
     for (int i = 0; i < globals.Proc_Num_Elem_Blk[iproc]; i++) {
-      gds_qsort((globals.GElems[iproc]) + j, globals.Proc_Num_Elem_In_Blk[iproc][i]);
+      gds_qsort((globals.GElems[iproc].data()) + j, globals.Proc_Num_Elem_In_Blk[iproc][i]);
       j += globals.Proc_Num_Elem_In_Blk[iproc][i];
     }
 
@@ -1927,7 +1920,7 @@ void NemSpread<T, INT>::find_elem_block(INT *proc_elem_blk, int iproc, int /*pro
    */
 
   my_sort(globals.Num_Internal_Elems[iproc] + globals.Num_Border_Elems[iproc], proc_elem_blk,
-          globals.GElems[iproc]);
+          globals.GElems[iproc].data());
 
   /* Now change proc_elem_blk to be a list of global element block IDs */
   for (INT i = 0; i < globals.Num_Internal_Elems[iproc] + globals.Num_Border_Elems[iproc]; i++) {

--- a/packages/seacas/applications/nem_spread/el_exoII_io.C
+++ b/packages/seacas/applications/nem_spread/el_exoII_io.C
@@ -192,35 +192,36 @@ template <typename T, typename INT> void NemSpread<T, INT>::load_mesh()
     globals.Proc_SS_Elem_List_Length[iproc] = 0;
   }
 
-  globals.GElem_Blks = (INT **)array_alloc(__FILE__, __LINE__, 1, 26 * Proc_Info[2], sizeof(INT *));
-  globals.Proc_Nodes_Per_Elem     = globals.GElem_Blks + Proc_Info[2];
-  globals.Proc_Elem_Blk_Ids       = globals.Proc_Nodes_Per_Elem + Proc_Info[2];
-  globals.Proc_Elem_Blk_Types     = globals.Proc_Elem_Blk_Ids + Proc_Info[2];
-  globals.Proc_Num_Attr           = globals.Proc_Elem_Blk_Types + Proc_Info[2];
-  globals.Proc_Num_Elem_In_Blk    = globals.Proc_Num_Attr + Proc_Info[2];
-  globals.Proc_Connect_Ptr        = globals.Proc_Num_Elem_In_Blk + Proc_Info[2];
-  globals.Proc_Elem_Connect       = globals.Proc_Connect_Ptr + Proc_Info[2];
-  globals.Proc_NS_Ids             = globals.Proc_Elem_Connect + Proc_Info[2];
-  globals.Proc_NS_Count           = globals.Proc_NS_Ids + Proc_Info[2];
-  globals.Proc_NS_DF_Count        = globals.Proc_NS_Count + Proc_Info[2];
-  globals.Proc_NS_Pointers        = globals.Proc_NS_DF_Count + Proc_Info[2];
-  globals.Proc_NS_List            = globals.Proc_NS_Pointers + Proc_Info[2];
-  globals.GNode_Sets              = globals.Proc_NS_List + Proc_Info[2];
-  globals.Proc_NS_GNMap_List      = globals.GNode_Sets + Proc_Info[2];
-  globals.Proc_SS_Ids             = globals.Proc_NS_GNMap_List + Proc_Info[2];
-  globals.Proc_SS_Elem_Count      = globals.Proc_SS_Ids + Proc_Info[2];
-  globals.Proc_SS_DF_Count        = globals.Proc_SS_Elem_Count + Proc_Info[2];
-  globals.Proc_SS_Elem_Pointers   = globals.Proc_SS_DF_Count + Proc_Info[2];
-  globals.Proc_SS_Elem_List       = globals.Proc_SS_Elem_Pointers + Proc_Info[2];
-  globals.Proc_SS_Side_List       = globals.Proc_SS_Elem_List + Proc_Info[2];
-  globals.Proc_SS_DF_Pointers     = globals.Proc_SS_Side_List + Proc_Info[2];
-  globals.GSide_Sets              = globals.Proc_SS_DF_Pointers + Proc_Info[2];
-  globals.Proc_SS_GEMap_List      = globals.GSide_Sets + Proc_Info[2];
-  globals.Proc_Global_Elem_Id_Map = globals.Proc_SS_GEMap_List + Proc_Info[2];
-  globals.Proc_Global_Node_Id_Map = globals.Proc_Global_Elem_Id_Map + Proc_Info[2];
+  globals.GElem_Blks = (INT **)array_alloc(__FILE__, __LINE__, 1, 24 * Proc_Info[2], sizeof(INT *));
+  globals.Proc_Nodes_Per_Elem   = globals.GElem_Blks + Proc_Info[2];
+  globals.Proc_Elem_Blk_Ids     = globals.Proc_Nodes_Per_Elem + Proc_Info[2];
+  globals.Proc_Elem_Blk_Types   = globals.Proc_Elem_Blk_Ids + Proc_Info[2];
+  globals.Proc_Num_Attr         = globals.Proc_Elem_Blk_Types + Proc_Info[2];
+  globals.Proc_Num_Elem_In_Blk  = globals.Proc_Num_Attr + Proc_Info[2];
+  globals.Proc_Connect_Ptr      = globals.Proc_Num_Elem_In_Blk + Proc_Info[2];
+  globals.Proc_Elem_Connect     = globals.Proc_Connect_Ptr + Proc_Info[2];
+  globals.Proc_NS_Ids           = globals.Proc_Elem_Connect + Proc_Info[2];
+  globals.Proc_NS_Count         = globals.Proc_NS_Ids + Proc_Info[2];
+  globals.Proc_NS_DF_Count      = globals.Proc_NS_Count + Proc_Info[2];
+  globals.Proc_NS_Pointers      = globals.Proc_NS_DF_Count + Proc_Info[2];
+  globals.Proc_NS_List          = globals.Proc_NS_Pointers + Proc_Info[2];
+  globals.GNode_Sets            = globals.Proc_NS_List + Proc_Info[2];
+  globals.Proc_NS_GNMap_List    = globals.GNode_Sets + Proc_Info[2];
+  globals.Proc_SS_Ids           = globals.Proc_NS_GNMap_List + Proc_Info[2];
+  globals.Proc_SS_Elem_Count    = globals.Proc_SS_Ids + Proc_Info[2];
+  globals.Proc_SS_DF_Count      = globals.Proc_SS_Elem_Count + Proc_Info[2];
+  globals.Proc_SS_Elem_Pointers = globals.Proc_SS_DF_Count + Proc_Info[2];
+  globals.Proc_SS_Elem_List     = globals.Proc_SS_Elem_Pointers + Proc_Info[2];
+  globals.Proc_SS_Side_List     = globals.Proc_SS_Elem_List + Proc_Info[2];
+  globals.Proc_SS_DF_Pointers   = globals.Proc_SS_Side_List + Proc_Info[2];
+  globals.GSide_Sets            = globals.Proc_SS_DF_Pointers + Proc_Info[2];
+  globals.Proc_SS_GEMap_List    = globals.GSide_Sets + Proc_Info[2];
+
+  globals.Proc_Global_Elem_Id_Map.resize(Proc_Info[2]);
+  globals.Proc_Global_Node_Id_Map.resize(Proc_Info[2]);
 
   /* Initialize */
-  for (int iproc = 0; iproc < 25 * Proc_Info[2]; iproc++) {
+  for (int iproc = 0; iproc < 24 * Proc_Info[2]; iproc++) {
     globals.GElem_Blks[iproc] = nullptr;
   }
 
@@ -922,9 +923,9 @@ void NemSpread<T, INT>::read_coord(int exoid, int max_name_length)
   }
 
   /* Handle global node ids... */
-  INT *global_node_ids = (INT *)array_alloc(__FILE__, __LINE__, 1, globals.Num_Node, sizeof(INT));
+  std::vector<INT> global_node_ids(globals.Num_Node);
 
-  check_exodus_error(ex_get_id_map(exoid, EX_NODE_MAP, global_node_ids), "ex_get_id_map");
+  check_exodus_error(ex_get_id_map(exoid, EX_NODE_MAP, global_node_ids.data()), "ex_get_id_map");
   /*
    * Check whether map is sequential (1..globals.Num_Node). If it is, then it
    * provides no information and we don't need to store it in the
@@ -959,19 +960,11 @@ void NemSpread<T, INT>::read_coord(int exoid, int max_name_length)
 
         size_t itotal_nodes = globals.Num_Internal_Nodes[iproc] + globals.Num_Border_Nodes[iproc] +
                               globals.Num_External_Nodes[iproc];
-        globals.Proc_Global_Node_Id_Map[iproc] =
-            (INT *)array_alloc(__FILE__, __LINE__, 1, itotal_nodes, sizeof(INT));
 
+        globals.Proc_Global_Node_Id_Map[iproc].resize(itotal_nodes);
         extract_global_node_ids(global_node_ids, globals.Num_Node, iproc);
       }
     }
-    else {
-      /* Should be nullptr already, but make it more clear */
-      for (int iproc = Proc_Info[4]; iproc < Proc_Info[4] + Proc_Info[5]; iproc++) {
-        globals.Proc_Global_Node_Id_Map[iproc] = nullptr;
-      }
-    }
-    safe_free((void **)&global_node_ids);
   }
 } /* END of routine read_coord */
 
@@ -1199,7 +1192,7 @@ template <typename T, typename INT> void NemSpread<T, INT>::read_elem_blk(int ex
    */
   GM_Elem_Types = (int *)array_alloc(__FILE__, __LINE__, 1, globals.Num_Elem, sizeof(int));
 
-  INT *global_ids = (INT *)array_alloc(__FILE__, __LINE__, 1, globals.Num_Elem, sizeof(INT));
+  std::vector<INT> global_ids(globals.Num_Elem);
 
   for (int iproc = Proc_Info[4]; iproc < Proc_Info[4] + Proc_Info[5]; iproc++) {
 
@@ -1446,7 +1439,7 @@ template <typename T, typename INT> void NemSpread<T, INT>::read_elem_blk(int ex
   } /* End "for(ielem_blk=0; ielem_blk < globals.Num_Elem_Blk; ielem_blk++)" */
 
   /* Handle global element ids... */
-  check_exodus_error(ex_get_id_map(exoid, EX_ELEM_MAP, global_ids), "ex_get_id_map");
+  check_exodus_error(ex_get_id_map(exoid, EX_ELEM_MAP, global_ids.data()), "ex_get_id_map");
 
   /*
    * Check whether map is sequential (1..globals.Num_Elem). If it is, then it
@@ -1479,21 +1472,17 @@ template <typename T, typename INT> void NemSpread<T, INT>::read_elem_blk(int ex
 
     if (!sequential) {
       for (int iproc = Proc_Info[4]; iproc < Proc_Info[4] + Proc_Info[5]; iproc++) {
-
-        globals.Proc_Global_Elem_Id_Map[iproc] = (INT *)array_alloc(
-            __FILE__, __LINE__, 1,
-            globals.Num_Internal_Elems[iproc] + globals.Num_Border_Elems[iproc], sizeof(INT));
-
+        globals.Proc_Global_Elem_Id_Map[iproc].resize(globals.Num_Internal_Elems[iproc] +
+                                                      globals.Num_Border_Elems[iproc]);
         extract_global_element_ids(global_ids, globals.Num_Elem, iproc);
       }
     }
     else {
       /* Should be nullptr already, but make it more clear */
       for (int iproc = Proc_Info[4]; iproc < Proc_Info[4] + Proc_Info[5]; iproc++) {
-        globals.Proc_Global_Elem_Id_Map[iproc] = nullptr;
+        globals.Proc_Global_Elem_Id_Map[iproc].clear();
       }
     }
-    safe_free((void **)&global_ids);
   }
 } /* read_elem_blk */
 
@@ -1502,7 +1491,8 @@ template <typename T, typename INT> void NemSpread<T, INT>::read_elem_blk(int ex
 /*****************************************************************************/
 
 template <typename T, typename INT>
-void NemSpread<T, INT>::extract_global_element_ids(INT global_ids[], size_t /*Num_Elem*/, int iproc)
+void NemSpread<T, INT>::extract_global_element_ids(const std::vector<INT> &global_ids,
+                                                   size_t /*Num_Elem*/, int iproc)
 {
   /*
    * globals.Num_Elem -- number of elements in serial mesh.
@@ -1524,7 +1514,8 @@ void NemSpread<T, INT>::extract_global_element_ids(INT global_ids[], size_t /*Nu
 /*****************************************************************************/
 
 template <typename T, typename INT>
-void NemSpread<T, INT>::extract_global_node_ids(INT global_ids[], size_t /*Num_Node*/, int iproc)
+void NemSpread<T, INT>::extract_global_node_ids(const std::vector<INT> &global_ids,
+                                                size_t /*Num_Node*/, int iproc)
 {
   /*
    * Num_Elem -- number of elements in serial mesh.

--- a/packages/seacas/applications/nem_spread/el_exoII_io.C
+++ b/packages/seacas/applications/nem_spread/el_exoII_io.C
@@ -232,14 +232,9 @@ template <typename T, typename INT> void NemSpread<T, INT>::load_mesh()
     globals.Coor[iproc] = nullptr;
   }
 
-  globals.Proc_Elem_Attr = (T **)array_alloc(__FILE__, __LINE__, 1, 3 * Proc_Info[2], sizeof(T *));
-  globals.Proc_NS_Dist_Fact = globals.Proc_Elem_Attr + Proc_Info[2];
-  globals.Proc_SS_Dist_Fact = globals.Proc_NS_Dist_Fact + Proc_Info[2];
-
-  /* Initialize */
-  for (int iproc = 0; iproc < 3 * Proc_Info[2]; iproc++) {
-    globals.Proc_Elem_Attr[iproc] = nullptr;
-  }
+  globals.Proc_Elem_Attr.resize(Proc_Info[2]);
+  globals.Proc_NS_Dist_Fact.resize(Proc_Info[2]);
+  globals.Proc_SS_Dist_Fact.resize(Proc_Info[2]);
 
   /* Check for a problem which has too many processors for a given mesh */
 
@@ -678,18 +673,15 @@ template <typename T, typename INT> void NemSpread<T, INT>::load_mesh()
     safe_free((void **)&(globals.Proc_Elem_Connect[iproc]));
 
     safe_free((void **)&(globals.Coor[iproc]));
-    if (globals.Proc_Elem_Attr[iproc]) {
-      safe_free((void **)&(globals.Proc_Elem_Attr[iproc]));
-    }
-    if (globals.Proc_NS_Dist_Fact[iproc]) {
-      safe_free((void **)&(globals.Proc_NS_Dist_Fact[iproc]));
-    }
-    if (globals.Proc_SS_Dist_Fact[iproc]) {
-      safe_free((void **)&(globals.Proc_SS_Dist_Fact[iproc]));
-    }
+    globals.Proc_Elem_Attr[iproc].clear();
+    globals.Proc_NS_Dist_Fact[iproc].clear();
+    globals.Proc_SS_Dist_Fact[iproc].clear();
   }
   globals.N_Comm_Map.clear();
   globals.E_Comm_Map.clear();
+  globals.Proc_Elem_Attr.clear();
+  globals.Proc_NS_Dist_Fact.clear();
+  globals.Proc_SS_Dist_Fact.clear();
   fmt::print("\n");
 
 } /* END of routine load_mesh () *********************************************/
@@ -1236,8 +1228,7 @@ template <typename T, typename INT> void NemSpread<T, INT>::read_elem_blk(int ex
       iattr_length += globals.Proc_Num_Attr[iproc][i] * globals.Proc_Num_Elem_In_Blk[iproc][i];
     }
     if (iattr_length > 0) {
-      globals.Proc_Elem_Attr[iproc] =
-          (T *)array_alloc(__FILE__, __LINE__, 1, iattr_length, sizeof(T));
+      globals.Proc_Elem_Attr[iproc].resize(iattr_length);
     }
   } /* End "for(iproc=0; iproc <Proc_Info[2]; iproc)" */
 
@@ -2244,11 +2235,7 @@ void NemSpread<T, INT>::read_node_sets(int exoid, std::vector<INT> &num_nodes_in
           (INT *)array_alloc(__FILE__, __LINE__, 1, list_length[iproc], sizeof(INT));
 
       if (list_length[iproc] > 0) {
-        globals.Proc_NS_Dist_Fact[iproc] =
-            (T *)array_alloc(__FILE__, __LINE__, 1, list_length[iproc], sizeof(T));
-      }
-      else {
-        globals.Proc_NS_Dist_Fact[iproc] = nullptr;
+        globals.Proc_NS_Dist_Fact[iproc].resize(list_length[iproc]);
       }
     }
     else {
@@ -2863,11 +2850,7 @@ void NemSpread<T, INT>::read_side_sets(int exoid, std::vector<INT> &num_elem_in_
           globals.Proc_SS_DF_Pointers[iproc][i - 1] + proc_ss_df_cnt[iproc][i - 1];
 
       if (globals.Proc_SS_DF_Pointers[iproc][i] > 0) {
-        globals.Proc_SS_Dist_Fact[iproc] = (T *)array_alloc(
-            __FILE__, __LINE__, 1, globals.Proc_SS_DF_Pointers[iproc][i], sizeof(T));
-      }
-      else {
-        globals.Proc_SS_Dist_Fact[iproc] = nullptr;
+        globals.Proc_SS_Dist_Fact[iproc].resize(globals.Proc_SS_DF_Pointers[iproc][i]);
       }
     }
 

--- a/packages/seacas/applications/nem_spread/globals.h
+++ b/packages/seacas/applications/nem_spread/globals.h
@@ -357,8 +357,6 @@ public:
     safe_free((void **)&Proc_SS_Elem_List_Length);
 
     safe_free((void **)&Coor);
-    safe_free((void **)&Proc_Elem_Attr);
-    safe_free((void **)&Num_Internal_Nodes);
 
     safe_free((void **)&Info_Record);
     safe_free((void **)&GElem_Blks);

--- a/packages/seacas/applications/nem_spread/globals.h
+++ b/packages/seacas/applications/nem_spread/globals.h
@@ -92,20 +92,22 @@ public:
 
   std::vector<std::vector<INT>> Elem_Map{}; /* Map for Nemesis output */
 
-  INT **Proc_Global_Node_Id_Map{nullptr}; /* Data structure which contains the internal  *
-                                           * nodes on each processor.  It is a map       *
-                                           * from the local node number to the global    *
-                                           * node id (as found in node_num_map)       *
-                                           *  Type: int vector of length                 *
-                                           *       (Num_Internal_Nodes + Num_Border_Nodes*
-                                           *        Num_External_Nodes)               */
+  std::vector<std::vector<INT>>
+      Proc_Global_Node_Id_Map{}; /* Data structure which contains the internal  *
+                                  * nodes on each processor.  It is a map       *
+                                  * from the local node number to the global    *
+                                  * node id (as found in node_num_map)       *
+                                  *  Type: int vector of length                 *
+                                  *       (Num_Internal_Nodes + Num_Border_Nodes*
+                                  *        Num_External_Nodes)               */
 
-  INT **Proc_Global_Elem_Id_Map{nullptr}; /* Data structure which contains the internal  *
-                                           * elements on each processor.  It is a map    *
-                                           * from the local element number to the global *
-                                           * element id (as found in elem_num_map)            *
-                                           *  Type: int vector of length                 *
-                                           *        Num_Internal_Elems                   */
+  std::vector<std::vector<INT>>
+      Proc_Global_Elem_Id_Map{}; /* Data structure which contains the internal  *
+                                  * elements on each processor.  It is a map    *
+                                  * from the local element number to the global *
+                                  * element id (as found in elem_num_map)            *
+                                  *  Type: int vector of length                 *
+                                  *        Num_Internal_Elems                   */
 
   INT **GElem_Blks{nullptr}; /* Data structure which contains the mapping   *
                               * from the local element block number to the  *

--- a/packages/seacas/applications/nem_spread/globals.h
+++ b/packages/seacas/applications/nem_spread/globals.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(C) 1999-2022 National Technology & Engineering Solutions
+ * Copyright(C) 1999-2023 National Technology & Engineering Solutions
  * of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
  * NTESS, the U.S. Government retains certain rights in this software.
  *
@@ -17,19 +17,19 @@
 /*---------------------------------------------------------------------------*/
 template <typename INT> struct ELEM_COMM_MAP
 {
-  size_t map_id{0};
-  size_t elem_cnt{0};
-  INT   *elem_ids{nullptr};
-  INT   *side_ids{nullptr};
-  INT   *proc_ids{nullptr};
+  size_t           map_id{0};
+  size_t           elem_cnt{0};
+  std::vector<INT> elem_ids{};
+  std::vector<INT> side_ids{};
+  std::vector<INT> proc_ids{};
 };
 
 template <typename INT> struct NODE_COMM_MAP
 {
-  size_t map_id{0};
-  size_t node_cnt{0};
-  INT   *node_ids{nullptr};
-  INT   *proc_ids{nullptr};
+  size_t           map_id{0};
+  size_t           node_cnt{0};
+  std::vector<INT> node_ids{};
+  std::vector<INT> proc_ids{};
 };
 
 /*---------------------------------------------------------------------------*/
@@ -61,23 +61,21 @@ public:
   /*            THAT ARE THE DIFFERENT ON EACH PROCESSOR                     */
   /*---------------------------------------------------------------------------*/
 
-  INT *Num_Internal_Nodes{nullptr}; /* Number of internal nodes on the current proc*/
-  INT *Num_Border_Nodes{nullptr};   /* Number of border nodes on the current proc  */
-  INT *Num_External_Nodes{nullptr}; /* Number of external nodes on the current proc*/
-  INT *Num_Internal_Elems{nullptr}; /* Number of Elements on the local processor.  */
+  std::vector<INT> Num_Internal_Nodes{}; /* Number of internal nodes on the current proc*/
+  std::vector<INT> Num_Border_Nodes{};   /* Number of border nodes on the current proc  */
+  std::vector<INT> Num_External_Nodes{}; /* Number of external nodes on the current proc*/
+  std::vector<INT> Num_Internal_Elems{}; /* Number of Elements on the local processor.  */
 
-  INT *Num_Border_Elems{nullptr}; /* Number of Elements on the local processor *
-                                   * and shared by other processors. */
+  std::vector<INT> Num_Border_Elems{}; /* Number of Elements on the local processor *
+                                        * and shared by other processors. */
 
-  INT *Num_N_Comm_Maps{nullptr}; /* Number of nodal communication maps */
+  std::vector<INT> Num_N_Comm_Maps{}; /* Number of nodal communication maps */
+  std::vector<INT> Num_E_Comm_Maps{}; /* Number of elemental communication maps */
 
-  INT *Num_E_Comm_Maps{nullptr}; /* Number of elemental communication maps */
+  std::vector<ELEM_COMM_MAP<INT>> E_Comm_Map{}; /* Elemental communication map structure */
+  std::vector<NODE_COMM_MAP<INT>> N_Comm_Map{}; /* Nodal communication map structure */
 
-  ELEM_COMM_MAP<INT> **E_Comm_Map{nullptr}; /* Elemental communication map structure */
-
-  NODE_COMM_MAP<INT> **N_Comm_Map{nullptr}; /* Nodal communication map structure */
-
-  INT **GNodes{nullptr}; /* Data structure which contains the internal, *
+  std::vector<std::vector<INT>> GNodes{}; /* Data structure which contains the internal, *
                  * border, and external nodes on each processor*
                  * They are structured in that order, and      *
                  * monotonically within each category          *
@@ -85,12 +83,14 @@ public:
                  *       (Num_Internal_Nodes + Num_Border_Nodes*
                  Num_External_Nodes)                 */
 
-  INT **GElems{nullptr}; /* Data structure which contains the internal  *
-                          * elements on each processor.  It is a map    *
-                          * from the local element number to the global *
-                          * element number.                           *
-                          *  Type: int vector of length                 *
-                          *        Num_Internal_Elems                   */
+  std::vector<std::vector<INT>> GElems{}; /* Data structure which contains the internal  *
+                                           * elements on each processor.  It is a map    *
+                                           * from the local element number to the global *
+                                           * element number.                           *
+                                           *  Type: int vector of length                 *
+                                           *        Num_Internal_Elems                   */
+
+  std::vector<std::vector<INT>> Elem_Map{}; /* Map for Nemesis output */
 
   INT **Proc_Global_Node_Id_Map{nullptr}; /* Data structure which contains the internal  *
                                            * nodes on each processor.  It is a map       *
@@ -106,8 +106,6 @@ public:
                                            * element id (as found in elem_num_map)            *
                                            *  Type: int vector of length                 *
                                            *        Num_Internal_Elems                   */
-
-  INT **Elem_Map{nullptr}; /* Map for Nemesis output */
 
   INT **GElem_Blks{nullptr}; /* Data structure which contains the mapping   *
                               * from the local element block number to the  *

--- a/packages/seacas/applications/nem_spread/globals.h
+++ b/packages/seacas/applications/nem_spread/globals.h
@@ -159,9 +159,9 @@ public:
                                      * required by the current processor          *
                                      *  Type: int vector of variable length       */
 
-  T **Proc_Elem_Attr{nullptr}; /* Attribute list for the elements        *
-                                * required by the current processor      *
-                                *  Type: float vector of variable length */
+  std::vector<std::vector<T>> Proc_Elem_Attr{}; /* Attribute list for the elements        *
+                                                 * required by the current processor      *
+                                                 *  Type: float vector of variable length */
 
   /*---------------------------------------------------------------------------*/
   /*    VARIABLES THAT DEAL WITH SPECIFICATION OF ELEMENT BLOCK PROPERTIES     */
@@ -240,7 +240,7 @@ public:
                                 *  Type: int vector of length                 *
                                 *        Proc_NS_List_Length                  */
 
-  T **Proc_NS_Dist_Fact{nullptr};
+  std::vector<std::vector<T>> Proc_NS_Dist_Fact{};
   /* Node sets distribution factors for the node *
    * sets on a given processor                   *
    *  Type: float vector of length               *
@@ -282,7 +282,7 @@ public:
    *  Type: int array of dimensions              *
    *    Proc_Num_Side_Sets            */
 
-  T **Proc_SS_Dist_Fact{nullptr};
+  std::vector<std::vector<T>> Proc_SS_Dist_Fact{};
   /* Pointer for storage of the distribution     *
    * factors.                                    */
 

--- a/packages/seacas/applications/nem_spread/nem_spread.C
+++ b/packages/seacas/applications/nem_spread/nem_spread.C
@@ -1,5 +1,5 @@
 /*
- * Copyright(C) 1999-2021 National Technology & Engineering Solutions
+ * Copyright(C) 1999-2021, 2023 National Technology & Engineering Solutions
  * of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
  * NTESS, the U.S. Government retains certain rights in this software.
  *
@@ -327,16 +327,14 @@ int nem_spread(NemSpread<T, INT> &spreader, const char *salsa_cmd_file, int subc
     if (spreader.globals.Elem_Type != nullptr) {
       safe_free((void **)&spreader.globals.Elem_Type[i]);
     }
-    if (spreader.globals.Proc_Global_Node_Id_Map != nullptr) {
-      safe_free((void **)&spreader.globals.Proc_Global_Node_Id_Map[i]);
-    }
     safe_free((void **)&spreader.globals.Proc_SS_Ids[i]);
     safe_free((void **)&spreader.globals.Proc_SS_GEMap_List[i]);
     safe_free((void **)&spreader.globals.Proc_NS_Ids[i]);
     safe_free((void **)&spreader.globals.Proc_NS_GNMap_List[i]);
     safe_free((void **)&spreader.globals.Proc_Nodes_Per_Elem[i]);
     safe_free((void **)&spreader.globals.GElem_Blks[i]);
-    safe_free((void **)&spreader.globals.Proc_Global_Elem_Id_Map[i]);
+    spreader.globals.Proc_Global_Elem_Id_Map[i].clear();
+    spreader.globals.Proc_Global_Node_Id_Map[i].clear();
   }
   safe_free((void **)&spreader.globals.Elem_Type);
   safe_free((void **)&spreader.globals.GNodes);

--- a/packages/seacas/applications/nem_spread/nem_spread.C
+++ b/packages/seacas/applications/nem_spread/nem_spread.C
@@ -319,11 +319,9 @@ int nem_spread(NemSpread<T, INT> &spreader, const char *salsa_cmd_file, int subc
 
   fmt::print("Write of parallel exodus complete\n");
 
-  safe_free((void **)&(spreader.Proc_Ids));
   safe_free(reinterpret_cast<void **>(&(PIO_Info.RDsk_List)));
 
   for (int i = 0; i < spreader.Proc_Info[0]; i++) {
-    safe_free((void **)&spreader.globals.GNodes[i]);
     if (spreader.globals.Elem_Type != nullptr) {
       safe_free((void **)&spreader.globals.Elem_Type[i]);
     }
@@ -337,6 +335,5 @@ int nem_spread(NemSpread<T, INT> &spreader, const char *salsa_cmd_file, int subc
     spreader.globals.Proc_Global_Node_Id_Map[i].clear();
   }
   safe_free((void **)&spreader.globals.Elem_Type);
-  safe_free((void **)&spreader.globals.GNodes);
   return 0;
 }

--- a/packages/seacas/applications/nem_spread/nem_spread.h
+++ b/packages/seacas/applications/nem_spread/nem_spread.h
@@ -35,7 +35,7 @@ public:
                               size_t iend_elem, int *local_ielem_blk, int iproc);
   void extract_elem_attr(T *elem_attr, int icurrent_elem_blk, size_t istart_elem, size_t iend_elem,
                          int natt_p_elem, int iproc);
-  void find_elem_block(INT *proc_elem_blk, int iproc, int proc_for);
+  void find_elem_block(std::vector<INT> &proc_elem_blk, int iproc, int proc_for);
   void read_node_set_ids(int mesh_exoid, std::vector<INT> &num_nodes_in_node_set,
                          std::vector<INT> &num_df_in_nsets, int max_name_length);
   void read_side_set_ids(int mesh_exoid, std::vector<INT> &num_elem_in_ssets,

--- a/packages/seacas/applications/nem_spread/nem_spread.h
+++ b/packages/seacas/applications/nem_spread/nem_spread.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(C) 1999-2022 National Technology & Engineering Solutions
+ * Copyright(C) 1999-2023 National Technology & Engineering Solutions
  * of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
  * NTESS, the U.S. Government retains certain rights in this software.
  *
@@ -59,13 +59,16 @@ public:
 
   void process_lb_data(INT *Integer_Vector, int indx);
   void read_proc_init(int lb_exoid, int proc_info[], int **proc_ids_ptr);
-  void read_lb_init(int lb_exoid, INT *Int_Space, INT *Int_Node_Num, INT *Bor_Node_Num,
-                    INT *Ext_Node_Num, INT *Int_Elem_Num, INT *Bor_Elem_Num, INT *Node_Comm_Num,
-                    INT *Elem_Comm_Num, char *Title);
+  void read_lb_init(int lb_exoid, std::vector<INT> &Int_Space, std::vector<INT> &Int_Node_Num,
+                    std::vector<INT> &Bor_Node_Num, std::vector<INT> &Ext_Node_Num,
+                    std::vector<INT> &Int_Elem_Num, std::vector<INT> &Bor_Elem_Num,
+                    std::vector<INT> &Node_Comm_Num, std::vector<INT> &Elem_Comm_Num, char *Title);
 
-  void read_cmap_params(int lb_exoid, INT *Node_Comm_Num, INT *Elem_Comm_Num, INT *Num_N_Comm_Maps,
-                        INT *Num_E_Comm_Maps, ELEM_COMM_MAP<INT> **E_Comm_Map,
-                        NODE_COMM_MAP<INT> **N_Comm_Map, INT *cmap_max_size, INT **comm_vec);
+  void read_cmap_params(int lb_exoid, INT *Node_Comm_Num, INT *Elem_Comm_Num,
+                        std::vector<INT> &Num_N_Comm_Maps, std::vector<INT> &Num_E_Comm_Maps,
+                        std::vector<ELEM_COMM_MAP<INT>> &E_Comm_Map,
+                        std::vector<NODE_COMM_MAP<INT>> &N_Comm_Map, INT *cmap_max_size,
+                        INT **comm_vec);
 
   void create_elem_types();
   void read_mesh_param();

--- a/packages/seacas/applications/nem_spread/nem_spread.h
+++ b/packages/seacas/applications/nem_spread/nem_spread.h
@@ -157,7 +157,7 @@ public:
 
   char *Coord_Name[3]{}; /* The name(s) of the coordinate axes.   */
 
-  std::array<int, 6> Proc_Info;
+  std::array<int, 6> Proc_Info{};
   std::vector<int>   Proc_Ids{};
 
   NemSpread() { Coord_Name[0] = Coord_Name[1] = Coord_Name[2] = nullptr; }

--- a/packages/seacas/applications/nem_spread/nem_spread.h
+++ b/packages/seacas/applications/nem_spread/nem_spread.h
@@ -14,7 +14,7 @@
 #include "rf_io_const.h"
 
 #define UTIL_NAME "nem_spread"
-#define VER_STR   "7.01 (2021/03/19)"
+#define VER_STR   "7.02 (2023/02/06)"
 
 extern void   check_exodus_error(int, const char *);
 extern double second();
@@ -35,12 +35,14 @@ public:
   void extract_elem_attr(T *elem_attr, int icurrent_elem_blk, size_t istart_elem, size_t iend_elem,
                          int natt_p_elem, int iproc);
   void find_elem_block(INT *proc_elem_blk, int iproc, int proc_for);
-  void read_node_set_ids(int mesh_exoid, INT /*num_nodes_in_node_set*/[], INT /*num_df_in_nsets*/[],
-                         int max_name_length);
-  void read_side_set_ids(int mesh_exoid, INT /*num_elem_in_ssets*/[], INT /*num_df_in_ssets*/[],
-                         int max_name_length);
-  void read_node_sets(int exoid, INT * /*num_nodes_in_node_set*/, INT * /*num_df_in_nsets*/);
-  void read_side_sets(int exoid, INT * /*num_elem_in_ssets*/, INT * /*num_df_in_ssets*/);
+  void read_node_set_ids(int mesh_exoid, std::vector<INT> &num_nodes_in_node_set,
+                         std::vector<INT> &num_df_in_nsets, int max_name_length);
+  void read_side_set_ids(int mesh_exoid, std::vector<INT> &num_elem_in_ssets,
+                         std::vector<INT> &num_df_in_ssets, int max_name_length);
+  void read_node_sets(int exoid, std::vector<INT> &num_nodes_in_node_set,
+                      std::vector<INT> &num_df_in_nsets);
+  void read_side_sets(int exoid, std::vector<INT> &num_elem_in_ssets,
+                      std::vector<INT> &num_df_in_ssets);
 
   void read_nodal_vars(int mesh_exoid);
 
@@ -51,8 +53,9 @@ public:
                       int num_nset, char **ns_names, int *local_nstt, int num_sset, char **ss_names,
                       int *local_sstt);
 
-  void write_parExo_data(int mesh_exoid, int max_name_length, int iproc, INT *Num_Nodes_In_NS,
-                         INT *Num_Elems_In_SS, INT *Num_Elems_In_EB);
+  void write_parExo_data(int mesh_exoid, int max_name_length, int iproc,
+                         std::vector<INT> &Num_Nodes_In_NS, std::vector<INT> &Num_Elems_In_SS,
+                         std::vector<INT> &Num_Elems_In_EB);
 
   void write_var_timestep(int exoid, int proc, int time_step, INT *eb_ids_global,
                           INT *ss_ids_global, INT *ns_ids_global);
@@ -107,22 +110,22 @@ public:
    *
    *----------------------------------------------------------------------------*/
 
-  INT *Node_Set_Ids{nullptr};           /* Vector of node set ids             *
+  std::vector<INT> Node_Set_Ids;        /* Vector of node set ids             *
                                          * (ptr to vector of length,          *
                                          *  Num_Node_Set)                     */
-  INT *Side_Set_Ids{nullptr};           /* Side set ids                       *
+  std::vector<INT> Side_Set_Ids;        /* Side set ids                       *
                                          * (ptr to vector of length,          *
                                          *  Num_Side_Set)                     */
-  INT *Num_Elem_In_Blk{nullptr};        /* Number of elements in each element *
+  std::vector<INT> Num_Elem_In_Blk;     /* Number of elements in each element *
                                          * block (ptr to vector of length,    *
                                          *        Num_Elem_Blk)               */
-  INT *Num_Nodes_Per_Elem{nullptr};     /* Number of nodes per element in each*
+  std::vector<INT> Num_Nodes_Per_Elem;  /* Number of nodes per element in each*
                                          * elem block (ptr to vector of       *
                                          * length, Num_Elem_Blk)              */
-  INT *Num_Attr_Per_Elem{nullptr};      /* Number of attributes per element in*
+  std::vector<INT> Num_Attr_Per_Elem;   /* Number of attributes per element in*
                                          * each block (ptr to vector of       *
                                          * length, Num_Elem_Blk)              */
-  INT *Elem_Blk_Ids{nullptr};           /* Element block id's of each element *
+  std::vector<INT> Elem_Blk_Ids;        /* Element block id's of each element *
                                          * block (ptr to vector of length,    *
                                          *        Num_Elem_Blk)               */
   char **Elem_Blk_Types{nullptr};       /* Element block types for each       *

--- a/packages/seacas/applications/nem_spread/nem_spread.h
+++ b/packages/seacas/applications/nem_spread/nem_spread.h
@@ -71,8 +71,7 @@ public:
   void read_cmap_params(int lb_exoid, INT *Node_Comm_Num, INT *Elem_Comm_Num,
                         std::vector<INT> &Num_N_Comm_Maps, std::vector<INT> &Num_E_Comm_Maps,
                         std::vector<ELEM_COMM_MAP<INT>> &E_Comm_Map,
-                        std::vector<NODE_COMM_MAP<INT>> &N_Comm_Map, INT *cmap_max_size,
-                        INT **comm_vec);
+                        std::vector<NODE_COMM_MAP<INT>> &N_Comm_Map, INT *cmap_max_size);
 
   void create_elem_types();
   void read_mesh_param();

--- a/packages/seacas/applications/nem_spread/nem_spread.h
+++ b/packages/seacas/applications/nem_spread/nem_spread.h
@@ -7,6 +7,8 @@
  */
 #pragma once
 
+#include <array>
+
 #include "globals.h"
 #include "nem_spread.h"        // for NemSpread, etc
 #include "pe_str_util_const.h" // for strip_string, token_compare, etc
@@ -28,8 +30,8 @@ public:
   void   read_elem_blk_ids(int mesh_exoid, int max_name_length);
   void   read_elem_blk(int exoid);
   void   extract_elem_blk();
-  void   extract_global_element_ids(INT global_ids[], size_t Num_Elem, int iproc);
-  void   extract_global_node_ids(INT global_ids[], size_t Num_Node, int iproc);
+  void   extract_global_element_ids(const std::vector<INT> &global_ids, size_t Num_Elem, int iproc);
+  void   extract_global_node_ids(const std::vector<INT> &global_ids, size_t Num_Node, int iproc);
   size_t extract_elem_connect(INT elem_blk[], int icurrent_elem_blk, size_t istart_elem,
                               size_t iend_elem, int *local_ielem_blk, int iproc);
   void extract_elem_attr(T *elem_attr, int icurrent_elem_blk, size_t istart_elem, size_t iend_elem,
@@ -61,7 +63,7 @@ public:
                           INT *ss_ids_global, INT *ns_ids_global);
 
   void process_lb_data(INT *Integer_Vector, int indx);
-  void read_proc_init(int lb_exoid, int proc_info[], int **proc_ids_ptr);
+  void read_proc_init(int lb_exoid, std::array<int, 6> &proc_info, std::vector<int> &proc_ids);
   void read_lb_init(int lb_exoid, std::vector<INT> &Int_Space, std::vector<INT> &Int_Node_Num,
                     std::vector<INT> &Bor_Node_Num, std::vector<INT> &Ext_Node_Num,
                     std::vector<INT> &Int_Elem_Num, std::vector<INT> &Bor_Elem_Num,
@@ -157,14 +159,10 @@ public:
 
   char *Coord_Name[3]{}; /* The name(s) of the coordinate axes.   */
 
-  int  Proc_Info[6]{};
-  int *Proc_Ids{nullptr};
+  std::array<int, 6> Proc_Info;
+  std::vector<int>   Proc_Ids{};
 
-  NemSpread()
-  {
-    Coord_Name[0] = Coord_Name[1] = Coord_Name[2] = nullptr;
-    Proc_Info[0] = Proc_Info[1] = Proc_Info[2] = Proc_Info[3] = Proc_Info[4] = Proc_Info[5] = 0;
-  }
+  NemSpread() { Coord_Name[0] = Coord_Name[1] = Coord_Name[2] = nullptr; }
 
   ~NemSpread() { safe_free((void **)&GM_Elem_Types); }
 };

--- a/packages/seacas/applications/nem_spread/nem_spread.h
+++ b/packages/seacas/applications/nem_spread/nem_spread.h
@@ -10,7 +10,6 @@
 #include <array>
 
 #include "globals.h"
-#include "nem_spread.h"        // for NemSpread, etc
 #include "pe_str_util_const.h" // for strip_string, token_compare, etc
 #include "rf_allo.h"
 #include "rf_io_const.h"

--- a/packages/seacas/applications/nem_spread/pe_load_lb_info.C
+++ b/packages/seacas/applications/nem_spread/pe_load_lb_info.C
@@ -5,12 +5,6 @@
  *
  * See packages/seacas/LICENSE for details
  */
-#include <cassert>
-#include <cstddef> // for size_t
-#include <cstdio>  // for stderr, etc
-#include <cstdlib> // for exit
-#include <string>
-
 #include "exodusII.h" // for ex_inquire, ex_opts, etc
 #include "fmt/ostream.h"
 #include "globals.h"     // for ELEM_COMM_MAP, etc
@@ -20,6 +14,11 @@
 #include "rf_io_const.h" // for Debug_Flag, Exo_LB_File
 #include "rf_util.h"     // for print_line
 #include "sort_utils.h"  // for gds_qsort
+#include <cassert>
+#include <cstddef> // for size_t
+#include <cstdio>  // for stderr, etc
+#include <cstdlib> // for exit
+#include <string>
 
 char **qa_record_ptr, **inf_record_ptr;
 int    num_inf_rec = 0, num_qa_rec = 0, length_qa = 0;
@@ -290,14 +289,14 @@ template <typename T, typename INT> void NemSpread<T, INT>::load_lb_info()
       fmt::print("\n\t***For Processor {}***\n", Proc_Ids[iproc]);
       fmt::print("\tInternal nodes owned by the current processor\n\t");
       for (INT i = 0; i < globals.Num_Internal_Nodes[iproc]; i++) {
-        fmt::print(" ", (size_t)globals.GNodes[iproc][i]);
+        fmt::print(" {}", globals.GNodes[iproc][i]);
       }
 
       fmt::print("\n");
 
       fmt::print("\tBorder nodes owned by the current processor\n\t");
       for (INT i = 0; i < globals.Num_Border_Nodes[iproc]; i++) {
-        fmt::print(" ", (size_t)globals.GNodes[iproc][i + globals.Num_Internal_Nodes[iproc]]);
+        fmt::print(" {}", globals.GNodes[iproc][i + globals.Num_Internal_Nodes[iproc]]);
       }
 
       fmt::print("\n");
@@ -305,8 +304,8 @@ template <typename T, typename INT> void NemSpread<T, INT>::load_lb_info()
       if (globals.Num_External_Nodes[iproc] > 0) {
         fmt::print("\tExternal nodes needed by the current processor\n\t");
         for (INT i = 0; i < globals.Num_External_Nodes[iproc]; i++) {
-          fmt::print(" {}", (size_t)globals.GNodes[iproc][i + globals.Num_Internal_Nodes[iproc] +
-                                                          globals.Num_Border_Nodes[iproc]]);
+          fmt::print(" {}", globals.GNodes[iproc][i + globals.Num_Internal_Nodes[iproc] +
+                                                  globals.Num_Border_Nodes[iproc]]);
         }
 
         fmt::print("\n");
@@ -314,7 +313,7 @@ template <typename T, typename INT> void NemSpread<T, INT>::load_lb_info()
 
       fmt::print("\tInternal elements owned by the current processor\n\t");
       for (INT i = 0; i < globals.Num_Internal_Elems[iproc]; i++) {
-        fmt::print(" {}", (size_t)globals.GElems[iproc][i]);
+        fmt::print(" {}", globals.GElems[iproc][i]);
       }
 
       fmt::print("\n");
@@ -322,7 +321,7 @@ template <typename T, typename INT> void NemSpread<T, INT>::load_lb_info()
       if (globals.Num_Border_Elems[iproc] > 0) {
         fmt::print("\tBorder elements owned by the current processor\n\t");
         for (INT i = 0; i < globals.Num_Border_Elems[iproc]; i++) {
-          fmt::print(" {}", (size_t)globals.GElems[iproc][i + globals.Num_Internal_Elems[iproc]]);
+          fmt::print(" {}", globals.GElems[iproc][i + globals.Num_Internal_Elems[iproc]]);
         }
 
         fmt::print("\n");
@@ -332,11 +331,11 @@ template <typename T, typename INT> void NemSpread<T, INT>::load_lb_info()
         fmt::print("\tNodal Comm Map for the current processor\n");
         fmt::print("\t\tnode IDs:");
         for (size_t i = 0; i < globals.N_Comm_Map[iproc].node_cnt; i++) {
-          fmt::print(" {}", (size_t)globals.N_Comm_Map[iproc].node_ids[i]);
+          fmt::print(" {}", globals.N_Comm_Map[iproc].node_ids[i]);
         }
         fmt::print("\n\t\tproc IDs:");
         for (size_t i = 0; i < globals.N_Comm_Map[iproc].node_cnt; i++) {
-          fmt::print(" {}", (size_t)globals.N_Comm_Map[iproc].proc_ids[i]);
+          fmt::print(" {}", globals.N_Comm_Map[iproc].proc_ids[i]);
         }
 
         fmt::print("\n");
@@ -346,15 +345,15 @@ template <typename T, typename INT> void NemSpread<T, INT>::load_lb_info()
         fmt::print("\tElemental Comm Map for the current processor\n");
         fmt::print("\t\telement IDs:");
         for (size_t i = 0; i < globals.E_Comm_Map[iproc].elem_cnt; i++) {
-          fmt::print(" {}", (size_t)globals.E_Comm_Map[iproc].elem_ids[i]);
+          fmt::print(" {}", globals.E_Comm_Map[iproc].elem_ids[i]);
         }
         fmt::print("\n\t\tside IDs:");
         for (size_t i = 0; i < globals.E_Comm_Map[iproc].elem_cnt; i++) {
-          fmt::print(" {}", (size_t)globals.E_Comm_Map[iproc].side_ids[i]);
+          fmt::print(" {}", globals.E_Comm_Map[iproc].side_ids[i]);
         }
         fmt::print("\n\t\tproc IDs:");
         for (size_t i = 0; i < globals.E_Comm_Map[iproc].elem_cnt; i++) {
-          fmt::print(" {}", (size_t)globals.E_Comm_Map[iproc].proc_ids[i]);
+          fmt::print(" {}", globals.E_Comm_Map[iproc].proc_ids[i]);
         }
 
         fmt::print("\n");
@@ -678,11 +677,11 @@ in mesh file",
     print_line("-", 79);
     fmt::print("\n");
     for (int i = 0; i < Proc_Info[2]; i++) {
-      fmt::print("{:6d}  {:6d}  {:6d}   {:6d}    {:6d}    {:6d}     {:6d}     {:6d}\n",
-                 (size_t)Proc_Ids[i], (size_t)globals.Num_Internal_Nodes[i],
-                 (size_t)globals.Num_Border_Nodes[i], (size_t)globals.Num_External_Nodes[i],
-                 (size_t)globals.Num_Internal_Elems[i], (size_t)globals.Num_Border_Elems[i],
-                 (size_t)globals.Num_N_Comm_Maps[i], (size_t)globals.Num_E_Comm_Maps[i]);
+      fmt::print("{:6d}  {:6d}  {:6d}   {:6d}    {:6d}    {:6d}     {:6d}     {:6d}\n", Proc_Ids[i],
+                 globals.Num_Internal_Nodes[i], globals.Num_Border_Nodes[i],
+                 globals.Num_External_Nodes[i], globals.Num_Internal_Elems[i],
+                 globals.Num_Border_Elems[i], globals.Num_N_Comm_Maps[i],
+                 globals.Num_E_Comm_Maps[i]);
     }
     print_line("=", 79);
     fmt::print("\n\n");
@@ -786,7 +785,7 @@ void NemSpread<T, INT>::read_cmap_params(int lb_exoid, INT *Node_Comm_Num, INT *
   if (Debug_Flag >= 4) {
     print_line("=", 79);
     fmt::print("\t\tCOMMUNICATION MAP INFORMATION\n");
-    fmt::print("\t\t   largest cmap = {} integers\n", (size_t)*cmap_max_size);
+    fmt::print("\t\t   largest cmap = {} integers\n", *cmap_max_size);
     print_line("=", 79);
 
     int bprnt_n = 0;

--- a/packages/seacas/applications/nem_spread/pe_load_lb_info.C
+++ b/packages/seacas/applications/nem_spread/pe_load_lb_info.C
@@ -94,7 +94,7 @@ template <typename T, typename INT> void NemSpread<T, INT>::load_lb_info()
   }
 
   /* Read information about the processor configuration */
-  read_proc_init(lb_exoid, Proc_Info, &Proc_Ids);
+  read_proc_init(lb_exoid, Proc_Info, Proc_Ids);
 
   /* Allocate space for the counts */
   globals.Num_Internal_Nodes.resize(Proc_Info[2]);
@@ -481,7 +481,8 @@ void NemSpread<T, INT>::process_lb_data(INT *Integer_Vector, int indx)
 /*****************************************************************************/
 
 template <typename T, typename INT>
-void NemSpread<T, INT>::read_proc_init(int lb_exoid, int proc_info[], int **proc_ids_ptr)
+void NemSpread<T, INT>::read_proc_init(int lb_exoid, std::array<int, 6> &proc_info,
+                                       std::vector<int> &proc_ids)
 
 /*----------------------------------------------------------------------------
  *  read_proc_init:
@@ -507,15 +508,11 @@ void NemSpread<T, INT>::read_proc_init(int lb_exoid, int proc_info[], int **proc
 
   /* Calculate which processor is responsible for what */
   proc_info[2] = proc_info[0];
-  int *proc_ids =
-      reinterpret_cast<int *>(array_alloc(__FILE__, __LINE__, 1, proc_info[2], sizeof(int)));
+  proc_ids.resize(proc_info[2]);
 
   for (int i1 = 0; i1 < proc_info[2]; i1++) {
     proc_ids[i1] = i1;
   }
-
-  *proc_ids_ptr = proc_ids;
-
 } /* End of read_proc_init() *************************************************/
 /*****************************************************************************/
 /*****************************************************************************/

--- a/packages/seacas/applications/nem_spread/pe_util.C
+++ b/packages/seacas/applications/nem_spread/pe_util.C
@@ -1,5 +1,5 @@
 /*
- * Copyright(C) 1999-2021 National Technology & Engineering Solutions
+ * Copyright(C) 1999-2021, 2023 National Technology & Engineering Solutions
  * of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
  * NTESS, the U.S. Government retains certain rights in this software.
  *
@@ -10,8 +10,9 @@
 #include "ps_pario_const.h" // for Parallel_IO, PIO_Info
 #include "rf_allo.h"        // for array_alloc
 #include "rf_io_const.h"    // for Debug_Flag
-#include <cstdlib>          // for exit
-#include <cstring>          // for strlen, etc
+#include <array>
+#include <cstdlib> // for exit
+#include <cstring> // for strlen, etc
 #include <sstream>
 #include <string>
 
@@ -28,7 +29,8 @@
 /*****************************************************************************/
 /*****************************************************************************/
 /*****************************************************************************/
-void gen_disk_map(struct Parallel_IO *pio_info, int proc_info[], int /*proc*/, int nproc)
+void gen_disk_map(struct Parallel_IO *pio_info, const std::array<int, 6> &proc_info, int /*proc*/,
+                  int nproc)
 /*
  * This function generates a map of which processor ID writes to which
  * RAID. Note that this is for each processor in the list, not necessarily

--- a/packages/seacas/applications/nem_spread/pe_write_parExo_info.C
+++ b/packages/seacas/applications/nem_spread/pe_write_parExo_info.C
@@ -61,27 +61,33 @@ extern std::string GeomTitle;
 /****************************************************************************/
 
 template void NemSpread<float, int>::write_parExo_data(int mesh_exoid, int max_name_length,
-                                                       int iproc, int *Num_Nodes_In_NS,
-                                                       int *Num_Elems_In_SS, int *Num_Elems_In_EB);
+                                                       int iproc, std::vector<int> &Num_Nodes_In_NS,
+                                                       std::vector<int> &Num_Elems_In_SS,
+                                                       std::vector<int> &Num_Elems_In_EB);
 
 template void NemSpread<double, int>::write_parExo_data(int mesh_exoid, int max_name_length,
-                                                        int iproc, int *Num_Nodes_In_NS,
-                                                        int *Num_Elems_In_SS, int *Num_Elems_In_EB);
+                                                        int               iproc,
+                                                        std::vector<int> &Num_Nodes_In_NS,
+                                                        std::vector<int> &Num_Elems_In_SS,
+                                                        std::vector<int> &Num_Elems_In_EB);
 
 template void NemSpread<double, int64_t>::write_parExo_data(int mesh_exoid, int max_name_length,
-                                                            int iproc, int64_t *Num_Nodes_In_NS,
-                                                            int64_t *Num_Elems_In_SS,
-                                                            int64_t *Num_Elems_In_EB);
+                                                            int                   iproc,
+                                                            std::vector<int64_t> &Num_Nodes_In_NS,
+                                                            std::vector<int64_t> &Num_Elems_In_SS,
+                                                            std::vector<int64_t> &Num_Elems_In_EB);
 
 template void NemSpread<float, int64_t>::write_parExo_data(int mesh_exoid, int max_name_length,
-                                                           int iproc, int64_t *Num_Nodes_In_NS,
-                                                           int64_t *Num_Elems_In_SS,
-                                                           int64_t *Num_Elems_In_EB);
+                                                           int                   iproc,
+                                                           std::vector<int64_t> &Num_Nodes_In_NS,
+                                                           std::vector<int64_t> &Num_Elems_In_SS,
+                                                           std::vector<int64_t> &Num_Elems_In_EB);
 
 template <typename T, typename INT>
 void NemSpread<T, INT>::write_parExo_data(int mesh_exoid, int max_name_length, int iproc,
-                                          INT *Num_Nodes_In_NS, INT *Num_Elems_In_SS,
-                                          INT *Num_Elems_In_EB)
+                                          std::vector<INT> &Num_Nodes_In_NS,
+                                          std::vector<INT> &Num_Elems_In_SS,
+                                          std::vector<INT> &Num_Elems_In_EB)
 {
   /* Performance metrics. */
   size_t bytes_out      = 0;
@@ -277,8 +283,8 @@ void NemSpread<T, INT>::write_parExo_data(int mesh_exoid, int max_name_length, i
     fmt::print("\tNumber External Nodes: {}\n", globals.Num_External_Nodes[iproc]);
     fmt::print("\tNumber Internal Elements: {}\n", globals.Num_Internal_Elems[iproc]);
     fmt::print("\tNumber Border Elements: {}\n", globals.Num_Border_Elems[iproc]);
-    fmt::print("\tNumber Nodal Cmaps: {}\n", static_cast<size_t>(ncomm_cnt));
-    fmt::print("\tNumber Elemental Cmaps: {}\n", static_cast<size_t>(ecomm_cnt));
+    fmt::print("\tNumber Nodal Cmaps: {}\n", ncomm_cnt);
+    fmt::print("\tNumber Elemental Cmaps: {}\n", ecomm_cnt);
     fmt::print("\tProccesor For: {}\n", proc_for);
   }
 
@@ -387,8 +393,8 @@ void NemSpread<T, INT>::write_parExo_data(int mesh_exoid, int max_name_length, i
     bytes_out += 3 * globals.Num_Node_Set * sizeof(INT);
     tt1 = second();
 
-    if (ex_put_ns_param_global(mesh_exoid, Node_Set_Ids, Num_Nodes_In_NS, glob_ns_df_cnts.data()) <
-        0) {
+    if (ex_put_ns_param_global(mesh_exoid, Node_Set_Ids.data(), Num_Nodes_In_NS.data(),
+                               glob_ns_df_cnts.data()) < 0) {
       fmt::print(stderr, "[{}]: ERROR, unable to output global node-set params\n", __func__);
       ex_close(mesh_exoid);
       exit(1);
@@ -406,8 +412,8 @@ void NemSpread<T, INT>::write_parExo_data(int mesh_exoid, int max_name_length, i
     bytes_out += 3 * globals.Num_Side_Set * sizeof(INT);
     tt1 = second();
 
-    if (ex_put_ss_param_global(mesh_exoid, Side_Set_Ids, Num_Elems_In_SS, glob_ss_df_cnts.data()) <
-        0) {
+    if (ex_put_ss_param_global(mesh_exoid, Side_Set_Ids.data(), Num_Elems_In_SS.data(),
+                               glob_ss_df_cnts.data()) < 0) {
       fmt::print(stderr, "[{}]: ERROR, unable to output global side-set params\n", __func__);
       ex_close(mesh_exoid);
       exit(1);
@@ -420,7 +426,7 @@ void NemSpread<T, INT>::write_parExo_data(int mesh_exoid, int max_name_length, i
   bytes_out += globals.Num_Elem_Blk * sizeof(INT);
   tt1 = second();
 
-  if (ex_put_eb_info_global(mesh_exoid, Elem_Blk_Ids, Num_Elems_In_EB) < 0) {
+  if (ex_put_eb_info_global(mesh_exoid, Elem_Blk_Ids.data(), Num_Elems_In_EB.data()) < 0) {
     fmt::print(stderr, "[{}]: ERROR, unable to output global elem blk IDs\n", __func__);
     ex_close(mesh_exoid);
     exit(1);

--- a/packages/seacas/applications/nem_spread/pe_write_parExo_info.C
+++ b/packages/seacas/applications/nem_spread/pe_write_parExo_info.C
@@ -633,7 +633,7 @@ void NemSpread<T, INT>::write_parExo_data(int mesh_exoid, int max_name_length, i
 
   /* If non-nullptr, output the global node id map which preserves
      the global node ids in the original mesh */
-  if (globals.Proc_Global_Node_Id_Map[iproc] != nullptr) {
+  if (!globals.Proc_Global_Node_Id_Map[iproc].empty()) {
     bytes_out += itotal_nodes * sizeof(INT);
     if (ex_put_map_param(mesh_exoid, 1, 0) < 0) {
       fmt::print(stderr, "[{}]: ERROR, unable to define global node map parameters!\n", __func__);
@@ -641,7 +641,8 @@ void NemSpread<T, INT>::write_parExo_data(int mesh_exoid, int max_name_length, i
       exit(1);
     }
 
-    if (ex_put_num_map(mesh_exoid, EX_NODE_MAP, 1, globals.Proc_Global_Node_Id_Map[iproc]) < 0) {
+    if (ex_put_num_map(mesh_exoid, EX_NODE_MAP, 1, globals.Proc_Global_Node_Id_Map[iproc].data()) <
+        0) {
       fmt::print(stderr, "[{}]: ERROR, unable to output global node id map!\n", __func__);
       ex_close(mesh_exoid);
       exit(1);
@@ -823,7 +824,7 @@ void NemSpread<T, INT>::write_parExo_data(int mesh_exoid, int max_name_length, i
 
     /* If non-nullptr, output the global element id map which preserves
        the global element ids in the original mesh */
-    if (globals.Proc_Global_Elem_Id_Map[iproc] != nullptr) {
+    if (!globals.Proc_Global_Elem_Id_Map[iproc].empty()) {
       bytes_out +=
           globals.Num_Internal_Elems[iproc] * globals.Num_Border_Elems[iproc] * sizeof(INT);
       if (ex_put_map_param(mesh_exoid, 0, 1) < 0) {
@@ -832,7 +833,8 @@ void NemSpread<T, INT>::write_parExo_data(int mesh_exoid, int max_name_length, i
         exit(1);
       }
 
-      if (ex_put_num_map(mesh_exoid, EX_ELEM_MAP, 1, globals.Proc_Global_Elem_Id_Map[iproc]) < 0) {
+      if (ex_put_num_map(mesh_exoid, EX_ELEM_MAP, 1,
+                         globals.Proc_Global_Elem_Id_Map[iproc].data()) < 0) {
         fmt::print(stderr, "[{}]: ERROR, unable to output global id map!\n", __func__);
         ex_close(mesh_exoid);
         exit(1);

--- a/packages/seacas/applications/nem_spread/ps_pario_const.h
+++ b/packages/seacas/applications/nem_spread/ps_pario_const.h
@@ -1,5 +1,5 @@
 /*
- * Copyright(C) 1999-2020, 2022 National Technology & Engineering Solutions
+ * Copyright(C) 1999-2020, 2022, 2023 National Technology & Engineering Solutions
  * of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
  * NTESS, the U.S. Government retains certain rights in this software.
  *
@@ -59,5 +59,6 @@ extern struct Parallel_IO PIO_Info;
 
 extern std::string Par_Nem_File_Name; /* The parallel nemesis file name */
 
-void        gen_disk_map(struct Parallel_IO *pio_info, int proc_info[], int proc, int nproc);
+void gen_disk_map(struct Parallel_IO *pio_info, const std::array<int, 6> &proc_info, int proc,
+                  int nproc);
 std::string gen_par_filename(const std::string &scalar_fname, int proc_for, int nprocs);

--- a/packages/seacas/applications/nem_spread/ps_restart.C
+++ b/packages/seacas/applications/nem_spread/ps_restart.C
@@ -1,5 +1,5 @@
 /*
- * Copyright(C) 1999-2021 National Technology & Engineering Solutions
+ * Copyright(C) 1999-2021, 2023 National Technology & Engineering Solutions
  * of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
  * NTESS, the U.S. Government retains certain rights in this software.
  *
@@ -19,12 +19,6 @@
 #include <cstdlib>          // for exit, free, malloc
 #include <string>
 #include <vector> // for vector
-
-namespace {
-  template <typename INT>
-  size_t find_gnode_inter(INT *intersect, size_t num_g_nodes, INT *glob_vec, size_t num_int_nodes,
-                          size_t num_bor_nodes, size_t num_ext_nodes, INT *loc_vec);
-} // namespace
 
 /*****************************************************************************/
 /*****************************************************************************/
@@ -129,7 +123,6 @@ template <typename T, typename INT> void NemSpread<T, INT>::read_restart_data()
   INT ***eb_map_ptr    = nullptr;
   INT  **eb_cnts_local = nullptr;
   int    exoid         = 0;
-  int   *par_exoid     = nullptr;
 
   float       vers;
   std::string cTemp;
@@ -160,6 +153,53 @@ template <typename T, typename INT> void NemSpread<T, INT>::read_restart_data()
   /* allocate space for the global variables */
   Restart_Info.Glob_Vals.resize(Restart_Info.NVar_Glob);
 
+  /*
+   * in order to speed up finding matches in the global element
+   * number map, set up an array of pointers to the start of
+   * each element block's global element number map. That way
+   * only entries for the current element block have to be searched
+   */
+  eb_map_ptr = (INT ***)array_alloc(__FILE__, __LINE__, 2, Proc_Info[2], globals.Num_Elem_Blk,
+                                    sizeof(INT *));
+  if (!eb_map_ptr) {
+    fmt::print(stderr, "[{}]: ERROR, insufficient memory!\n", __func__);
+    exit(1);
+  }
+  eb_cnts_local =
+      (INT **)array_alloc(__FILE__, __LINE__, 2, Proc_Info[2], globals.Num_Elem_Blk, sizeof(INT));
+  if (!eb_cnts_local) {
+    fmt::print(stderr, "[{}]: ERROR, insufficient memory!\n", __func__);
+    exit(1);
+  }
+
+  /*
+   * for now, assume that element blocks have been
+   * stored in the same order as the global blocks
+   */
+  for (int iproc = 0; iproc < Proc_Info[2]; iproc++) {
+    int    ifound = 0;
+    size_t offset = 0;
+    int    ilocal;
+    for (int cnt = 0; cnt < globals.Num_Elem_Blk; cnt++) {
+      for (ilocal = ifound; ilocal < globals.Proc_Num_Elem_Blk[iproc]; ilocal++) {
+        if (globals.Proc_Elem_Blk_Ids[iproc][ilocal] == eb_ids_global[cnt]) {
+          break;
+        }
+      }
+
+      if (ilocal < globals.Proc_Num_Elem_Blk[iproc]) {
+        eb_map_ptr[iproc][cnt]    = &globals.GElems[iproc][offset];
+        eb_cnts_local[iproc][cnt] = globals.Proc_Num_Elem_In_Blk[iproc][ilocal];
+        offset += globals.Proc_Num_Elem_In_Blk[iproc][ilocal];
+        ifound = ilocal; /* don't search the same part of the list over */
+      }
+      else {
+        eb_map_ptr[iproc][cnt]    = nullptr;
+        eb_cnts_local[iproc][cnt] = 0;
+      }
+    }
+  }
+
   if (Restart_Info.NVar_Elem > 0) {
 
     /* allocate storage space */
@@ -171,18 +211,6 @@ template <typename T, typename INT> void NemSpread<T, INT>::read_restart_data()
                           (globals.Num_Internal_Elems[iproc] + globals.Num_Border_Elems[iproc]);
       Restart_Info.Elem_Vals[iproc].resize(array_size);
     }
-
-    /*
-     * at this point, I need to broadcast the global element block ids
-     * and counts to the processors. I know that this is redundant data
-     * since they will all receive this information in read_mesh, but
-     * the variables which contain that information are static in
-     * el_exoII_io.c, and cannot be used here. So, take a second and
-     * broadcast all of this out.
-     *
-     * I want to do this here so that it is done only once no matter
-     * how many time steps are retrieved
-     */
 
     /* Get the Element Block IDs from the input file */
     if (ex_get_ids(exoid, EX_ELEM_BLOCK, eb_ids_global.data()) < 0) {
@@ -198,53 +226,6 @@ template <typename T, typename INT> void NemSpread<T, INT>::read_restart_data()
         fmt::print(stderr, "{}: unable to get element count for block id {}", __func__,
                    (size_t)eb_ids_global[cnt]);
         exit(1);
-      }
-    }
-
-    /*
-     * in order to speed up finding matches in the global element
-     * number map, set up an array of pointers to the start of
-     * each element block's global element number map. That way
-     * only entries for the current element block have to be searched
-     */
-    eb_map_ptr = (INT ***)array_alloc(__FILE__, __LINE__, 2, Proc_Info[2], globals.Num_Elem_Blk,
-                                      sizeof(INT *));
-    if (!eb_map_ptr) {
-      fmt::print(stderr, "[{}]: ERROR, insufficient memory!\n", __func__);
-      exit(1);
-    }
-    eb_cnts_local =
-        (INT **)array_alloc(__FILE__, __LINE__, 2, Proc_Info[2], globals.Num_Elem_Blk, sizeof(INT));
-    if (!eb_cnts_local) {
-      fmt::print(stderr, "[{}]: ERROR, insufficient memory!\n", __func__);
-      exit(1);
-    }
-
-    /*
-     * for now, assume that element blocks have been
-     * stored in the same order as the global blocks
-     */
-    for (int iproc = 0; iproc < Proc_Info[2]; iproc++) {
-      int    ifound = 0;
-      size_t offset = 0;
-      int    ilocal;
-      for (int cnt = 0; cnt < globals.Num_Elem_Blk; cnt++) {
-        for (ilocal = ifound; ilocal < globals.Proc_Num_Elem_Blk[iproc]; ilocal++) {
-          if (globals.Proc_Elem_Blk_Ids[iproc][ilocal] == eb_ids_global[cnt]) {
-            break;
-          }
-        }
-
-        if (ilocal < globals.Proc_Num_Elem_Blk[iproc]) {
-          eb_map_ptr[iproc][cnt]    = &globals.GElems[iproc][offset];
-          eb_cnts_local[iproc][cnt] = globals.Proc_Num_Elem_In_Blk[iproc][ilocal];
-          offset += globals.Proc_Num_Elem_In_Blk[iproc][ilocal];
-          ifound = ilocal; /* don't search the same part of the list over */
-        }
-        else {
-          eb_map_ptr[iproc][cnt]    = nullptr;
-          eb_cnts_local[iproc][cnt] = 0;
-        }
       }
     }
 
@@ -275,18 +256,6 @@ template <typename T, typename INT> void NemSpread<T, INT>::read_restart_data()
       Restart_Info.Sset_Vals[iproc].resize(array_size);
     }
 
-    /*
-     * at this point, I need to broadcast the ids and counts to the
-     * processors. I know that this is redundant data since they will
-     * all receive this information in read_mesh, but the variables
-     * which contain that information are static in el_exoII_io.c, and
-     * cannot be used here. So, take a second and broadcast all of
-     * this out.
-     *
-     * I want to do this here so that it is done only once no matter
-     * how many time steps are retrieved
-     */
-
     /* Get the Sideset IDs from the input file */
     if (ex_get_ids(exoid, EX_SIDE_SET, ss_ids_global.data()) < 0) {
       fmt::print(stderr, "{}: unable to get sideset IDs", __func__);
@@ -315,18 +284,6 @@ template <typename T, typename INT> void NemSpread<T, INT>::read_restart_data()
       Restart_Info.Nset_Vals[iproc].resize(array_size);
     }
 
-    /*
-     * at this point, I need to broadcast the ids and counts to the
-     * processors. I know that this is redundant data since they will
-     * all receive this information in read_mesh, but the variables
-     * which contain that information are static in el_exoII_io.c, and
-     * cannot be used here. So, take a second and broadcast all of
-     * this out.
-     *
-     * I want to do this here so that it is done only once no matter
-     * how many time steps are retrieved
-     */
-
     /* Get the Nodeset IDs from the input file */
     if (ex_get_ids(exoid, EX_NODE_SET, ns_ids_global.data()) < 0) {
       fmt::print(stderr, "{}: unable to get nodeset IDs", __func__);
@@ -344,17 +301,7 @@ template <typename T, typename INT> void NemSpread<T, INT>::read_restart_data()
     }
   } /* End: "if (Restart_Info.NVar_Nset > 0 )" */
 
-  /*
-   * NOTE: A possible place to speed this up would be to
-   * get the global node and element lists here, and broadcast
-   * them out only once.
-   */
-
-  par_exoid = (int *)malloc(Proc_Info[2] * sizeof(int));
-  if (par_exoid == nullptr) {
-    fmt::print(stderr, "[{}]: ERROR, insufficient memory!\n", __func__);
-    exit(1);
-  }
+  std::vector<int> par_exoid(Proc_Info[2]);
 
   /* See if any '/' in the name.  IF present, isolate the basename of the file */
   size_t found = Output_File_Base_Name.find_last_of('/');
@@ -476,22 +423,20 @@ template <typename T, typename INT> void NemSpread<T, INT>::read_restart_data()
       }
     }
   }
-  free(par_exoid);
-  par_exoid = nullptr;
 }
 
 template <typename T, typename INT>
 int NemSpread<T, INT>::read_var_param(int exoid, int max_name_length)
 {
   /* Get the number of time indices contained in the file */
-  int ret_int = ex_inquire_int(exoid, EX_INQ_TIME);
+  int num_times = ex_inquire_int(exoid, EX_INQ_TIME);
 
   /* see if the user want to get all of the time indices */
   if (Restart_Info.Num_Times == -1) {
 
-    Restart_Info.Num_Times = ret_int;
+    Restart_Info.Num_Times = num_times;
 
-    if (ret_int > 0) {
+    if (num_times > 0) {
       /* allocate array space */
       Restart_Info.Time_Idx.resize(Restart_Info.Num_Times);
 
@@ -506,14 +451,14 @@ int NemSpread<T, INT>::read_var_param(int exoid, int max_name_length)
 
       /* if the user wants the last time, then set it */
       if (Restart_Info.Time_Idx[cnt] == 0) {
-        Restart_Info.Time_Idx[cnt] = ret_int;
+        Restart_Info.Time_Idx[cnt] = num_times;
       }
 
-      if (Restart_Info.Time_Idx[cnt] > ret_int) {
+      if (Restart_Info.Time_Idx[cnt] > num_times) {
         fmt::print(stderr, "{}: Requested time index, {}, out of range.\n", __func__,
                    Restart_Info.Time_Idx[cnt]);
         fmt::print(stderr, "{}: Valid time indices in {} are from 1 to {}.\n", __func__,
-                   Exo_Res_File, ret_int);
+                   Exo_Res_File, num_times);
         return -1;
       }
     }
@@ -964,96 +909,3 @@ template <typename T, typename INT> int NemSpread<T, INT>::compare_mesh_param(in
 
   return (ret);
 }
-
-/*****************************************************************************/
-namespace {
-  template <typename INT>
-  size_t find_gnode_inter(INT *intersect, size_t num_g_nodes, INT *glob_vec, size_t num_int_nodes,
-                          size_t num_bor_nodes, size_t num_ext_nodes, INT *loc_vec)
-
-  /*
-   * This function assumes that glob_vec is monotonic and that loc_vec is
-   * monotonic for each of the internal, border and external node IDs it
-   * contains.
-   */
-  {
-    size_t count = 0;
-
-    /* Initialize the intersect vector */
-    for (size_t i1 = 0; i1 < num_g_nodes; i1++) {
-      intersect[i1] = -1;
-    }
-
-    /* Check for the possibility of an intersection */
-    size_t min_set1 = glob_vec[0];
-    size_t max_set1 = glob_vec[num_g_nodes - 1];
-
-    /* Search through the internal nodes */
-    if (num_int_nodes > 0) {
-      size_t min_set2 = loc_vec[0];
-      size_t max_set2 = loc_vec[num_int_nodes - 1];
-
-      if ((max_set2 >= min_set1) && (min_set2 <= max_set1)) {
-        for (size_t i1 = 0, i2 = 0; i1 < num_g_nodes; i1++) {
-          while ((i2 < (num_int_nodes - 1)) && (glob_vec[i1] > loc_vec[i2])) {
-            i2++;
-          }
-          if (glob_vec[i1] == loc_vec[i2]) {
-            intersect[i1] = i2;
-            count++;
-          }
-        }
-      }
-    }
-
-    /* Search through the border nodes */
-    if (num_bor_nodes > 0) {
-      size_t min_set2 = loc_vec[num_int_nodes];
-      size_t max_set2 = loc_vec[num_int_nodes + num_bor_nodes - 1];
-
-      size_t offset = num_int_nodes;
-
-      if ((max_set2 >= min_set1) && (min_set2 <= max_set1)) {
-        for (size_t i1 = 0, i2 = 0; i1 < num_g_nodes; i1++) {
-          while ((i2 < (num_bor_nodes - 1)) && (glob_vec[i1] > loc_vec[offset + i2])) {
-            i2++;
-          }
-
-          if (glob_vec[i1] == loc_vec[offset + i2]) {
-            intersect[i1] = offset + i2;
-            count++;
-          }
-        }
-      }
-    }
-
-    /* Search through the external nodes */
-    if (num_ext_nodes > 0) {
-      size_t min_set2 = loc_vec[num_int_nodes + num_bor_nodes];
-      size_t max_set2 = loc_vec[num_int_nodes + num_bor_nodes + num_ext_nodes - 1];
-
-      size_t offset = num_int_nodes + num_bor_nodes;
-
-      if ((max_set2 >= min_set1) && (min_set2 <= max_set1)) {
-        for (size_t i1 = 0, i2 = 0; i1 < num_g_nodes; i1++) {
-          while ((i2 < (num_ext_nodes - 1)) && (glob_vec[i1] > loc_vec[offset + i2])) {
-            i2++;
-          }
-
-          if (glob_vec[i1] == loc_vec[offset + i2]) {
-            intersect[i1] = offset + i2;
-            count++;
-          }
-        }
-      }
-    }
-
-#ifdef DEBUG
-    assert(count < num_g_nodes &&
-           "find_gnode_inter ERROR: Catastrophic error in node structure observed\n");
-#endif
-
-    return count;
-  }
-
-} // namespace

--- a/packages/seacas/applications/nem_spread/sort_utils.C
+++ b/packages/seacas/applications/nem_spread/sort_utils.C
@@ -1,5 +1,5 @@
 /*
- * Copyright(C) 1999-2022 National Technology & Engineering Solutions
+ * Copyright(C) 1999-2023 National Technology & Engineering Solutions
  * of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
  * NTESS, the U.S. Government retains certain rights in this software.
  *
@@ -40,7 +40,7 @@ namespace {
     V[J]   = _t;
   }
 
-  template <typename INT> INT gds_imedian3(INT v[], INT iv[], size_t left, size_t right)
+  template <typename INT> INT gds_imedian3(const INT v[], INT iv[], size_t left, size_t right)
   {
     size_t center = (left + right) / 2;
 
@@ -58,7 +58,7 @@ namespace {
     return iv[right - 1];
   }
 
-  template <typename INT> void gds_iqsort(INT v[], INT iv[], size_t left, size_t right)
+  template <typename INT> void gds_iqsort(const INT v[], INT iv[], size_t left, size_t right)
   {
     if (left + GDS_QSORT_CUTOFF <= right) {
       size_t pivot = gds_imedian3(v, iv, left, right);
@@ -86,7 +86,7 @@ namespace {
     }
   }
 
-  template <typename INT> void gds_iisort(INT v[], INT iv[], size_t N)
+  template <typename INT> void gds_iisort(const INT v[], INT iv[], size_t N)
   {
     if (N == 0) {
       return;
@@ -243,7 +243,7 @@ template <typename INT> void indexed_sort(INT v[], INT iv[], size_t N)
 #endif
 }
 
-template <typename INT> void gds_iqsort(INT v[], INT iv[], size_t N)
+template <typename INT> void gds_iqsort(const INT v[], INT iv[], size_t N)
 {
   if (N <= 1) {
     return;
@@ -276,10 +276,10 @@ template <typename INT> void gds_qsort(INT v[], size_t N)
 #endif
 }
 
-template void gds_iqsort(int v[], int iv[], size_t N);
+template void gds_iqsort(const int v[], int iv[], size_t N);
 template void gds_qsort(int v[], size_t N);
 
-template void gds_iqsort(int64_t v[], int64_t iv[], size_t N);
+template void gds_iqsort(const int64_t v[], int64_t iv[], size_t N);
 template void gds_qsort(int64_t v[], size_t N);
 
 template void indexed_sort(int v[], int iv[], size_t N);

--- a/packages/seacas/applications/nem_spread/sort_utils.h
+++ b/packages/seacas/applications/nem_spread/sort_utils.h
@@ -1,12 +1,12 @@
 /*
- * Copyright(C) 1999-2020, 2022 National Technology & Engineering Solutions
+ * Copyright(C) 1999-2020, 2022, 2023 National Technology & Engineering Solutions
  * of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
  * NTESS, the U.S. Government retains certain rights in this software.
  *
  * See packages/seacas/LICENSE for details
  */
 #pragma once
-template <typename INT> void gds_iqsort(INT v[], INT iv[], size_t N);
+template <typename INT> void gds_iqsort(const INT v[], INT iv[], size_t N);
 
 template <typename INT> void gds_qsort(INT v[], size_t N);
 

--- a/packages/seacas/applications/slice/Slice.C
+++ b/packages/seacas/applications/slice/Slice.C
@@ -570,7 +570,7 @@ namespace {
         idx_t              common     = get_common_node_count(region);
         idx_t              proc_count = interFace.processor_count();
         idx_t              obj_val    = 0;
-        std::vector<idx_t> options(METIS_NOPTIONS);
+        std::vector<idx_t> options((METIS_NOPTIONS));
         METIS_SetDefaultOptions(&options[0]);
         if (interFace.decomposition_method() == "kway") {
           options[METIS_OPTION_PTYPE] = METIS_PTYPE_KWAY;

--- a/packages/seacas/libraries/exodus/include/exodusII_int.h
+++ b/packages/seacas/libraries/exodus/include/exodusII_int.h
@@ -1,6 +1,6 @@
 /*
 
- * Copyright(C) 1999-2020, 2022 National Technology & Engineering Solutions
+ * Copyright(C) 1999-2020, 2022, 2023 National Technology & Engineering Solutions
  * of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
  * NTESS, the U.S. Government retains certain rights in this software.
  *
@@ -800,10 +800,11 @@ EXODUS_EXPORT void ex__compress_variable(int exoid, int varid, int type);
 EXODUS_EXPORT int  ex__id_lkup(int exoid, ex_entity_type id_type, ex_entity_id num);
 EXODUS_EXPORT int  ex__check_valid_file_id(
      int exoid, const char *func); /** Return fatal error if exoid does not refer to valid file */
-EXODUS_EXPORT int ex__check_multiple_open(const char *path, int mode, const char *func);
-EXODUS_EXPORT int ex__check_file_type(const char *path, int *type);
-EXODUS_EXPORT int ex__get_dimension(int exoid, const char *DIMENSION, const char *label,
-                                    size_t *count, int *dimid, const char *routine);
+EXODUS_EXPORT int   ex__check_multiple_open(const char *path, int mode, const char *func);
+EXODUS_EXPORT int   ex__check_file_type(const char *path, int *type);
+EXODUS_EXPORT char *ex__canonicalize_filename(const char *path);
+EXODUS_EXPORT int   ex__get_dimension(int exoid, const char *DIMENSION, const char *label,
+                                      size_t *count, int *dimid, const char *routine);
 
 EXODUS_EXPORT int ex__get_nodal_var(int exoid, int time_step, int nodal_var_index,
                                     int64_t num_nodes, void *nodal_var_vals);

--- a/packages/seacas/libraries/exodus/new_header.html
+++ b/packages/seacas/libraries/exodus/new_header.html
@@ -1,6 +1,6 @@
 <!-- HTML header for doxygen 1.8.13-->
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <meta http-equiv="Content-Type" content="text/xhtml;charset=UTF-8"/>
 <meta http-equiv="X-UA-Compatible" content="IE=9"/>

--- a/packages/seacas/libraries/exodus/src/ex_create.c
+++ b/packages/seacas/libraries/exodus/src/ex_create.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(C) 1999-2021 National Technology & Engineering Solutions
+ * Copyright(C) 1999-2021, 2023 National Technology & Engineering Solutions
  * of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
  * NTESS, the U.S. Government retains certain rights in this software.
  *
@@ -123,13 +123,15 @@ exoid = ex_create ("test.exo"       \comment{filename path}
 */
 #include "exodusII.h"
 #include "exodusII_int.h"
+#include <libgen.h>
+#include <stdlib.h>
 
 /* NOTE: Do *not* call `ex_create_int()` directly.  The public API
  *       function name is `ex_create()` which is a wrapper that calls
  *       `ex_create_int` with an additional argument to make sure
  *       library and include file are consistent
  */
-int ex_create_int(const char *path, int cmode, int *comp_ws, int *io_ws, int run_version)
+int ex_create_int(const char *rel_path, int cmode, int *comp_ws, int *io_ws, int run_version)
 {
   int  exoid  = 0;
   int  status = 0;
@@ -143,12 +145,16 @@ int ex_create_int(const char *path, int cmode, int *comp_ws, int *io_ws, int run
 
   nc_mode = ex__handle_mode(my_mode, is_parallel, run_version);
 
+  fprintf(stderr, "EX_CREATE: %s\n", rel_path);
+  char *path = ex__canonicalize_filename(rel_path);
+
   /* Verify that this file is not already open for read or write...
      In theory, should be ok for the file to be open multiple times
      for read, but bad things can happen if being read and written
      at the same time...
   */
   if (ex__check_multiple_open(path, EX_WRITE, __func__)) {
+    free(path);
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -177,13 +183,16 @@ int ex_create_int(const char *path, int cmode, int *comp_ws, int *io_ws, int run
     }
 #endif
     ex_err(__func__, errmsg, status);
+    free(path);
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
   status = ex__populate_header(exoid, path, my_mode, is_parallel, comp_ws, io_ws);
   if (status != EX_NOERR) {
+    free(path);
     EX_FUNC_LEAVE(status);
   }
 
+  free(path);
   EX_FUNC_LEAVE(exoid);
 }

--- a/packages/seacas/libraries/exodus/src/ex_utils.c
+++ b/packages/seacas/libraries/exodus/src/ex_utils.c
@@ -2322,7 +2322,7 @@ char *ex__canonicalize_filename(char const *file_path)
 {
 #if defined(WIN32) || defined(__WIN32__) || defined(_WIN32) || defined(_MSC_VER) ||                \
     defined(__MINGW32__) || defined(_WIN64) || defined(__MINGW64__)
-  return _fullpath(NULL, rel_path, _MAX_PATH);
+  return _fullpath(NULL, file_path, _MAX_PATH);
 #else
   char        *canonical_file_path = NULL;
   unsigned int file_path_len       = strlen(file_path);

--- a/packages/seacas/libraries/exodus/src/ex_utils.c
+++ b/packages/seacas/libraries/exodus/src/ex_utils.c
@@ -2376,7 +2376,9 @@ char *ex__canonicalize_filename(char const *file_path)
       free(file_path_copy);
     }
   }
-  fprintf(stderr, "Path: %s, Canonical: %s\n", file_path, canonical_file_path);
+  if (canonical_file_path != NULL) {
+    fprintf(stderr, "Path: %s, Canonical: %s\n", file_path, canonical_file_path);
+  }
   return canonical_file_path;
 #endif
 }

--- a/packages/seacas/libraries/exodus/src/ex_utils.c
+++ b/packages/seacas/libraries/exodus/src/ex_utils.c
@@ -2289,3 +2289,94 @@ char *ex_copy_string(char *dest, char const *source, size_t elements)
   *d = '\0';
   return d;
 }
+
+/*
+ * Code from:
+ * https://stackoverflow.com/questions/11034002/how-to-get-absolute-path-of-file-or-directory-that-does-not-exist
+ *
+ * Return the input path in a canonical form. This is achieved by
+ * expanding all symbolic links, resolving references to "." and "..",
+ * and removing duplicate "/" characters.
+ *
+ * If the file exists, its path is canonicalized and returned. If the file,
+ * or parts of the containing directory, do not exist, path components are
+ * removed from the end until an existing path is found. The remainder of the
+ * path is then appended to the canonical form of the existing path,
+ * and returned. Consequently, the returned path may not exist. The portion
+ * of the path which exists, however, is represented in canonical form.
+ *
+ * If successful, this function returns a C-string, which needs to be freed by
+ * the caller using free().
+ *
+ * ARGUMENTS:
+ *   file_path
+ *   File path, whose canonical form to return.
+ *
+ * RETURNS:
+ *   On success, returns the canonical path to the file, which needs to be freed
+ *   by the caller.
+ *
+ *   On failure, returns NULL.
+ */
+char *ex__canonicalize_filename(char const *file_path)
+{
+#if defined(WIN32) || defined(__WIN32__) || defined(_WIN32) || defined(_MSC_VER) ||                \
+    defined(__MINGW32__) || defined(_WIN64) || defined(__MINGW64__)
+  return _fullpath(NULL, rel_path, _MAX_PATH);
+#else
+  char        *canonical_file_path = NULL;
+  unsigned int file_path_len       = strlen(file_path);
+
+  if (file_path_len > 0) {
+    fprintf(stderr, "Input Path: %s\n", file_path);
+    canonical_file_path = realpath(file_path, NULL);
+    if (canonical_file_path == NULL && errno == ENOENT) {
+      // The file was not found. Back up to a segment which exists,
+      // and append the remainder of the path to it.
+      char *file_path_copy = NULL;
+      if (file_path[0] == '/' || (strncmp(file_path, "./", 2) == 0) ||
+          (strncmp(file_path, "../", 3) == 0)) {
+        // Absolute path, or path starts with "./" or "../"
+        file_path_copy = strdup(file_path);
+      }
+      else {
+        // Relative path
+        file_path_copy = (char *)malloc(strlen(file_path) + 3);
+        strcpy(file_path_copy, "./");
+        strcat(file_path_copy, file_path);
+      }
+
+      // Remove path components from the end, until an existing path is found
+      for (int char_idx = strlen(file_path_copy) - 1; char_idx >= 0 && canonical_file_path == NULL;
+           --char_idx) {
+        if (file_path_copy[char_idx] == '/') {
+          // Remove the slash character
+          file_path_copy[char_idx] = '\0';
+
+          canonical_file_path = realpath(file_path_copy, NULL);
+          if (canonical_file_path != NULL) {
+            // An existing path was found. Append the remainder of the path
+            // to a canonical form of the existing path.
+            char *combined_file_path = (char *)malloc(strlen(canonical_file_path) +
+                                                      strlen(file_path_copy + char_idx + 1) + 2);
+            strcpy(combined_file_path, canonical_file_path);
+            strcat(combined_file_path, "/");
+            strcat(combined_file_path, file_path_copy + char_idx + 1);
+            free(canonical_file_path);
+            canonical_file_path = combined_file_path;
+          }
+          else {
+            // The path segment does not exist. Replace the slash character
+            // and keep trying by removing the previous path component.
+            file_path_copy[char_idx] = '/';
+          }
+        }
+      }
+
+      free(file_path_copy);
+    }
+  }
+  fprintf(stderr, "Path: %s, Canonical: %s\n", file_path, canonical_file_path);
+  return canonical_file_path;
+#endif
+}

--- a/packages/seacas/libraries/exodus/test/rd_wt_mesh.c
+++ b/packages/seacas/libraries/exodus/test/rd_wt_mesh.c
@@ -773,10 +773,6 @@ int write_exo_mesh(char *file_name, int rank, int num_dim, int num_domains, int 
 
         if (exoid[npd] < 0) {
           printf("after ex_create\n");
-          if (elem_var_tab) {
-            free(elem_var_tab);
-            elem_var_tab = NULL;
-          }
           if (globals) {
             free(globals);
             globals = NULL;
@@ -900,6 +896,12 @@ int write_exo_mesh(char *file_name, int rank, int num_dim, int num_domains, int 
       }
       err = ex_put_all_var_param(exoid[npd], num_global_fields, num_nodal_fields,
                                  num_element_fields, elem_var_tab, 0, 0, 0, 0);
+
+      if (elem_var_tab) {
+        free(elem_var_tab);
+        elem_var_tab = NULL;
+      }
+
       if (err) {
         fprintf(stderr, "after ex_put_all_var_param, error = %d\n", err);
         ex_close(exoid[npd]);
@@ -1017,6 +1019,7 @@ int write_exo_mesh(char *file_name, int rank, int num_dim, int num_domains, int 
             t_tmp2 = my_timer();
             raw_write_time += t_tmp2 - t_tmp1;
             if (err) {
+              free(globals);
               fprintf(stderr, "after ex_put_global_var, error = %d\n", err);
               ex_close(exoid[npd]);
               exit(1);

--- a/packages/seacas/libraries/exodus/test/testrd-blob.c
+++ b/packages/seacas/libraries/exodus/test/testrd-blob.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(C) 1999-2022 National Technology & Engineering Solutions
+ * Copyright(C) 1999-2023 National Technology & Engineering Solutions
  * of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
  * NTESS, the U.S. Government retains certain rights in this software.
  *
@@ -224,15 +224,20 @@ int main(int argc, char **argv)
       printf("Time at step %d is %f.\n", i + 1, time_value);
 
       for (int k = 0; k < num_blob; k++) {
-        EXCHECK(ex_get_reduction_vars(exoid, i + 1, EX_BLOB, blb[k].id, num_red_vars, var_values));
-        printf("Values for Blob %" PRId64 " at step %d: %f\t%f\t%f\t%f\n", blb[k].id, i + 1,
-               var_values[0], var_values[1], var_values[2], var_values[3]);
+        if (var_values != NULL) {
+          EXCHECK(
+              ex_get_reduction_vars(exoid, i + 1, EX_BLOB, blb[k].id, num_red_vars, var_values));
+          printf("Values for Blob %" PRId64 " at step %d: %f\t%f\t%f\t%f\n", blb[k].id, i + 1,
+                 var_values[0], var_values[1], var_values[2], var_values[3]);
+        }
 
-        for (int var_idx = 0; var_idx < num_vars; var_idx++) {
-          EXCHECK(ex_get_var(exoid, i + 1, EX_BLOB, var_idx + 1, blobs[k].id, blobs[k].num_entry,
-                             vals));
-          for (int j = 0; j < blobs[k].num_entry; j++) {
-            printf("%5.3f\n", vals[j]);
+        if (vals != NULL) {
+          for (int var_idx = 0; var_idx < num_vars; var_idx++) {
+            EXCHECK(ex_get_var(exoid, i + 1, EX_BLOB, var_idx + 1, blobs[k].id, blobs[k].num_entry,
+                               vals));
+            for (int j = 0; j < blobs[k].num_entry; j++) {
+              printf("%5.3f\n", vals[j]);
+            }
           }
         }
       }

--- a/packages/seacas/libraries/exodus/test/testrd1.c
+++ b/packages/seacas/libraries/exodus/test/testrd1.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(C) 1999-2022 National Technology & Engineering Solutions
+ * Copyright(C) 1999-2023 National Technology & Engineering Solutions
  * of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
  * NTESS, the U.S. Government retains certain rights in this software.
  *
@@ -793,17 +793,19 @@ int main(int argc, char **argv)
   error = ex_get_variable_param(exoid, EX_GLOBAL, &num_glo_vars);
   printf("\nafter ex_get_variable_param, error = %3d\n", error);
 
-  for (int i = 0; i < num_glo_vars; i++) {
-    var_names[i] = (char *)my_calloc((MAX_STR_LENGTH + 1), sizeof(char));
-  }
+  if (num_glo_vars > 0) {
+    for (int i = 0; i < num_glo_vars; i++) {
+      var_names[i] = (char *)my_calloc((MAX_STR_LENGTH + 1), sizeof(char));
+    }
 
-  error = ex_get_variable_name(exoid, EX_GLOBAL, 1, var_names[0]);
-  printf("\nafter ex_get_variable_name, error = %3d\n", error);
+    error = ex_get_variable_name(exoid, EX_GLOBAL, 1, var_names[0]);
+    printf("\nafter ex_get_variable_name, error = %3d\n", error);
 
-  printf("There are %2d global variables; their names are :\n", num_glo_vars);
-  for (int i = 0; i < num_glo_vars; i++) {
-    printf(" '%s'\n", var_names[i]);
-    free(var_names[i]);
+    printf("There are %2d global variables; their names are :\n", num_glo_vars);
+    for (int i = 0; i < num_glo_vars; i++) {
+      printf(" '%s'\n", var_names[i]);
+      free(var_names[i]);
+    }
   }
 
   /* read nodal variables parameters and names */

--- a/packages/seacas/libraries/ioss/src/Ioss_Getline.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Getline.C
@@ -38,7 +38,8 @@
 #endif
 
 #include <termios.h>
-struct termios io_new_termios, io_old_termios;
+struct termios io_new_termios;
+struct termios io_old_termios;
 #endif
 
 /********************* C library headers ********************************/

--- a/packages/seacas/libraries/ioss/src/text_mesh/Iotm_TextMeshFuncs.h
+++ b/packages/seacas/libraries/ioss/src/text_mesh/Iotm_TextMeshFuncs.h
@@ -1,4 +1,4 @@
-// Copyright(C) 1999-2020, 2022 National Technology & Engineering Solutions
+// Copyright(C) 1999-2020, 2022, 2023 National Technology & Engineering Solutions
 // of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
 // NTESS, the U.S. Government retains certain rights in this software.
 
@@ -6,23 +6,18 @@
 
 // #######################  Start Clang Header Tool Managed Headers ########################
 // clang-format off
-#include <ctype.h>                                   // for toupper
-#include <stddef.h>                                  // for size_t
+#include <cctype>                                   // for toupper
+#include <cstddef>                                  // for size_t
 #include <algorithm>                                 // for remove, etc
 #include <iterator>                                  // for insert_iterator
-#include <map>
 #include <set>                                       // for set
-#include <sstream>                                   // for operator<<, etc
 #include <string>                                    // for basic_string, etc
 #include <utility>                                   // for pair
 #include <vector>                                    // for vector
-#include <unordered_map>
 #include <sstream>                       // for ostringstream
 #include <iostream>
-#include <functional>
 #include <stdexcept>
 #include <numeric>
-#include <strings.h>
 
 // clang-format on
 // #######################   End Clang Header Tool Managed Headers  ########################

--- a/packages/seacas/libraries/supes/ext_lib/getline_int.c
+++ b/packages/seacas/libraries/supes/ext_lib/getline_int.c
@@ -517,12 +517,17 @@ static void gl_del(int loc, int killsave)
   if ((loc == -1 && gl_pos > 0) || (loc == 0 && gl_pos < gl_cnt)) {
     int j = 0;
     for (int i = gl_pos + loc; i < gl_cnt; i++) {
-      if ((j == 0) && (killsave != 0)) {
-        gl_killbuf[0] = gl_buf[i];
-        gl_killbuf[1] = '\0';
-        j             = 1;
+      if (i < GL_BUF_SIZE - 1) {
+        if ((j == 0) && (killsave != 0)) {
+          gl_killbuf[0] = gl_buf[i];
+          gl_killbuf[1] = '\0';
+          j             = 1;
+        }
+        gl_buf[i] = gl_buf[i + 1];
       }
-      gl_buf[i] = gl_buf[i + 1];
+      else {
+        gl_error("\n*** Error: getline(): logic error in gl_del().\n");
+      }
     }
     gl_fixup(gl_prompt, gl_pos + loc, gl_pos + loc);
   }
@@ -534,7 +539,7 @@ static void gl_kill(int pos)
 
 /* delete from pos to the end of line */
 {
-  if (pos < gl_cnt) {
+  if (pos < gl_cnt && pos < GL_BUF_SIZE) {
     copy_string(gl_killbuf, gl_buf + pos, GL_BUF_SIZE);
     gl_buf[pos] = '\0';
     gl_fixup(gl_prompt, pos, pos);

--- a/packages/seacas/libraries/svdi/cgi/met_metxlate.c
+++ b/packages/seacas/libraries/svdi/cgi/met_metxlate.c
@@ -5156,8 +5156,10 @@ static int poly_clip(point *cmin, point *cmax, float *vx, float *vy, int vlen, f
     else { /* after 1st time through, use new vertex list */
       curlen  = *lenout;
       *lenout = 0;
-      s.x     = xout[curlen - 1];
-      s.y     = yout[curlen - 1];
+      if (curlen > 0) {
+        s.x = xout[curlen - 1];
+        s.y = yout[curlen - 1];
+      }
     }
 
     for (i = 0; i < curlen; i++) { /* loop through all vertices */

--- a/packages/seacas/libraries/svdi/cgi/met_metxlate.c
+++ b/packages/seacas/libraries/svdi/cgi/met_metxlate.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(C) 1999-2020, 2022 National Technology & Engineering Solutions
+ * Copyright(C) 1999-2020, 2022, 2023 National Technology & Engineering Solutions
  * of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
  * NTESS, the U.S. Government retains certain rights in this software.
  *
@@ -310,6 +310,7 @@
  */
 
 #include "svdi.h"
+
 /******************************************************************************/
 /*                                                                            */
 /*      type and constant declarations                                        */
@@ -334,6 +335,7 @@
 /* end cgimet.h */
 #include "data_def.h"
 
+#include <assert.h>
 #include <ctype.h>
 #include <math.h>
 #include <stdio.h>
@@ -2464,6 +2466,7 @@ static void xcca(anything **params, int num_surfaces, anything **surf_list)
           /* reorder the cell colors */
           for (k = 0; k < ny1; k++) {
             for (j = 0; j < nx1; j++) {
+              assert(count < MAX_ARRAY);
               varray[count++] = cells[index--];
             }
 
@@ -2509,6 +2512,7 @@ static void xcca(anything **params, int num_surfaces, anything **surf_list)
           /* store as much info as possible before calling vdpixl */
           for (k = 0; k < ny1; k++) {
             for (j = 0; j < nx1; j++) {
+              assert(count < MAX_ARRAY);
               rarray[count] = (float)cells[index++] / 255.0f;
               garray[count] = (float)cells[index++] / 255.0f;
               barray[count] = (float)cells[index++] / 255.0f;
@@ -2544,6 +2548,7 @@ static void xcca(anything **params, int num_surfaces, anything **surf_list)
           /* store as much info as possible before calling vdpixl */
           for (k = 0; k < ny1; k++) {
             for (j = 0; j < nx1; j++) {
+              assert(count < MAX_ARRAY);
               rarray[count] = (float)cells[index] / 255.0f;
               garray[count] = (float)cells[index + 1] / 255.0f;
               barray[count] = (float)cells[index + 2] / 255.0f;
@@ -2844,6 +2849,7 @@ static void xcpxa(anything **params, int num_surfaces, anything **surf_list)
           /* reorder the pixel colors */
           for (k = 0; k < ny1; k++) {
             for (j = 0; j < nx1; j++) {
+              assert(count < MAX_ARRAY);
               varray[count++] = pxclrs[index--];
             }
 
@@ -2888,6 +2894,7 @@ static void xcpxa(anything **params, int num_surfaces, anything **surf_list)
           /* store as much info as possible before calling vdpixl */
           for (k = 0; k < ny1; k++) {
             for (j = 0; j < nx1; j++) {
+              assert(count < MAX_ARRAY);
               rarray[count] = (float)pxclrs[index++] / 255.0f;
               garray[count] = (float)pxclrs[index++] / 255.0f;
               barray[count] = (float)pxclrs[index++] / 255.0f;
@@ -2923,6 +2930,7 @@ static void xcpxa(anything **params, int num_surfaces, anything **surf_list)
           /* store as much info as possible before calling vdpixl */
           for (k = 0; k < ny1; k++) {
             for (j = 0; j < nx1; j++) {
+              assert(count < MAX_ARRAY);
               rarray[count] = (float)pxclrs[index] / 255.0f;
               garray[count] = (float)pxclrs[index + 1] / 255.0f;
               barray[count] = (float)pxclrs[index + 2] / 255.0f;

--- a/packages/seacas/libraries/svdi/cgi/pst_pstxlate.c
+++ b/packages/seacas/libraries/svdi/cgi/pst_pstxlate.c
@@ -1,5 +1,5 @@
 /*
- * Copyright(C) 1999-2020, 2022 National Technology & Engineering Solutions
+ * Copyright(C) 1999-2020, 2022, 2023 National Technology & Engineering Solutions
  * of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
  * NTESS, the U.S. Government retains certain rights in this software.
  *
@@ -343,6 +343,7 @@
 
 /* end cgipst.h */
 #include "data_def.h"
+#include <assert.h>
 #include <ctype.h>
 #include <math.h>
 #include <stdio.h>
@@ -2471,6 +2472,7 @@ static void xcca(anything **params, int num_surfaces, anything **surf_list)
           /* reorder the cell colors */
           for (k = 0; k < ny1; k++) {
             for (j = 0; j < nx1; j++) {
+              assert(count < MAX_ARRAY);
               varray[count++] = cells[index--];
             }
 
@@ -2516,6 +2518,7 @@ static void xcca(anything **params, int num_surfaces, anything **surf_list)
           /* store as much info as possible before calling vdpixl */
           for (k = 0; k < ny1; k++) {
             for (j = 0; j < nx1; j++) {
+              assert(count < MAX_ARRAY);
               rarray[count] = (float)cells[index++] / 255.0f;
               garray[count] = (float)cells[index++] / 255.0f;
               barray[count] = (float)cells[index++] / 255.0f;
@@ -2551,6 +2554,7 @@ static void xcca(anything **params, int num_surfaces, anything **surf_list)
           /* store as much info as possible before calling vdpixl */
           for (k = 0; k < ny1; k++) {
             for (j = 0; j < nx1; j++) {
+              assert(count < MAX_ARRAY);
               rarray[count] = (float)cells[index] / 255.0f;
               garray[count] = (float)cells[index + 1] / 255.0f;
               barray[count] = (float)cells[index + 2] / 255.0f;
@@ -2858,6 +2862,7 @@ static void xcpxa(anything **params, int num_surfaces, anything **surf_list)
           /* reorder the pixel colors */
           for (k = 0; k < ny1; k++) {
             for (j = 0; j < nx1; j++) {
+              assert(count < MAX_ARRAY);
               varray[count++] = pxclrs[index--];
             }
 
@@ -2902,6 +2907,7 @@ static void xcpxa(anything **params, int num_surfaces, anything **surf_list)
           /* store as much info as possible before calling vdpixl */
           for (k = 0; k < ny1; k++) {
             for (j = 0; j < nx1; j++) {
+              assert(count < MAX_ARRAY);
               rarray[count] = (float)pxclrs[index++] / 255.0f;
               garray[count] = (float)pxclrs[index++] / 255.0f;
               barray[count] = (float)pxclrs[index++] / 255.0f;
@@ -2937,6 +2943,7 @@ static void xcpxa(anything **params, int num_surfaces, anything **surf_list)
           /* store as much info as possible before calling vdpixl */
           for (k = 0; k < ny1; k++) {
             for (j = 0; j < nx1; j++) {
+              assert(count < MAX_ARRAY);
               rarray[count] = (float)pxclrs[index] / 255.0f;
               garray[count] = (float)pxclrs[index + 1] / 255.0f;
               barray[count] = (float)pxclrs[index + 2] / 255.0f;

--- a/packages/seacas/libraries/svdi/cgi/pst_pstxlate.c
+++ b/packages/seacas/libraries/svdi/cgi/pst_pstxlate.c
@@ -5172,8 +5172,10 @@ static int poly_clip(point *cmin, point *cmax, float *vx, float *vy, int vlen, f
     else { /* after 1st time through, use new vertex list */
       curlen  = *lenout;
       *lenout = 0;
-      s.x     = xout[curlen - 1];
-      s.y     = yout[curlen - 1];
+      if (curlen > 0) {
+        s.x = xout[curlen - 1];
+        s.y = yout[curlen - 1];
+      }
     }
 
     for (i = 0; i < curlen; i++) { /* loop through all vertices */

--- a/packages/seacas/libraries/svdi/cgi/x11_x11xlate.c
+++ b/packages/seacas/libraries/svdi/cgi/x11_x11xlate.c
@@ -5166,8 +5166,10 @@ static int poly_clip(point *cmin, point *cmax, float *vx, float *vy, int vlen, f
     else { /* after 1st time through, use new vertex list */
       curlen  = *lenout;
       *lenout = 0;
-      s.x     = xout[curlen - 1];
-      s.y     = yout[curlen - 1];
+      if (curlen > 0) {
+        s.x = xout[curlen - 1];
+        s.y = yout[curlen - 1];
+      }
     }
 
     for (i = 0; i < curlen; i++) { /* loop through all vertices */

--- a/packages/seacas/libraries/svdi/cgi/x11_x11xlate.c
+++ b/packages/seacas/libraries/svdi/cgi/x11_x11xlate.c
@@ -311,6 +311,7 @@
  */
 
 #include "svdi.h"
+
 /******************************************************************************/
 /*                                                                            */
 /*      type and constant declarations                                        */
@@ -334,6 +335,7 @@
 
 /* end cgix11.h */
 #include "data_def.h"
+#include <assert.h>
 #include <ctype.h>
 #include <math.h>
 #include <stdio.h>
@@ -2467,6 +2469,7 @@ static void xcca(anything **params, int num_surfaces, anything **surf_list)
           /* reorder the cell colors */
           for (k = 0; k < ny1; k++) {
             for (j = 0; j < nx1; j++) {
+              assert(count < MAX_ARRAY);
               varray[count++] = cells[index--];
             }
 
@@ -2512,6 +2515,7 @@ static void xcca(anything **params, int num_surfaces, anything **surf_list)
           /* store as much info as possible before calling vdpixl */
           for (k = 0; k < ny1; k++) {
             for (j = 0; j < nx1; j++) {
+              assert(count < MAX_ARRAY);
               rarray[count] = (float)cells[index++] / 255.0f;
               garray[count] = (float)cells[index++] / 255.0f;
               barray[count] = (float)cells[index++] / 255.0f;
@@ -2547,6 +2551,7 @@ static void xcca(anything **params, int num_surfaces, anything **surf_list)
           /* store as much info as possible before calling vdpixl */
           for (k = 0; k < ny1; k++) {
             for (j = 0; j < nx1; j++) {
+              assert(count < MAX_ARRAY);
               rarray[count] = (float)cells[index] / 255.0f;
               garray[count] = (float)cells[index + 1] / 255.0f;
               barray[count] = (float)cells[index + 2] / 255.0f;
@@ -2854,6 +2859,7 @@ static void xcpxa(anything **params, int num_surfaces, anything **surf_list)
           /* reorder the pixel colors */
           for (k = 0; k < ny1; k++) {
             for (j = 0; j < nx1; j++) {
+              assert(count < MAX_ARRAY);
               varray[count++] = pxclrs[index--];
             }
 
@@ -2898,6 +2904,7 @@ static void xcpxa(anything **params, int num_surfaces, anything **surf_list)
           /* store as much info as possible before calling vdpixl */
           for (k = 0; k < ny1; k++) {
             for (j = 0; j < nx1; j++) {
+              assert(count < MAX_ARRAY);
               rarray[count] = (float)pxclrs[index++] / 255.0f;
               garray[count] = (float)pxclrs[index++] / 255.0f;
               barray[count] = (float)pxclrs[index++] / 255.0f;
@@ -2933,6 +2940,7 @@ static void xcpxa(anything **params, int num_surfaces, anything **surf_list)
           /* store as much info as possible before calling vdpixl */
           for (k = 0; k < ny1; k++) {
             for (j = 0; j < nx1; j++) {
+              assert(count < MAX_ARRAY);
               rarray[count] = (float)pxclrs[index] / 255.0f;
               garray[count] = (float)pxclrs[index + 1] / 255.0f;
               barray[count] = (float)pxclrs[index + 2] / 255.0f;

--- a/packages/seacas/scripts/exomerge3.py
+++ b/packages/seacas/scripts/exomerge3.py
@@ -1,7 +1,7 @@
 """
 Exomerge is a lightweight Python interface for manipulating ExodusII files.
 
-Copyright(C) 1999-2020, 2022 National Technology & Engineering Solutions
+Copyright(C) 1999-2020, 2022, 2023 National Technology & Engineering Solutions
 of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
 NTESS, the U.S. Government retains certain rights in this software.
 
@@ -7710,7 +7710,7 @@ class ExodusModel(object):
         else:
             self.info_records.append('Discarded title from the '
                                      'following file:')
-            self.info_records.append(filename)
+            self.info_records.append(filename[:80])
             self.info_records.append(exodus_file.title())
         # run a check on the model to ensure arrays are correct sizes
         self._verify()


### PR DESCRIPTION
Converting lots of `array_alloc` allocated variables to use std::vector instead.  Easier to follow logic and also less prone to memory leaks or invalid access.