### PR TITLE
Allow modern Netcdf without HDF5

### DIFF
--- a/cmake/tribits/common_tpls/FindTPLNetcdf.cmake
+++ b/cmake/tribits/common_tpls/FindTPLNetcdf.cmake
@@ -43,7 +43,7 @@ endif()
 
 set(Netcdf_ALLOW_MODERN FALSE CACHE BOOL "Allow finding Netcdf as a modern CMake config file with exported targets (and only this way)")
 
-if (Netcdf_ALLOW_MODERN AND HDF5_FOUND_MODERN_CONFIG_FILE)
+if (Netcdf_ALLOW_MODERN)
 
   set(minimum_modern_netCDF_version 4.7.4)
   print_var(Netcdf_ALLOW_MODERN)


### PR DESCRIPTION
NetCDF can be built without HDF5,
and this change allows that to work
with the "modern" options