### PR TITLE
EXODUS.PY: Fix element attribute query by name

### DIFF
--- a/.github/workflows/python-linting.yml
+++ b/.github/workflows/python-linting.yml
@@ -23,7 +23,7 @@ jobs:
           pip install pylint
       - name: Lint exodus.py
         run: |
-          flake8 --ignore E501 packages/seacas/scripts/exodus3.in.py
+          flake8 --ignore E501,W503 packages/seacas/scripts/exodus3.in.py
       - name: Lint exomerge.py
         if: success() || failure()
         run: |

--- a/install-tpl.sh
+++ b/install-tpl.sh
@@ -526,7 +526,7 @@ then
         git clone https://github.com/Unidata/netcdf-c netcdf-c
     fi
 
-   net_version="v4.9.0"
+   net_version="v4.9.1"
 #   net_version="v4.8.1"
 #   net_version="master"
 

--- a/install-tpl.sh
+++ b/install-tpl.sh
@@ -526,7 +526,7 @@ then
         git clone https://github.com/Unidata/netcdf-c netcdf-c
     fi
 
-   net_version="v4.9.1"
+   net_version="v4.9.0"
 #   net_version="v4.8.1"
 #   net_version="master"
 

--- a/packages/seacas/scripts/exodus3.in.py
+++ b/packages/seacas/scripts/exodus3.in.py
@@ -2216,12 +2216,23 @@ class exodus:
         """
 
         numVals = 0
-        if objType == 'EX_NODAL':
+        if objType == "EX_NODAL":
             numVals = self.num_nodes()
-        elif objType == 'EX_ELEM_BLOCK' or objType == 'EX_FACE_BLOCK' or objType == 'EX_EDGE_BLOCK':
-            (_elemType, numElem, _nodesPerElem, _numAttr) = self.__ex_get_block(objType, entityId)
+        elif (
+            objType == "EX_ELEM_BLOCK"
+            or objType == "EX_FACE_BLOCK"
+            or objType == "EX_EDGE_BLOCK"
+        ):
+            (_elemType, numElem, _nodesPerElem, _numAttr) = self.__ex_get_block(
+                objType, entityId
+            )
             return numElem.value
-        elif objType == 'EX_NODE_SET' or objType == 'EX_EDGE_SET' or objType == 'EX_FACE_SET' or objType == 'EX_SIDE_SET':
+        elif (
+            objType == "EX_NODE_SET"
+            or objType == "EX_EDGE_SET"
+            or objType == "EX_FACE_SET"
+            or objType == "EX_SIDE_SET"
+        ):
             (numVals, _numDistFactInSet) = self.__ex_get_set_param(objType, entityId)
 
         return numVals

--- a/packages/seacas/scripts/exodus3.in.py
+++ b/packages/seacas/scripts/exodus3.in.py
@@ -2822,26 +2822,8 @@ class exodus:
         -------
             <int>  num_blk_elems
         """
-        (_elemType, numElem, _nodesPerElem, _numAttr) = self.__ex_get_block('EX_ELEM_BLOCK', object_id)
-        return numElem.value
-
-    def num_entities_in_blk(self, object_id):
-        """
-        get the number of elements in an element block
-
-        >>> num_blk_elems = exo.num_elems_in_blk(elem_blk_id)
-
-        Parameters
-        ----------
-        elem_blk_id : int
-            element block *ID* (not *INDEX*)
-
-        Returns
-        -------
-            <int>  num_blk_elems
-        """
-        (_elemType, numElem, _nodesPerElem, _numAttr) = self.__ex_get_block('EX_ELEM_BLOCK', object_id)
-        return numElem.value
+        vals = self.get_entity_count('EX_ELEM_BLOCK', object_id)
+        return vals
 
     def num_nodes_per_elem(self, object_id):
         """
@@ -5610,7 +5592,7 @@ class exodus:
     def __ex_get_elem_attr(self, elemBlkID):
         elem_blk_id = ctypes.c_longlong(elemBlkID)
         numAttrThisBlk = self.num_attr(elemBlkID)
-        numElemsThisBlk = self.num_elems_in_blk(elemBlkID)
+        numElemsThisBlk = self.get_entity_count('EX_ELEM_BLOCK', elemBlkID)
         totalAttr = numAttrThisBlk * numElemsThisBlk
         attrib = (ctypes.c_double * totalAttr)()
         EXODUS_LIB.ex_get_attr(

--- a/packages/seacas/scripts/exodus3.in.py
+++ b/packages/seacas/scripts/exodus3.in.py
@@ -1,5 +1,5 @@
 """
