### PR TITLE
remove modern HDF5 version check

### DIFF
--- a/cmake/tribits/common_tpls/FindTPLHDF5.cmake
+++ b/cmake/tribits/common_tpls/FindTPLHDF5.cmake
@@ -6,10 +6,9 @@ set(HDF5_INTERNAL_IS_MODERN FALSE)
 
 if (Netcdf_ALLOW_MODERN)
 
-  set(minimum_modern_HDF5_version 1.10.2)
   print_var(Netcdf_ALLOW_MODERN)
-  message("-- Using find_package(HDF5 ${minimum_modern_HDF5_version} CONFIG) ...")
-  find_package(HDF5  ${minimum_modern_HDF5_version}  CONFIG)
+  message("-- Using find_package(HDF5 CONFIG) ...")
+  find_package(HDF5 CONFIG)
   if (HDF5_FOUND)
     message("-- Found HDF5_CONFIG=${HDF5_CONFIG}")
     message("-- Generating Netcdf::all_libs and NetcdfConfig.cmake")


### PR DESCRIPTION
HDF5 exports a version compatibility
file that requires that the major
*and minor* version numbers agree
to be compatible.
Thus, if we give version 1.10 to
find_package, it will not accept
HDF5 1.13 for example.
Since the "modern" mode is opt-in,
it may be easiest just to remove
this minimum version since it was
just a guess anyways.

@bartlettroscoe