### PR TITLE
Update find of CGNS using modern cmake files.

### DIFF
--- a/cmake/tribits/common_tpls/FindTPLCGNS.cmake
+++ b/cmake/tribits/common_tpls/FindTPLCGNS.cmake
@@ -49,10 +49,14 @@ if ((CGNS_ALLOW_MODERN AND HDF5_FOUND_MODERN_CONFIG_FILE) OR CGNS_FORCE_MODERN)
   if (CGNS_FOUND)
     message("-- Found CGNS_CONFIG=${CGNS_CONFIG}")
     message("-- Generating CGNS::all_libs and CGNSConfig.cmake")
+    set(CGNS_TARGET CGNS::cgns_shared)
+    if(NOT TARGET CGNS::cgns_shared)
+      set(CGNS_TARGET CGNS::cgns_static)
+    endif()
     tribits_extpkg_create_imported_all_libs_target_and_config_file(
       CGNS
       INNER_FIND_PACKAGE_NAME  CGNS
-      IMPORTED_TARGETS_FOR_ALL_LIBS   cgns)
+      IMPORTED_TARGETS_FOR_ALL_LIBS  ${CGNS_TARGET})
     set(TPL_CGNS_NOT_FOUND FALSE)
   endif()
 


### PR DESCRIPTION
CGNS now contains a cgns-config.cmake file.
Here, we are updating FindTPLCGNS.cmake to be able to find that.