-exodus.py v 1.20.19 (seacas-py3) is a python wrapper of some of the exodus library
+exodus.py v 1.20.20 (seacas-py3) is a python wrapper of some of the exodus library
 (Python 3 Version)
 
 Exodus is a common database for multiple application codes (mesh
@@ -70,10 +70,10 @@ from enum import Enum
 
 EXODUS_PY_COPYRIGHT_AND_LICENSE = __doc__
 
-EXODUS_PY_VERSION = "1.20.19 (seacas-py3)"
+EXODUS_PY_VERSION = "1.20.20 (seacas-py3)"
 
 EXODUS_PY_COPYRIGHT = """
-You are using exodus.py v 1.20.19 (seacas-py3), a python wrapper of some of the exodus library.
+You are using exodus.py v 1.20.20 (seacas-py3), a python wrapper of some of the exodus library.
 
 Copyright (c) 2013-2022 National Technology &
 Engineering Solutions of Sandia, LLC (NTESS).  Under the terms of
@@ -5490,17 +5490,30 @@ class exodus:
             attr_index,
             attrib)
 
-    def __ex_get_one_attr(self, objType, elemBlkID, attrIndx):
-        elem_blk_id = ctypes.c_longlong(elemBlkID)
+    def __ex_get_one_attr(self, objType, entityId, attrIndx):
+        entity_id = ctypes.c_longlong(entityId)
         obj_type = ctypes.c_int(get_entity_type(objType))
         attr_index = ctypes.c_longlong(attrIndx)
-        inqType = ex_inquiry_map(ex_obj_to_inq(objType))
-        num_objs = ctypes.c_int(self.__ex_inquire_int(inqType)).value
-        attrib = (ctypes.c_double * num_objs)()
+
+        numVals = 0
+        if objType == 'EX_NODAL':
+            numVals = self.num_nodes()
+        elif objType == 'EX_ELEM_BLOCK':
+            numVals = self.num_elems_in_blk(entityId)
+        elif objType == 'EX_NODE_SET':
+            (numVals, _numDistFactInSet) = self.__ex_get_set_param(objType, entityId)
+        elif objType == 'EX_EDGE_SET':
+            (numVals, _numDistFactInSet) = self.__ex_get_set_param(objType, entityId)
+        elif objType == 'EX_FACE_SET':
+            (numVals, _numDistFactInSet) = self.__ex_get_set_param(objType, entityId)
+        elif objType == 'EX_SIDE_SET':
+            (numVals, _numDistFactInSet) = self.__ex_get_set_param(objType, entityId)
+
+        attrib = (ctypes.c_double * numVals)()
         EXODUS_LIB.ex_get_one_attr(
             self.fileId,
             obj_type,
-            elem_blk_id,
+            entity_id,
             attr_index,
             ctypes.byref(attrib))
         return attrib

--- a/packages/seacas/scripts/exodus3.in.py
+++ b/packages/seacas/scripts/exodus3.in.py
@@ -2214,7 +2214,7 @@ class exodus:
         entityId : int
             id of the entity (block, set) *ID* (not *INDEX*)
         """
-        
+
         numVals = 0
         if objType == 'EX_NODAL':
             numVals = self.num_nodes()


### PR DESCRIPTION
Fix the `__ex_get_one_attr` function to correctly query the number of entities (nodes, elements) in the set or block.  Still not as generic as it should be and we should probably refactor into a separate function the code returning `numVals` as it is used in at least two places in the code.  

@mvlopri