### PR TITLE
Fixed build errors related to sys/statfs.h include

### DIFF
--- a/packages/seacas/libraries/ioss/src/Ioss_FileInfo.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_FileInfo.C
@@ -27,10 +27,13 @@
 #endif
 #else
 #include <unistd.h>
-#if defined(__APPLE__) && defined(__MACH__)
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__)
 #include <sys/mount.h>
 #include <sys/param.h>
-#else
+#elif defined(__OpenBSD__)
+#include <sys/types.h>
+#include <sys/mount.h>
+#elif defined(__linux__)
 #include <sys/statfs.h>
 #endif
 #endif


### PR DESCRIPTION
The sys/statfs.h header is a linux thing, but it was being included for all non-Window/Mac. This broke building on FreeBSD, and probably other OSes too.

After consulting various man pages from various OSes, we now include the right headers per-OS for the statfs() function.