### PR TITLE
Fixed reported regression building with Emscripten

### DIFF
--- a/packages/seacas/libraries/ioss/src/Ioss_FileInfo.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_FileInfo.C
@@ -33,7 +33,7 @@
 #elif defined(__OpenBSD__)
 #include <sys/types.h>
 #include <sys/mount.h>
-#elif defined(__linux__)
+#else
 #include <sys/statfs.h>
 #endif
 #endif


### PR DESCRIPTION
#include <sys/statfs.h> not only for linux, but as a general fallback.

Thanks to Adrien Stucky for finding the problem.