### PR TITLE
Eliminate use of reserved identifiers in SEACAS libraries and code

### DIFF
--- a/packages/seacas/applications/conjoin/CJ_Internals.C
+++ b/packages/seacas/applications/conjoin/CJ_Internals.C
@@ -318,12 +318,12 @@ int Excn::Internals::put_metadata(const Mesh<INT> &mesh, const CommunicationMeta
       return EX_FATAL;
     }
 
-    struct ex__file_item *file = ex__find_file_item(exodusFilePtr);
+    struct exi_file_item *file = exi_find_file_item(exodusFilePtr);
     if (file) {
       file->time_varid = varid;
     }
 
-    ex__compress_variable(exodusFilePtr, varid, -2); /* don't compress, but do set collective io */
+    exi_compress_variable(exodusFilePtr, varid, -2); /* don't compress, but do set collective io */
   }
 
   int map_type  = get_type(exodusFilePtr, EX_MAPS_INT64_DB);
@@ -355,7 +355,7 @@ int Excn::Internals::put_metadata(const Mesh<INT> &mesh, const CommunicationMeta
       }
       return EX_FATAL;
     }
-    ex__compress_variable(exodusFilePtr, varid, 1);
+    exi_compress_variable(exodusFilePtr, varid, 1);
   }
 
   if (mesh.elementCount > 0) {
@@ -387,7 +387,7 @@ int Excn::Internals::put_metadata(const Mesh<INT> &mesh, const CommunicationMeta
       }
       return EX_FATAL;
     }
-    ex__compress_variable(exodusFilePtr, varid, 1);
+    exi_compress_variable(exodusFilePtr, varid, 1);
   }
 
   if (mesh.blockCount > 0) {
@@ -468,7 +468,7 @@ int Excn::Internals::put_metadata(const std::vector<Block> &blocks)
   // Iterate over element blocks ...
   for (size_t iblk = 0; iblk < num_elem_blk; iblk++) {
 
-    ex__inc_file_item(exodusFilePtr, ex__get_counter_list(EX_ELEM_BLOCK));
+    exi_inc_file_item(exodusFilePtr, exi_get_counter_list(EX_ELEM_BLOCK));
 
     if (blocks[iblk].elementCount == 0) {
       continue;
@@ -533,7 +533,7 @@ int Excn::Internals::put_metadata(const std::vector<Block> &blocks)
         ex_err_fn(exodusFilePtr, __func__, errmsg.c_str(), status);
         return EX_FATAL;
       }
-      ex__compress_variable(exodusFilePtr, varid, 2);
+      exi_compress_variable(exodusFilePtr, varid, 2);
 
       // Attribute name array...
       std::array adims{numattrdim, namestrdim};
@@ -563,7 +563,7 @@ int Excn::Internals::put_metadata(const std::vector<Block> &blocks)
       ex_err_fn(exodusFilePtr, __func__, errmsg.c_str(), status);
       return EX_FATAL;
     }
-    ex__compress_variable(exodusFilePtr, connid, 1);
+    exi_compress_variable(exodusFilePtr, connid, 1);
 
     // store element type as attribute of connectivity variable
     status = nc_put_att_text(exodusFilePtr, connid, ATT_NAME_ELB,
@@ -648,9 +648,9 @@ template <typename INT> int Excn::Internals::put_metadata(const std::vector<Node
 
   for (int i = 0; i < num_node_sets; i++) {
 
-    //  NOTE: ex__inc_file_item is used to find the number of node sets
+    //  NOTE: exi_inc_file_item is used to find the number of node sets
     // for a specific file and returns that value incremented.
-    int cur_num_node_sets = ex__inc_file_item(exodusFilePtr, ex__get_counter_list(EX_NODE_SET));
+    int cur_num_node_sets = exi_inc_file_item(exodusFilePtr, exi_get_counter_list(EX_NODE_SET));
 
     if (nodesets[i].nodeCount == 0) {
       continue;
@@ -693,7 +693,7 @@ template <typename INT> int Excn::Internals::put_metadata(const std::vector<Node
       }
       return EX_FATAL;
     }
-    ex__compress_variable(exodusFilePtr, varid, 1);
+    exi_compress_variable(exodusFilePtr, varid, 1);
 
     // Create variable for distribution factors if required
     if (nodesets[i].dfCount > 0) {
@@ -726,7 +726,7 @@ template <typename INT> int Excn::Internals::put_metadata(const std::vector<Node
         }
         return EX_FATAL;
       }
-      ex__compress_variable(exodusFilePtr, varid, 2);
+      exi_compress_variable(exodusFilePtr, varid, 2);
     }
   }
   return EX_NOERR;
@@ -796,9 +796,9 @@ template <typename INT> int Excn::Internals::put_metadata(const std::vector<Side
 
   for (int i = 0; i < num_side_sets; i++) {
 
-    //  NOTE: ex__inc_file_item is used to find the number of side sets
+    //  NOTE: exi_inc_file_item is used to find the number of side sets
     // for a specific file and returns that value incremented.
-    int cur_num_side_sets = ex__inc_file_item(exodusFilePtr, ex__get_counter_list(EX_SIDE_SET));
+    int cur_num_side_sets = exi_inc_file_item(exodusFilePtr, exi_get_counter_list(EX_SIDE_SET));
 
     if (sidesets[i].sideCount == 0) {
       continue;
@@ -840,7 +840,7 @@ template <typename INT> int Excn::Internals::put_metadata(const std::vector<Side
       }
       return EX_FATAL;
     }
-    ex__compress_variable(exodusFilePtr, varid, 1);
+    exi_compress_variable(exodusFilePtr, varid, 1);
 
     // create side list variable for side set
     status = nc_def_var(exodusFilePtr, VAR_SIDE_SS(cur_num_side_sets + 1), bulk_type, 1,
@@ -859,7 +859,7 @@ template <typename INT> int Excn::Internals::put_metadata(const std::vector<Side
       }
       return EX_FATAL;
     }
-    ex__compress_variable(exodusFilePtr, varid, 1);
+    exi_compress_variable(exodusFilePtr, varid, 1);
 
     // Create variable for distribution factors if required
     if (sidesets[i].dfCount > 0) {
@@ -900,7 +900,7 @@ template <typename INT> int Excn::Internals::put_metadata(const std::vector<Side
         }
         return EX_FATAL;
       }
-      ex__compress_variable(exodusFilePtr, varid, 2);
+      exi_compress_variable(exodusFilePtr, varid, 2);
     }
   }
   return EX_NOERR;
@@ -1021,7 +1021,7 @@ namespace {
           ex_err_fn(exodusFilePtr, __func__, errmsg.c_str(), status);
           return EX_FATAL;
         }
-        ex__compress_variable(exodusFilePtr, varid, 2);
+        exi_compress_variable(exodusFilePtr, varid, 2);
       }
 
       if (dimension > 1) {
@@ -1034,7 +1034,7 @@ namespace {
           ex_err_fn(exodusFilePtr, __func__, errmsg.c_str(), status);
           return EX_FATAL;
         }
-        ex__compress_variable(exodusFilePtr, varid, 2);
+        exi_compress_variable(exodusFilePtr, varid, 2);
       }
 
       if (dimension > 2) {
@@ -1047,7 +1047,7 @@ namespace {
           ex_err_fn(exodusFilePtr, __func__, errmsg.c_str(), status);
           return EX_FATAL;
         }
-        ex__compress_variable(exodusFilePtr, varid, 2);
+        exi_compress_variable(exodusFilePtr, varid, 2);
       }
     }
 

--- a/packages/seacas/applications/ejoin/EJ_index_sort.C
+++ b/packages/seacas/applications/ejoin/EJ_index_sort.C
@@ -110,7 +110,7 @@ namespace {
     }
   }
 
-  template <typename T, typename INT> void ex__iqsort(T *v, INT iv[], size_t N)
+  template <typename T, typename INT> void exi_iqsort(T *v, INT iv[], size_t N)
   {
     if (N <= 1) {
       return;
@@ -138,14 +138,14 @@ void index_coord_sort(const std::vector<double> &xyz, std::vector<INT> &index, i
   for (size_t i = axis; i < xyz.size(); i += 3) {
     comp[j++] = xyz[i];
   }
-  ex__iqsort(comp.data(), index.data(), index.size());
+  exi_iqsort(comp.data(), index.data(), index.size());
 }
 
 template <typename INT> void index_sort(const std::vector<INT> &ids, std::vector<INT> &index)
 {
   index.resize(ids.size());
   std::iota(index.begin(), index.end(), (INT)0);
-  ex__iqsort(ids.data(), index.data(), index.size());
+  exi_iqsort(ids.data(), index.data(), index.size());
 }
 
 template void index_coord_sort(const std::vector<double> &xyz, std::vector<int> &index, int axis);

--- a/packages/seacas/applications/epu/EP_Internals.C
+++ b/packages/seacas/applications/epu/EP_Internals.C
@@ -485,12 +485,12 @@ int Excn::Internals<INT>::put_metadata(const Mesh &mesh, const CommunicationMeta
       return EX_FATAL;
     }
 
-    struct ex__file_item *file = ex__find_file_item(exodusFilePtr);
+    struct exi_file_item *file = exi_find_file_item(exodusFilePtr);
     if (file) {
       file->time_varid = varid;
     }
 
-    ex__compress_variable(exodusFilePtr, varid, -2); /* don't compress, but do set collective io */
+    exi_compress_variable(exodusFilePtr, varid, -2); /* don't compress, but do set collective io */
   }
 
   if (mesh.nodeCount > 0) {
@@ -521,7 +521,7 @@ int Excn::Internals<INT>::put_metadata(const Mesh &mesh, const CommunicationMeta
         }
         return EX_FATAL;
       }
-      ex__compress_variable(exodusFilePtr, varid, 1);
+      exi_compress_variable(exodusFilePtr, varid, 1);
     }
   }
 
@@ -555,7 +555,7 @@ int Excn::Internals<INT>::put_metadata(const Mesh &mesh, const CommunicationMeta
         }
         return EX_FATAL;
       }
-      ex__compress_variable(exodusFilePtr, varid, 1);
+      exi_compress_variable(exodusFilePtr, varid, 1);
     }
   }
 
@@ -658,7 +658,7 @@ template <typename INT> int Excn::Internals<INT>::put_metadata(const std::vector
   // Iterate over element blocks ...
   for (size_t iblk = 0; iblk < num_elem_blk; iblk++) {
 
-    ex__inc_file_item(exodusFilePtr, ex__get_counter_list(EX_ELEM_BLOCK));
+    exi_inc_file_item(exodusFilePtr, exi_get_counter_list(EX_ELEM_BLOCK));
 
     if (blocks[iblk].elementCount == 0) {
       continue;
@@ -723,7 +723,7 @@ template <typename INT> int Excn::Internals<INT>::put_metadata(const std::vector
         ex_err_fn(exodusFilePtr, __func__, errmsg.c_str(), status);
         return EX_FATAL;
       }
-      ex__compress_variable(exodusFilePtr, varid, 2);
+      exi_compress_variable(exodusFilePtr, varid, 2);
 
       // Attribute name array...
       dims[0] = numattrdim;
@@ -753,7 +753,7 @@ template <typename INT> int Excn::Internals<INT>::put_metadata(const std::vector
       ex_err_fn(exodusFilePtr, __func__, errmsg.c_str(), status);
       return EX_FATAL;
     }
-    ex__compress_variable(exodusFilePtr, connid, 1);
+    exi_compress_variable(exodusFilePtr, connid, 1);
 
     // store element type as attribute of connectivity variable
     status = nc_put_att_text(exodusFilePtr, connid, ATT_NAME_ELB,
@@ -843,10 +843,10 @@ int Excn::Internals<INT>::put_metadata(const std::vector<NodeSet<INT>> &nodesets
 
   for (int i = 0; i < num_node_sets; i++) {
 
-    //  NOTE: ex__inc_file_item is used to find the number of node sets
+    //  NOTE: exi_inc_file_item is used to find the number of node sets
     // for a specific file and returns that value incremented.
     int cur_num_node_sets =
-        (int)ex__inc_file_item(exodusFilePtr, ex__get_counter_list(EX_NODE_SET));
+        (int)exi_inc_file_item(exodusFilePtr, exi_get_counter_list(EX_NODE_SET));
 
     if (nodesets[i].nodeCount == 0) {
       continue;
@@ -888,7 +888,7 @@ int Excn::Internals<INT>::put_metadata(const std::vector<NodeSet<INT>> &nodesets
       }
       return EX_FATAL;
     }
-    ex__compress_variable(exodusFilePtr, varid, 1);
+    exi_compress_variable(exodusFilePtr, varid, 1);
 
     // Create variable for distribution factors if required
     if (nodesets[i].dfCount > 0) {
@@ -921,7 +921,7 @@ int Excn::Internals<INT>::put_metadata(const std::vector<NodeSet<INT>> &nodesets
         }
         return EX_FATAL;
       }
-      ex__compress_variable(exodusFilePtr, varid, 2);
+      exi_compress_variable(exodusFilePtr, varid, 2);
     }
   }
   return EX_NOERR;
@@ -994,10 +994,10 @@ int Excn::Internals<INT>::put_metadata(const std::vector<SideSet<INT>> &sidesets
 
   for (size_t i = 0; i < num_side_sets; i++) {
 
-    //  NOTE: ex__inc_file_item is used to find the number of side sets
+    //  NOTE: exi_inc_file_item is used to find the number of side sets
     // for a specific file and returns that value incremented.
     int cur_num_side_sets =
-        (int)ex__inc_file_item(exodusFilePtr, ex__get_counter_list(EX_SIDE_SET));
+        (int)exi_inc_file_item(exodusFilePtr, exi_get_counter_list(EX_SIDE_SET));
 
     if (sidesets[i].sideCount == 0) {
       continue;
@@ -1038,7 +1038,7 @@ int Excn::Internals<INT>::put_metadata(const std::vector<SideSet<INT>> &sidesets
       }
       return EX_FATAL;
     }
-    ex__compress_variable(exodusFilePtr, varid, 1);
+    exi_compress_variable(exodusFilePtr, varid, 1);
 
     // create side list variable for side set
     status = nc_def_var(exodusFilePtr, VAR_SIDE_SS(cur_num_side_sets + 1), bulk_type, 1,
@@ -1057,7 +1057,7 @@ int Excn::Internals<INT>::put_metadata(const std::vector<SideSet<INT>> &sidesets
       }
       return EX_FATAL;
     }
-    ex__compress_variable(exodusFilePtr, varid, 1);
+    exi_compress_variable(exodusFilePtr, varid, 1);
 
     // Create variable for distribution factors if required
     if (sidesets[i].dfCount > 0) {
@@ -1098,7 +1098,7 @@ int Excn::Internals<INT>::put_metadata(const std::vector<SideSet<INT>> &sidesets
         }
         return EX_FATAL;
       }
-      ex__compress_variable(exodusFilePtr, varid, 2);
+      exi_compress_variable(exodusFilePtr, varid, 2);
     }
   }
   return EX_NOERR;
@@ -1171,10 +1171,10 @@ int Excn::Internals<INT>::put_metadata(const std::vector<EdgeBlock<INT>> &edgebl
 
   for (size_t i = 0; i < num_edge_blocks; i++) {
 
-    //  NOTE: ex__inc_file_item is used to find the number of edge blocks
+    //  NOTE: exi_inc_file_item is used to find the number of edge blocks
     // for a specific file and returns that value incremented.
     int cur_num_edge_blocks =
-        (int)ex__inc_file_item(exodusFilePtr, ex__get_counter_list(EX_EDGE_BLOCK));
+        (int)exi_inc_file_item(exodusFilePtr, exi_get_counter_list(EX_EDGE_BLOCK));
 
     if (edgeblocks[i].edgeCount == 0) {
       continue;
@@ -1224,7 +1224,7 @@ int Excn::Internals<INT>::put_metadata(const std::vector<EdgeBlock<INT>> &edgebl
       ex_err_fn(exodusFilePtr, __func__, errmsg.c_str(), status);
       return EX_FATAL;
     }
-    ex__compress_variable(exodusFilePtr, connid, 1);
+    exi_compress_variable(exodusFilePtr, connid, 1);
 
     // store edge type as attribute of connectivity variable
     status = nc_put_att_text(exodusFilePtr, connid, ATT_NAME_ELB,
@@ -1308,10 +1308,10 @@ int Excn::Internals<INT>::put_metadata(const std::vector<FaceBlock<INT>> &facebl
 
   for (size_t i = 0; i < num_face_blocks; i++) {
 
-    //  NOTE: ex__inc_file_item is used to find the number of face blocks
+    //  NOTE: exi_inc_file_item is used to find the number of face blocks
     // for a specific file and returns that value incremented.
     int cur_num_face_blocks =
-        (int)ex__inc_file_item(exodusFilePtr, ex__get_counter_list(EX_FACE_BLOCK));
+        (int)exi_inc_file_item(exodusFilePtr, exi_get_counter_list(EX_FACE_BLOCK));
 
     if (faceblocks[i].faceCount == 0) {
       continue;
@@ -1362,7 +1362,7 @@ int Excn::Internals<INT>::put_metadata(const std::vector<FaceBlock<INT>> &facebl
       ex_err_fn(exodusFilePtr, __func__, errmsg.c_str(), status);
       return EX_FATAL;
     }
-    ex__compress_variable(exodusFilePtr, connid, 1);
+    exi_compress_variable(exodusFilePtr, connid, 1);
 
     // store face type as attribute of connectivity variable
     status = nc_put_att_text(exodusFilePtr, connid, ATT_NAME_ELB,
@@ -1503,7 +1503,7 @@ namespace {
           ex_err_fn(exodusFilePtr, __func__, errmsg.c_str(), status);
           return EX_FATAL;
         }
-        ex__compress_variable(exodusFilePtr, varid, 2);
+        exi_compress_variable(exodusFilePtr, varid, 2);
       }
 
       if (dimension > 1) {
@@ -1516,7 +1516,7 @@ namespace {
           ex_err_fn(exodusFilePtr, __func__, errmsg.c_str(), status);
           return EX_FATAL;
         }
-        ex__compress_variable(exodusFilePtr, varid, 2);
+        exi_compress_variable(exodusFilePtr, varid, 2);
       }
 
       if (dimension > 2) {
@@ -1529,7 +1529,7 @@ namespace {
           ex_err_fn(exodusFilePtr, __func__, errmsg.c_str(), status);
           return EX_FATAL;
         }
-        ex__compress_variable(exodusFilePtr, varid, 2);
+        exi_compress_variable(exodusFilePtr, varid, 2);
       }
     }
 

--- a/packages/seacas/applications/exodiff/check.C
+++ b/packages/seacas/applications/exodiff/check.C
@@ -4,6 +4,7 @@
 //
 // See packages/seacas/LICENSE for details
 
+#include <algorithm>
 #include <cstdio>
 #include <cstdlib>
 #include <vector>

--- a/packages/seacas/libraries/exoIIv2for32/src/exo_jack_32.c
+++ b/packages/seacas/libraries/exoIIv2for32/src/exo_jack_32.c
@@ -2424,9 +2424,9 @@ void F2C(expfrm, EXPFRM)(int *idexo, int *nframe, void_int *cfids, real *coord, 
 
 /*!
  *  Routine to return floating point word size
- * \sa ex__get_cpu_ws()
+ * \sa exi_get_cpu_ws()
  */
-int F2C(excpws, EXCPWS)(void) { return (ex__get_cpu_ws()); }
+int F2C(excpws, EXCPWS)(void) { return (exi_get_cpu_ws()); }
 
 /*!
  *  Routine to return large model setting

--- a/packages/seacas/libraries/exodus/include/exodusII_int.h
+++ b/packages/seacas/libraries/exodus/include/exodusII_int.h
@@ -88,7 +88,7 @@ extern "C" {
 #define EX_FILE_ID_MASK (0xffff0000) /**< Must match FILE_ID_MASK in NetCDF nc4internal.h */
 #define EX_GRP_ID_MASK  (0x0000ffff) /**< Must match GRP_ID_MASK in NetCDF nc4internal.h */
 
-void ex__reset_error_status(void);
+void exi_reset_error_status(void);
 
 #if defined(EXODUS_THREADSAFE)
 #if !defined(exerrval)
@@ -114,18 +114,18 @@ typedef struct EX_mutex_struct
 } EX_mutex_t;
 
 extern EX_mutex_t   EX_g;
-extern int          ex__mutex_lock(EX_mutex_t *mutex);
-extern int          ex__mutex_unlock(EX_mutex_t *mutex, const char *func, int line);
-extern void         ex__pthread_first_thread_init(void);
+extern int          exi_mutex_lock(EX_mutex_t *mutex);
+extern int          exi_mutex_unlock(EX_mutex_t *mutex, const char *func, int line);
+extern void         exi_pthread_first_thread_init(void);
 extern EX_errval_t *exerrval_get();
 
 #define EX_FUNC_ENTER()                                                                            \
   do {                                                                                             \
     /* Initialize the thread-safe code */                                                          \
-    pthread_once(&EX_first_init_g, ex__pthread_first_thread_init);                                 \
+    pthread_once(&EX_first_init_g, exi_pthread_first_thread_init);                                 \
                                                                                                    \
     /* Grab the mutex for the library */                                                           \
-    ex__mutex_lock(&EX_g);                                                                         \
+    exi_mutex_lock(&EX_g);                                                                         \
     ex_errval               = exerrval_get();                                                      \
     exerrval                = 0;                                                                   \
     ex_errval->last_err_num = 0;                                                                   \
@@ -134,28 +134,28 @@ extern EX_errval_t *exerrval_get();
 #define EX_FUNC_ENTER_INT()                                                                        \
   do {                                                                                             \
     /* Initialize the thread-safe code */                                                          \
-    pthread_once(&EX_first_init_g, ex__pthread_first_thread_init);                                 \
+    pthread_once(&EX_first_init_g, exi_pthread_first_thread_init);                                 \
                                                                                                    \
     /* Grab the mutex for the library */                                                           \
-    ex__mutex_lock(&EX_g);                                                                         \
+    exi_mutex_lock(&EX_g);                                                                         \
     ex_errval = exerrval_get();                                                                    \
   } while (0)
 
 #define EX_FUNC_LEAVE(error)                                                                       \
   do {                                                                                             \
-    ex__mutex_unlock(&EX_g, __func__, __LINE__);                                                   \
+    exi_mutex_unlock(&EX_g, __func__, __LINE__);                                                   \
     return error;                                                                                  \
   } while (0)
 
 #define EX_FUNC_VOID()                                                                             \
   do {                                                                                             \
-    ex__mutex_unlock(&EX_g, __func__, __LINE__);                                                   \
+    exi_mutex_unlock(&EX_g, __func__, __LINE__);                                                   \
     return;                                                                                        \
   } while (0)
 
 #define EX_FUNC_UNLOCK()                                                                           \
   do {                                                                                             \
-    ex__mutex_unlock(&EX_g, __func__, __LINE__);                                                   \
+    exi_mutex_unlock(&EX_g, __func__, __LINE__);                                                   \
   } while (0)
 
 #else
@@ -165,7 +165,7 @@ extern EX_errval_t *exerrval_get();
 EXODUS_EXPORT int indent;
 #define EX_FUNC_ENTER()                                                                            \
   do {                                                                                             \
-    ex__reset_error_status();                                                                      \
+    exi_reset_error_status();                                                                      \
     fprintf(stderr, "%d Enter: %s\n", indent, __func__);                                           \
     indent++;                                                                                      \
   } while (0)
@@ -194,7 +194,7 @@ EXODUS_EXPORT int indent;
 #else
 #define EX_FUNC_ENTER()                                                                            \
   do {                                                                                             \
-    ex__reset_error_status();                                                                      \
+    exi_reset_error_status();                                                                      \
   } while (0)
 #define EX_FUNC_ENTER_INT()
 #define EX_FUNC_LEAVE(error) return error
@@ -276,10 +276,10 @@ EXODUS_EXPORT int indent;
 #define VAR_ID_EL_BLK                "eb_prop1"     /**< element block ids props   */
 #define VAR_ID_ED_BLK                "ed_prop1"     /**< edge    block ids props   */
 #define VAR_ID_FA_BLK                "fa_prop1"     /**< face    block ids props   */
-#define DIM_NUM_ENTITY_ASSEMBLY(num) ex__catstr("num_entity_assembly", num)
-#define VAR_ENTITY_ASSEMBLY(num)     ex__catstr("assembly_entity", num)
-#define DIM_NUM_VALUES_BLOB(num)     ex__catstr("num_values_blob", num)
-#define VAR_ENTITY_BLOB(num)         ex__catstr("blob_entity", num)
+#define DIM_NUM_ENTITY_ASSEMBLY(num) exi_catstr("num_entity_assembly", num)
+#define VAR_ENTITY_ASSEMBLY(num)     exi_catstr("assembly_entity", num)
+#define DIM_NUM_VALUES_BLOB(num)     exi_catstr("num_values_blob", num)
+#define VAR_ENTITY_BLOB(num)         exi_catstr("blob_entity", num)
 #define EX_ATTRIBUTE_TYPE            "_type"
 #define EX_ATTRIBUTE_TYPENAME        "_typename"
 #define EX_ATTRIBUTE_NAME            "_name"
@@ -288,84 +288,84 @@ EXODUS_EXPORT int indent;
 /*! element type names for each element block      */
 #define ATT_NAME_ELB "elem_type"
 /*! number of elements in element  block num               */
-#define DIM_NUM_EL_IN_BLK(num) ex__catstr("num_el_in_blk", num)
+#define DIM_NUM_EL_IN_BLK(num) exi_catstr("num_el_in_blk", num)
 /*! number of nodes per element in element block num       */
-#define DIM_NUM_NOD_PER_EL(num) ex__catstr("num_nod_per_el", num)
+#define DIM_NUM_NOD_PER_EL(num) exi_catstr("num_nod_per_el", num)
 /*! number of attributes in element block num               */
-#define DIM_NUM_ATT_IN_BLK(num) ex__catstr("num_att_in_blk", num)
+#define DIM_NUM_ATT_IN_BLK(num) exi_catstr("num_att_in_blk", num)
 /*! number of edges in edge block num               */
-#define DIM_NUM_ED_IN_EBLK(num) ex__catstr("num_ed_in_blk", num)
+#define DIM_NUM_ED_IN_EBLK(num) exi_catstr("num_ed_in_blk", num)
 /*! number of nodes per edge in edge block num          */
-#define DIM_NUM_NOD_PER_ED(num) ex__catstr("num_nod_per_ed", num)
+#define DIM_NUM_NOD_PER_ED(num) exi_catstr("num_nod_per_ed", num)
 /*! number of edges per element in element block num       */
-#define DIM_NUM_EDG_PER_EL(num) ex__catstr("num_edg_per_el", num)
+#define DIM_NUM_EDG_PER_EL(num) exi_catstr("num_edg_per_el", num)
 /*! number of attributes in edge block num               */
-#define DIM_NUM_ATT_IN_EBLK(num) ex__catstr("num_att_in_eblk", num)
+#define DIM_NUM_ATT_IN_EBLK(num) exi_catstr("num_att_in_eblk", num)
 /*! number of faces in face block num               */
-#define DIM_NUM_FA_IN_FBLK(num) ex__catstr("num_fa_in_blk", num)
+#define DIM_NUM_FA_IN_FBLK(num) exi_catstr("num_fa_in_blk", num)
 /*! number of nodes per face in face block num          */
-#define DIM_NUM_NOD_PER_FA(num) ex__catstr("num_nod_per_fa", num)
+#define DIM_NUM_NOD_PER_FA(num) exi_catstr("num_nod_per_fa", num)
 /*! number of faces per element in element block num       */
-#define DIM_NUM_FAC_PER_EL(num) ex__catstr("num_fac_per_el", num)
+#define DIM_NUM_FAC_PER_EL(num) exi_catstr("num_fac_per_el", num)
 /*! number of attributes in face block num               */
-#define DIM_NUM_ATT_IN_FBLK(num) ex__catstr("num_att_in_fblk", num)
+#define DIM_NUM_ATT_IN_FBLK(num) exi_catstr("num_att_in_fblk", num)
 /*! element connectivity for element block num       */
-#define VAR_CONN(num) ex__catstr("connect", num)
+#define VAR_CONN(num) exi_catstr("connect", num)
 /*! array containing number of entity per */
 /*  entity for n-sided face/element blocks */
-#define VAR_EBEPEC(num) ex__catstr("ebepecnt", num)
+#define VAR_EBEPEC(num) exi_catstr("ebepecnt", num)
 /*! list of attributes for element block num       */
-#define VAR_ATTRIB(num) ex__catstr("attrib", num)
+#define VAR_ATTRIB(num) exi_catstr("attrib", num)
 /*! list of attribute names for element block num     */
-#define VAR_NAME_ATTRIB(num) ex__catstr("attrib_name", num)
+#define VAR_NAME_ATTRIB(num) exi_catstr("attrib_name", num)
 /*! list of the numth property for all element blocks  */
-#define VAR_EB_PROP(num) ex__catstr("eb_prop", num)
+#define VAR_EB_PROP(num) exi_catstr("eb_prop", num)
 /*! edge connectivity for element block num       */
-#define VAR_ECONN(num) ex__catstr("edgconn", num)
+#define VAR_ECONN(num) exi_catstr("edgconn", num)
 /*! edge connectivity for edge block num          */
-#define VAR_EBCONN(num) ex__catstr("ebconn", num)
+#define VAR_EBCONN(num) exi_catstr("ebconn", num)
 /*! list of attributes for edge block num          */
-#define VAR_EATTRIB(num) ex__catstr("eattrb", num)
+#define VAR_EATTRIB(num) exi_catstr("eattrb", num)
 /*! list of attribute names for edge block num        */
-#define VAR_NAME_EATTRIB(num) ex__catstr("eattrib_name", num)
+#define VAR_NAME_EATTRIB(num) exi_catstr("eattrib_name", num)
 #define VAR_NATTRIB           "nattrb"
 #define VAR_NAME_NATTRIB      "nattrib_name"
 #define DIM_NUM_ATT_IN_NBLK   "num_att_in_nblk"
 
-#define VAR_NSATTRIB(num)      ex__catstr("nsattrb", num)
-#define VAR_NAME_NSATTRIB(num) ex__catstr("nsattrib_name", num)
-#define DIM_NUM_ATT_IN_NS(num) ex__catstr("num_att_in_ns", num)
+#define VAR_NSATTRIB(num)      exi_catstr("nsattrb", num)
+#define VAR_NAME_NSATTRIB(num) exi_catstr("nsattrib_name", num)
+#define DIM_NUM_ATT_IN_NS(num) exi_catstr("num_att_in_ns", num)
 
-#define VAR_SSATTRIB(num)      ex__catstr("ssattrb", num)
-#define VAR_NAME_SSATTRIB(num) ex__catstr("ssattrib_name", num)
-#define DIM_NUM_ATT_IN_SS(num) ex__catstr("num_att_in_ss", num)
+#define VAR_SSATTRIB(num)      exi_catstr("ssattrb", num)
+#define VAR_NAME_SSATTRIB(num) exi_catstr("ssattrib_name", num)
+#define DIM_NUM_ATT_IN_SS(num) exi_catstr("num_att_in_ss", num)
 
-#define VAR_ESATTRIB(num)      ex__catstr("esattrb", num)
-#define VAR_NAME_ESATTRIB(num) ex__catstr("esattrib_name", num)
-#define DIM_NUM_ATT_IN_ES(num) ex__catstr("num_att_in_es", num)
+#define VAR_ESATTRIB(num)      exi_catstr("esattrb", num)
+#define VAR_NAME_ESATTRIB(num) exi_catstr("esattrib_name", num)
+#define DIM_NUM_ATT_IN_ES(num) exi_catstr("num_att_in_es", num)
 
-#define VAR_FSATTRIB(num)      ex__catstr("fsattrb", num)
-#define VAR_NAME_FSATTRIB(num) ex__catstr("fsattrib_name", num)
-#define DIM_NUM_ATT_IN_FS(num) ex__catstr("num_att_in_fs", num)
+#define VAR_FSATTRIB(num)      exi_catstr("fsattrb", num)
+#define VAR_NAME_FSATTRIB(num) exi_catstr("fsattrib_name", num)
+#define DIM_NUM_ATT_IN_FS(num) exi_catstr("num_att_in_fs", num)
 
-#define VAR_ELSATTRIB(num)      ex__catstr("elsattrb", num)
-#define VAR_NAME_ELSATTRIB(num) ex__catstr("elsattrib_name", num)
-#define DIM_NUM_ATT_IN_ELS(num) ex__catstr("num_att_in_els", num)
+#define VAR_ELSATTRIB(num)      exi_catstr("elsattrb", num)
+#define VAR_NAME_ELSATTRIB(num) exi_catstr("elsattrib_name", num)
+#define DIM_NUM_ATT_IN_ELS(num) exi_catstr("num_att_in_els", num)
 
 /*! list of the numth property for all edge blocks     */
-#define VAR_ED_PROP(num) ex__catstr("ed_prop", num)
+#define VAR_ED_PROP(num) exi_catstr("ed_prop", num)
 /*! face connectivity for element block num       */
-#define VAR_FCONN(num) ex__catstr("facconn", num)
+#define VAR_FCONN(num) exi_catstr("facconn", num)
 /*! face connectivity for face block num          */
-#define VAR_FBCONN(num) ex__catstr("fbconn", num)
+#define VAR_FBCONN(num) exi_catstr("fbconn", num)
 /*! array containing number of entity per entity for n-sided face/element blocks */
-#define VAR_FBEPEC(num) ex__catstr("fbepecnt", num)
+#define VAR_FBEPEC(num) exi_catstr("fbepecnt", num)
 /*! list of attributes for face block num          */
-#define VAR_FATTRIB(num) ex__catstr("fattrb", num)
+#define VAR_FATTRIB(num) exi_catstr("fattrb", num)
 /*! list of attribute names for face block num        */
-#define VAR_NAME_FATTRIB(num) ex__catstr("fattrib_name", num)
+#define VAR_NAME_FATTRIB(num) exi_catstr("fattrib_name", num)
 /*! list of the numth property for all face blocks     */
-#define VAR_FA_PROP(num) ex__catstr("fa_prop", num)
+#define VAR_FA_PROP(num) exi_catstr("fa_prop", num)
 /*! name attached to element block, node set, side set, element map,
     or map properties */
 #define ATT_PROP_NAME "name"
@@ -374,73 +374,73 @@ EXODUS_EXPORT int indent;
 #define VAR_SS_STAT   "ss_status"     /**< side set status           */
 #define VAR_SS_IDS    "ss_prop1"      /**< side set id properties    */
 /*! number of sides in side set num*/
-#define DIM_NUM_SIDE_SS(num) ex__catstr("num_side_ss", num)
+#define DIM_NUM_SIDE_SS(num) exi_catstr("num_side_ss", num)
 /*! number of distribution factors in side set num           */
-#define DIM_NUM_DF_SS(num) ex__catstr("num_df_ss", num)
+#define DIM_NUM_DF_SS(num) exi_catstr("num_df_ss", num)
 /*! the distribution factors for each node in side set num */
-#define VAR_FACT_SS(num) ex__catstr("dist_fact_ss", num)
+#define VAR_FACT_SS(num) exi_catstr("dist_fact_ss", num)
 /*! list of elements in side set num                 */
-#define VAR_ELEM_SS(num) ex__catstr("elem_ss", num)
+#define VAR_ELEM_SS(num) exi_catstr("elem_ss", num)
 /*! list of sides in side set */
-#define VAR_SIDE_SS(num) ex__catstr("side_ss", num)
+#define VAR_SIDE_SS(num) exi_catstr("side_ss", num)
 /*! list of the numth property for all side sets       */
-#define VAR_SS_PROP(num) ex__catstr("ss_prop", num)
+#define VAR_SS_PROP(num) exi_catstr("ss_prop", num)
 #define DIM_NUM_ES       "num_edge_sets" /**< number of edge sets            */
 #define VAR_ES_STAT      "es_status"     /**< edge set status           */
 #define VAR_ES_IDS       "es_prop1"      /**< edge set id properties    */
 /*! number of edges in edge set num*/
-#define DIM_NUM_EDGE_ES(num) ex__catstr("num_edge_es", num)
+#define DIM_NUM_EDGE_ES(num) exi_catstr("num_edge_es", num)
 /*! number of distribution factors in edge set num           */
-#define DIM_NUM_DF_ES(num) ex__catstr("num_df_es", num)
+#define DIM_NUM_DF_ES(num) exi_catstr("num_df_es", num)
 /*! the distribution factors for each node in edge set num */
-#define VAR_FACT_ES(num) ex__catstr("dist_fact_es", num)
+#define VAR_FACT_ES(num) exi_catstr("dist_fact_es", num)
 /*! list of edges in edge set num                 */
-#define VAR_EDGE_ES(num) ex__catstr("edge_es", num)
+#define VAR_EDGE_ES(num) exi_catstr("edge_es", num)
 /*! list of orientations in the edge set.            */
-#define VAR_ORNT_ES(num) ex__catstr("ornt_es", num)
+#define VAR_ORNT_ES(num) exi_catstr("ornt_es", num)
 /*! list of the numth property for all edge sets       */
-#define VAR_ES_PROP(num) ex__catstr("es_prop", num)
+#define VAR_ES_PROP(num) exi_catstr("es_prop", num)
 #define DIM_NUM_FS       "num_face_sets" /**< number of face sets            */
 #define VAR_FS_STAT      "fs_status"     /**< face set status           */
 #define VAR_FS_IDS       "fs_prop1"      /**< face set id properties    */
 /*! number of faces in side set num*/
-#define DIM_NUM_FACE_FS(num) ex__catstr("num_face_fs", num)
+#define DIM_NUM_FACE_FS(num) exi_catstr("num_face_fs", num)
 /*! number of distribution factors in face set num           */
-#define DIM_NUM_DF_FS(num) ex__catstr("num_df_fs", num)
+#define DIM_NUM_DF_FS(num) exi_catstr("num_df_fs", num)
 /*! the distribution factors for each node in face set num                 */
-#define VAR_FACT_FS(num) ex__catstr("dist_fact_fs", num)
+#define VAR_FACT_FS(num) exi_catstr("dist_fact_fs", num)
 /*! list of elements in face set num                 */
-#define VAR_FACE_FS(num) ex__catstr("face_fs", num)
+#define VAR_FACE_FS(num) exi_catstr("face_fs", num)
 /*! list of sides in side set */
-#define VAR_ORNT_FS(num) ex__catstr("ornt_fs", num)
+#define VAR_ORNT_FS(num) exi_catstr("ornt_fs", num)
 /*! list of the numth property for all face sets       */
-#define VAR_FS_PROP(num) ex__catstr("fs_prop", num)
+#define VAR_FS_PROP(num) exi_catstr("fs_prop", num)
 #define DIM_NUM_ELS      "num_elem_sets" /**< number of elem sets            */
 /*! number of elements in elem set num                     */
-#define DIM_NUM_ELE_ELS(num) ex__catstr("num_ele_els", num)
+#define DIM_NUM_ELE_ELS(num) exi_catstr("num_ele_els", num)
 /*! number of distribution factors in element set num        */
-#define DIM_NUM_DF_ELS(num) ex__catstr("num_df_els", num)
+#define DIM_NUM_DF_ELS(num) exi_catstr("num_df_els", num)
 #define VAR_ELS_STAT        "els_status" /**< elem set status           */
 #define VAR_ELS_IDS         "els_prop1"  /**< elem set id properties    */
 /*! list of elements in elem set num                 */
-#define VAR_ELEM_ELS(num) ex__catstr("elem_els", num)
+#define VAR_ELEM_ELS(num) exi_catstr("elem_els", num)
 /*! list of distribution factors in elem set num */
-#define VAR_FACT_ELS(num) ex__catstr("dist_fact_els", num)
+#define VAR_FACT_ELS(num) exi_catstr("dist_fact_els", num)
 /*! list of the numth property for all elem sets       */
-#define VAR_ELS_PROP(num) ex__catstr("els_prop", num)
+#define VAR_ELS_PROP(num) exi_catstr("els_prop", num)
 #define DIM_NUM_NS        "num_node_sets" /**< number of node sets            */
 /*! number of nodes in node set num                     */
-#define DIM_NUM_NOD_NS(num) ex__catstr("num_nod_ns", num)
+#define DIM_NUM_NOD_NS(num) exi_catstr("num_nod_ns", num)
 /*! number of distribution factors in node set num           */
-#define DIM_NUM_DF_NS(num) ex__catstr("num_df_ns", num)
+#define DIM_NUM_DF_NS(num) exi_catstr("num_df_ns", num)
 #define VAR_NS_STAT        "ns_status" /**< node set status           */
 #define VAR_NS_IDS         "ns_prop1"  /**< node set id properties    */
 /*! list of nodes in node set num                     */
-#define VAR_NODE_NS(num) ex__catstr("node_ns", num)
+#define VAR_NODE_NS(num) exi_catstr("node_ns", num)
 /*! list of distribution factors in node set num */
-#define VAR_FACT_NS(num) ex__catstr("dist_fact_ns", num)
+#define VAR_FACT_NS(num) exi_catstr("dist_fact_ns", num)
 /*! list of the numth property for all node sets       */
-#define VAR_NS_PROP(num) ex__catstr("ns_prop", num)
+#define VAR_NS_PROP(num) exi_catstr("ns_prop", num)
 #define DIM_NUM_QA       "num_qa_rec"       /**< number of QA records           */
 #define VAR_QA_TITLE     "qa_records"       /**< QA records                */
 #define DIM_NUM_INFO     "num_info"         /**< number of information records  */
@@ -463,49 +463,49 @@ EXODUS_EXPORT int indent;
 #define VAR_NAME_NOD_VAR "name_nod_var"     /**< names of nodal variables  */
 #define VAR_NOD_VAR      "vals_nod_var"     /**< values of nodal variables \deprecated */
 /*! values of nodal variables */
-#define VAR_NOD_VAR_NEW(num) ex__catstr("vals_nod_var", num)
+#define VAR_NOD_VAR_NEW(num) exi_catstr("vals_nod_var", num)
 
 #define DIM_NUM_ASSEMBLY_VAR         "num_assembly_var"  /**< number of assembly variables    */
 #define VAR_NAME_ASSEMBLY_VAR        "name_assembly_var" /**< names of assembly variables*/
-#define VAR_ASSEMBLY_VAR(num1, num2) ex__catstr2("vals_assembly_var", num1, "assembly", num2)
+#define VAR_ASSEMBLY_VAR(num1, num2) exi_catstr2("vals_assembly_var", num1, "assembly", num2)
 
 #define DIM_NUM_BLOB_VAR         "num_blob_var"  /**< number of blob variables    */
 #define VAR_NAME_BLOB_VAR        "name_blob_var" /**< names of blob variables*/
-#define VAR_BLOB_VAR(num1, num2) ex__catstr2("vals_blob_var", num1, "blob", num2)
+#define VAR_BLOB_VAR(num1, num2) exi_catstr2("vals_blob_var", num1, "blob", num2)
 
 #define DIM_NUM_ELE_VAR  "num_elem_var"  /**< number of element variables    */
 #define VAR_NAME_ELE_VAR "name_elem_var" /**< names of element variables*/
 /*! values of element variable num1 in element block num2                    */
-#define VAR_ELEM_VAR(num1, num2) ex__catstr2("vals_elem_var", num1, "eb", num2)
+#define VAR_ELEM_VAR(num1, num2) exi_catstr2("vals_elem_var", num1, "eb", num2)
 #define DIM_NUM_EDG_VAR          "num_edge_var"  /**< number of edge variables       */
 #define VAR_NAME_EDG_VAR         "name_edge_var" /**< names of edge variables   */
 /*! values of edge variable num1 in edge block num2 */
-#define VAR_EDGE_VAR(num1, num2) ex__catstr2("vals_edge_var", num1, "eb", num2)
+#define VAR_EDGE_VAR(num1, num2) exi_catstr2("vals_edge_var", num1, "eb", num2)
 #define DIM_NUM_FAC_VAR          "num_face_var"  /**< number of face variables       */
 #define VAR_NAME_FAC_VAR         "name_face_var" /**< names of face variables   */
 /*! values of face variable num1 in face block num2 */
-#define VAR_FACE_VAR(num1, num2) ex__catstr2("vals_face_var", num1, "fb", num2)
+#define VAR_FACE_VAR(num1, num2) exi_catstr2("vals_face_var", num1, "fb", num2)
 
 #define DIM_NUM_NSET_VAR  "num_nset_var"  /**< number of nodeset variables    */
 #define VAR_NAME_NSET_VAR "name_nset_var" /**< names of nodeset variables*/
 /*! values of nodeset variable num1 in nodeset num2    */
-#define VAR_NS_VAR(num1, num2) ex__catstr2("vals_nset_var", num1, "ns", num2)
+#define VAR_NS_VAR(num1, num2) exi_catstr2("vals_nset_var", num1, "ns", num2)
 #define DIM_NUM_ESET_VAR       "num_eset_var" /**< number of edgeset variables    */
 /*! values of edgeset variable num1 in edgeset num2    */
 #define VAR_NAME_ESET_VAR      "name_eset_var" /**< names of edgeset variables*/
-#define VAR_ES_VAR(num1, num2) ex__catstr2("vals_eset_var", num1, "es", num2)
+#define VAR_ES_VAR(num1, num2) exi_catstr2("vals_eset_var", num1, "es", num2)
 #define DIM_NUM_FSET_VAR       "num_fset_var"  /**< number of faceset variables    */
 #define VAR_NAME_FSET_VAR      "name_fset_var" /**< names of faceset variables*/
 /*! values of faceset variable num1 in faceset num2    */
-#define VAR_FS_VAR(num1, num2) ex__catstr2("vals_fset_var", num1, "fs", num2)
+#define VAR_FS_VAR(num1, num2) exi_catstr2("vals_fset_var", num1, "fs", num2)
 #define DIM_NUM_SSET_VAR       "num_sset_var"  /**< number of sideset variables    */
 #define VAR_NAME_SSET_VAR      "name_sset_var" /**< names of sideset variables*/
 /*! values of sideset variable num1 in sideset num2    */
-#define VAR_SS_VAR(num1, num2) ex__catstr2("vals_sset_var", num1, "ss", num2)
+#define VAR_SS_VAR(num1, num2) exi_catstr2("vals_sset_var", num1, "ss", num2)
 #define DIM_NUM_ELSET_VAR      "num_elset_var"  /**< number of element set variables*/
 #define VAR_NAME_ELSET_VAR     "name_elset_var" /**< names of elemset variables*/
 /*! values of elemset variable num1 in elemset num2    */
-#define VAR_ELS_VAR(num1, num2) ex__catstr2("vals_elset_var", num1, "es", num2)
+#define VAR_ELS_VAR(num1, num2) exi_catstr2("vals_elset_var", num1, "es", num2)
 
 /**
  * \defgroup ReductionVariables Variables controlling storage of reduction variables
@@ -513,51 +513,51 @@ EXODUS_EXPORT int indent;
  */
 #define DIM_NUM_ASSEMBLY_RED_VAR  "num_assembly_red_var"  /**< number of assembly variables    */
 #define VAR_NAME_ASSEMBLY_RED_VAR "name_assembly_red_var" /**< names of assembly variables*/
-#define VAR_ASSEMBLY_RED_VAR(num) ex__catstr("vals_red_var_assembly", num)
+#define VAR_ASSEMBLY_RED_VAR(num) exi_catstr("vals_red_var_assembly", num)
 
 #define DIM_NUM_BLOB_RED_VAR  "num_blob_red_var"  /**< number of blob variables    */
 #define VAR_NAME_BLOB_RED_VAR "name_blob_red_var" /**< names of blob variables*/
-#define VAR_BLOB_RED_VAR(num) ex__catstr("vals_red_var_blob", num)
+#define VAR_BLOB_RED_VAR(num) exi_catstr("vals_red_var_blob", num)
 
 #define DIM_NUM_ELE_RED_VAR  "num_elem_red_var"  /**< number of element variables    */
 #define VAR_NAME_ELE_RED_VAR "name_elem_red_var" /**< names of element variables*/
 /*! values of element variable num in element block num                    */
-#define VAR_ELEM_RED_VAR(num) ex__catstr("vals_red_var_eb", num)
+#define VAR_ELEM_RED_VAR(num) exi_catstr("vals_red_var_eb", num)
 
 #define DIM_NUM_EDG_RED_VAR  "num_edge_red_var"  /**< number of edge variables       */
 #define VAR_NAME_EDG_RED_VAR "name_edge_red_var" /**< names of edge variables   */
 /*! values of edge variable num in edge block num */
-#define VAR_EDGE_RED_VAR(num) ex__catstr("vals_red_var_edb", num)
+#define VAR_EDGE_RED_VAR(num) exi_catstr("vals_red_var_edb", num)
 
 #define DIM_NUM_FAC_RED_VAR  "num_face_red_var"  /**< number of face variables       */
 #define VAR_NAME_FAC_RED_VAR "name_face_red_var" /**< names of face variables   */
 /*! values of face variable num in face block num */
-#define VAR_FACE_RED_VAR(num) ex__catstr("vals_red_var_fb", num)
+#define VAR_FACE_RED_VAR(num) exi_catstr("vals_red_var_fb", num)
 
 #define DIM_NUM_NSET_RED_VAR  "num_nset_red_var"  /**< number of nodeset variables    */
 #define VAR_NAME_NSET_RED_VAR "name_nset_red_var" /**< names of nodeset variables*/
 /*! values of nodeset variable num in nodeset num    */
-#define VAR_NS_RED_VAR(num) ex__catstr("vals_red_var_nset", num)
+#define VAR_NS_RED_VAR(num) exi_catstr("vals_red_var_nset", num)
 
 #define DIM_NUM_ESET_RED_VAR "num_eset_red_var" /**< number of edgeset variables    */
 /*! values of edgeset variable num in edgeset num    */
 #define VAR_NAME_ESET_RED_VAR "name_eset_red_var" /**< names of edgeset variables*/
-#define VAR_ES_RED_VAR(num)   ex__catstr("vals_red_var_eset", num)
+#define VAR_ES_RED_VAR(num)   exi_catstr("vals_red_var_eset", num)
 
 #define DIM_NUM_FSET_RED_VAR  "num_fset_red_var"  /**< number of faceset variables    */
 #define VAR_NAME_FSET_RED_VAR "name_fset_red_var" /**< names of faceset variables*/
 /*! values of faceset variable num in faceset num    */
-#define VAR_FS_RED_VAR(num) ex__catstr("vals_red_var_fset", num)
+#define VAR_FS_RED_VAR(num) exi_catstr("vals_red_var_fset", num)
 
 #define DIM_NUM_SSET_RED_VAR  "num_sset_red_var"  /**< number of sideset variables    */
 #define VAR_NAME_SSET_RED_VAR "name_sset_red_var" /**< names of sideset variables*/
 /*! values of sideset variable num in sideset num    */
-#define VAR_SS_RED_VAR(num) ex__catstr("vals_red_var_sset", num)
+#define VAR_SS_RED_VAR(num) exi_catstr("vals_red_var_sset", num)
 
 #define DIM_NUM_ELSET_RED_VAR  "num_elset_red_var"  /**< number of element set variables*/
 #define VAR_NAME_ELSET_RED_VAR "name_elset_red_var" /**< names of elemset variables*/
 /*! values of elemset variable num in elemset num    */
-#define VAR_ELS_RED_VAR(num) ex__catstr("vals_red_var_elset", num)
+#define VAR_ELS_RED_VAR(num) exi_catstr("vals_red_var_elset", num)
 /** @}*/
 
 /*! general dimension of length MAX_STR_LENGTH used for some string lengths   */
@@ -576,27 +576,27 @@ EXODUS_EXPORT int indent;
 #define VAR_NODE_NUM_MAP "node_num_map"  /**< node numbering map        */
 #define DIM_NUM_EM       "num_elem_maps" /**< number of element maps         */
 /*! the numth element map     */
-#define VAR_ELEM_MAP(num) ex__catstr("elem_map", num)
+#define VAR_ELEM_MAP(num) exi_catstr("elem_map", num)
 /*! list of the numth property for all element maps    */
-#define VAR_EM_PROP(num) ex__catstr("em_prop", num)
+#define VAR_EM_PROP(num) exi_catstr("em_prop", num)
 #define DIM_NUM_EDM      "num_edge_maps" /**< number of edge maps            */
 /*! the numth edge map        */
-#define VAR_EDGE_MAP(num) ex__catstr("edge_map", num)
+#define VAR_EDGE_MAP(num) exi_catstr("edge_map", num)
 /* list of the numth property for all edge maps       */
-#define VAR_EDM_PROP(num) ex__catstr("edm_prop", num)
+#define VAR_EDM_PROP(num) exi_catstr("edm_prop", num)
 #define DIM_NUM_FAM       "num_face_maps" /**< number of face maps            */
 /*! the numth face map        */
-#define VAR_FACE_MAP(num) ex__catstr("face_map", num)
+#define VAR_FACE_MAP(num) exi_catstr("face_map", num)
 /*! list of the numth property for all face maps       */
-#define VAR_FAM_PROP(num) ex__catstr("fam_prop", num)
+#define VAR_FAM_PROP(num) exi_catstr("fam_prop", num)
 #define DIM_NUM_NM        "num_node_maps" /**< number of node maps            */
 /*! the numth node map        */
-#define VAR_NODE_MAP(num) ex__catstr("node_map", num)
+#define VAR_NODE_MAP(num) exi_catstr("node_map", num)
 /*! list of the numth property for all node maps       */
-#define VAR_NM_PROP(num) ex__catstr("nm_prop", num)
+#define VAR_NM_PROP(num) exi_catstr("nm_prop", num)
 /*! list of the numth property for all assemblies      */
-#define VAR_ASSEMBLY_PROP(num) ex__catstr("assembly_prop", num)
-#define VAR_BLOB_PROP(num)     ex__catstr("blob_prop", num)
+#define VAR_ASSEMBLY_PROP(num) exi_catstr("assembly_prop", num)
+#define VAR_BLOB_PROP(num)     exi_catstr("blob_prop", num)
 
 #define DIM_NUM_CFRAMES  "num_cframes"
 #define DIM_NUM_CFRAME9  "num_cframes_9"
@@ -660,7 +660,7 @@ EXODUS_EXPORT int indent;
 #define DIM_NCNT_CMAP        "ncnt_cmap"
 #define DIM_ECNT_CMAP        "ecnt_cmap"
 
-enum ex__element_type {
+enum exi_element_type {
   EX_EL_UNK          = -1, /**< unknown entity */
   EX_EL_NULL_ELEMENT = 0,
   EX_EL_TRIANGLE     = 1,  /**< Triangle entity */
@@ -676,11 +676,11 @@ enum ex__element_type {
   EX_EL_TRISHELL     = 11, /**< Triangular Shell entity */
   EX_EL_PYRAMID      = 12  /**< Pyramid entity */
 };
-typedef enum ex__element_type ex__element_type;
+typedef enum exi_element_type exi_element_type;
 
 /* Internal structure declarations */
 
-struct ex__file_item
+struct exi_file_item
 {
   int          file_id;
   nc_type      netcdf_type_code;
@@ -705,10 +705,10 @@ struct ex__file_item
   unsigned int          has_edges : 1;   /**< for input only at this time */
   unsigned int          has_faces : 1;   /**< for input only at this time */
   unsigned int          has_elems : 1;   /**< for input only at this time */
-  struct ex__file_item *next;
+  struct exi_file_item *next;
 };
 
-struct ex__elem_blk_parm
+struct exi_elem_blk_parm
 {
   char             elem_type[33];
   int64_t          elem_blk_id;
@@ -718,25 +718,25 @@ struct ex__elem_blk_parm
   int              num_nodes_per_side[6];
   int              num_attr;
   int64_t          elem_ctr;
-  ex__element_type elem_type_val;
+  exi_element_type elem_type_val;
 };
 
 /* Used in exo_jack.c for fortran interface */
-enum ex__coordinate_frame_type {
+enum exi_coordinate_frame_type {
   EX_CF_RECTANGULAR = 1,
   EX_CF_CYLINDRICAL = 2,
   EX_CF_SPHERICAL   = 3
 };
-typedef enum ex__coordinate_frame_type ex__coordinate_frame_type;
+typedef enum exi_coordinate_frame_type exi_coordinate_frame_type;
 
-struct ex__list_item
+struct exi_list_item
 { /* for use with ex_get_file_item */
   int                   exo_id;
   int                   value;
-  struct ex__list_item *next;
+  struct exi_list_item *next;
 };
 
-struct ex__obj_stats
+struct exi_obj_stats
 {
   int64_t              *id_vals;
   int                  *stat_vals;
@@ -745,129 +745,129 @@ struct ex__obj_stats
   char                  valid_ids;
   char                  valid_stat;
   char                  sequential;
-  struct ex__obj_stats *next;
+  struct exi_obj_stats *next;
 };
 
 #ifndef EXODUS_EXPORT
 #define EXODUS_EXPORT extern
 #endif /* EXODUS_EXPORT */
 
-EXODUS_EXPORT void ex__iqsort(int v[], int iv[], size_t N);
-EXODUS_EXPORT void ex__iqsort64(int64_t v[], int64_t iv[], int64_t N);
+EXODUS_EXPORT void exi_iqsort(int v[], int iv[], size_t N);
+EXODUS_EXPORT void exi_iqsort64(int64_t v[], int64_t iv[], int64_t N);
 
-EXODUS_EXPORT char *ex__catstr(const char * /*string*/, int /*num*/);
-EXODUS_EXPORT char *ex__catstr2(const char * /*string1*/, int /*num1*/, const char * /*string2*/,
+EXODUS_EXPORT char *exi_catstr(const char * /*string*/, int /*num*/);
+EXODUS_EXPORT char *exi_catstr2(const char * /*string1*/, int /*num1*/, const char * /*string2*/,
                                 int /*num2*/);
-EXODUS_EXPORT char *ex__dim_num_entries_in_object(ex_entity_type /*obj_type*/, int /*idx*/);
-EXODUS_EXPORT char *ex__dim_num_objects(ex_entity_type obj_type);
-EXODUS_EXPORT char *ex__name_var_of_object(ex_entity_type /*obj_type*/, int /*i*/, int /*j*/);
-EXODUS_EXPORT char *ex__name_red_var_of_object(ex_entity_type /*obj_type*/, int /*indx*/);
-EXODUS_EXPORT char *ex__name_of_map(ex_entity_type /*map_type*/, int /*map_index*/);
+EXODUS_EXPORT char *exi_dim_num_entries_in_object(ex_entity_type /*obj_type*/, int /*idx*/);
+EXODUS_EXPORT char *exi_dim_num_objects(ex_entity_type obj_type);
+EXODUS_EXPORT char *exi_name_var_of_object(ex_entity_type /*obj_type*/, int /*i*/, int /*j*/);
+EXODUS_EXPORT char *exi_name_red_var_of_object(ex_entity_type /*obj_type*/, int /*indx*/);
+EXODUS_EXPORT char *exi_name_of_map(ex_entity_type /*map_type*/, int /*map_index*/);
 
-EXODUS_EXPORT int ex__conv_init(int exoid, int *comp_wordsize, int *io_wordsize, int file_wordsize,
+EXODUS_EXPORT int exi_conv_init(int exoid, int *comp_wordsize, int *io_wordsize, int file_wordsize,
                                 int int64_status, bool is_parallel, bool is_hdf5, bool is_pnetcdf,
                                 bool is_write);
 
-EXODUS_EXPORT void ex__conv_exit(int exoid);
+EXODUS_EXPORT void exi_conv_exit(int exoid);
 
 EXODUS_EXPORT nc_type nc_flt_code(int exoid);
-EXODUS_EXPORT int     ex__comp_ws(int exoid);
-EXODUS_EXPORT int     ex__get_cpu_ws(void);
-EXODUS_EXPORT int     ex__is_parallel(int exoid);
+EXODUS_EXPORT int     exi_comp_ws(int exoid);
+EXODUS_EXPORT int     exi_get_cpu_ws(void);
+EXODUS_EXPORT int     exi_is_parallel(int exoid);
 
-EXODUS_EXPORT struct ex__list_item **ex__get_counter_list(ex_entity_type obj_type);
-EXODUS_EXPORT int  ex__get_file_item(int /*exoid*/, struct ex__list_item  **/*list_ptr*/);
-EXODUS_EXPORT int  ex__inc_file_item(int /*exoid*/, struct ex__list_item  **/*list_ptr*/);
-EXODUS_EXPORT void ex__rm_file_item(int /*exoid*/, struct ex__list_item ** /*list_ptr*/);
+EXODUS_EXPORT struct exi_list_item **exi_get_counter_list(ex_entity_type obj_type);
+EXODUS_EXPORT int  exi_get_file_item(int /*exoid*/, struct exi_list_item  **/*list_ptr*/);
+EXODUS_EXPORT int  exi_inc_file_item(int /*exoid*/, struct exi_list_item  **/*list_ptr*/);
+EXODUS_EXPORT void exi_rm_file_item(int /*exoid*/, struct exi_list_item ** /*list_ptr*/);
 
-extern struct ex__obj_stats *exoII_eb;
-extern struct ex__obj_stats *exoII_ed;
-extern struct ex__obj_stats *exoII_fa;
-extern struct ex__obj_stats *exoII_ns;
-extern struct ex__obj_stats *exoII_es;
-extern struct ex__obj_stats *exoII_fs;
-extern struct ex__obj_stats *exoII_ss;
-extern struct ex__obj_stats *exoII_els;
-extern struct ex__obj_stats *exoII_em;
-extern struct ex__obj_stats *exoII_edm;
-extern struct ex__obj_stats *exoII_fam;
-extern struct ex__obj_stats *exoII_nm;
+extern struct exi_obj_stats *exoII_eb;
+extern struct exi_obj_stats *exoII_ed;
+extern struct exi_obj_stats *exoII_fa;
+extern struct exi_obj_stats *exoII_ns;
+extern struct exi_obj_stats *exoII_es;
+extern struct exi_obj_stats *exoII_fs;
+extern struct exi_obj_stats *exoII_ss;
+extern struct exi_obj_stats *exoII_els;
+extern struct exi_obj_stats *exoII_em;
+extern struct exi_obj_stats *exoII_edm;
+extern struct exi_obj_stats *exoII_fam;
+extern struct exi_obj_stats *exoII_nm;
 
-struct ex__file_item *ex__find_file_item(int exoid);
-struct ex__file_item *ex__add_file_item(int exoid);
-struct ex__obj_stats *ex__get_stat_ptr(int exoid, struct ex__obj_stats **obj_ptr);
+struct exi_file_item *exi_find_file_item(int exoid);
+struct exi_file_item *exi_add_file_item(int exoid);
+struct exi_obj_stats *exi_get_stat_ptr(int exoid, struct exi_obj_stats **obj_ptr);
 
-EXODUS_EXPORT void ex__rm_stat_ptr(int exoid, struct ex__obj_stats **obj_ptr);
+EXODUS_EXPORT void exi_rm_stat_ptr(int exoid, struct exi_obj_stats **obj_ptr);
 
-EXODUS_EXPORT void ex__set_compact_storage(int exoid, int varid);
-EXODUS_EXPORT void ex__compress_variable(int exoid, int varid, int type);
-EXODUS_EXPORT int  ex__id_lkup(int exoid, ex_entity_type id_type, ex_entity_id num);
-EXODUS_EXPORT int  ex__check_valid_file_id(
+EXODUS_EXPORT void exi_set_compact_storage(int exoid, int varid);
+EXODUS_EXPORT void exi_compress_variable(int exoid, int varid, int type);
+EXODUS_EXPORT int  exi_id_lkup(int exoid, ex_entity_type id_type, ex_entity_id num);
+EXODUS_EXPORT int  exi_check_valid_file_id(
      int exoid, const char *func); /** Return fatal error if exoid does not refer to valid file */
-EXODUS_EXPORT int   ex__check_multiple_open(const char *path, int mode, const char *func);
-EXODUS_EXPORT int   ex__check_file_type(const char *path, int *type);
-EXODUS_EXPORT char *ex__canonicalize_filename(const char *path);
-EXODUS_EXPORT int   ex__get_dimension(int exoid, const char *DIMENSION, const char *label,
+EXODUS_EXPORT int   exi_check_multiple_open(const char *path, int mode, const char *func);
+EXODUS_EXPORT int   exi_check_file_type(const char *path, int *type);
+EXODUS_EXPORT char *exi_canonicalize_filename(const char *path);
+EXODUS_EXPORT int   exi_get_dimension(int exoid, const char *DIMENSION, const char *label,
                                       size_t *count, int *dimid, const char *routine);
 
-EXODUS_EXPORT int ex__get_nodal_var_time(int exoid, int nodal_var_index, int64_t node_number,
+EXODUS_EXPORT int exi_get_nodal_var_time(int exoid, int nodal_var_index, int64_t node_number,
                                          int beg_time_step, int end_time_step,
                                          void *nodal_var_vals);
 
-EXODUS_EXPORT int ex__put_nodal_var_multi_time(int exoid, int nodal_var_index, int64_t num_nodes,
+EXODUS_EXPORT int exi_put_nodal_var_multi_time(int exoid, int nodal_var_index, int64_t num_nodes,
                                                int beg_time_step, int end_time_step,
                                                const void *nodal_var_vals);
 
-EXODUS_EXPORT int ex__get_nodal_var_multi_time(int exoid, int nodal_var_index, int64_t node_number,
+EXODUS_EXPORT int exi_get_nodal_var_multi_time(int exoid, int nodal_var_index, int64_t node_number,
                                                int beg_time_step, int end_time_step,
                                                void *nodal_var_vals);
 
-EXODUS_EXPORT int ex__put_nodal_var_time(int exoid, int nodal_var_index, int64_t num_nodes,
+EXODUS_EXPORT int exi_put_nodal_var_time(int exoid, int nodal_var_index, int64_t num_nodes,
                                          int beg_time_step, int end_time_step,
                                          const void *nodal_var_vals);
 
-EXODUS_EXPORT int ex__get_partial_nodal_var(int exoid, int time_step, int nodal_var_index,
+EXODUS_EXPORT int exi_get_partial_nodal_var(int exoid, int time_step, int nodal_var_index,
                                             int64_t start_node, int64_t num_nodes, void *var_vals);
 
-EXODUS_EXPORT int ex__put_partial_nodal_var(int exoid, int time_step, int nodal_var_index,
+EXODUS_EXPORT int exi_put_partial_nodal_var(int exoid, int time_step, int nodal_var_index,
                                             int64_t start_node, int64_t num_nodes,
                                             const void *nodal_var_vals);
-EXODUS_EXPORT int ex__get_glob_vars(int exoid, int time_step, int num_glob_vars,
+EXODUS_EXPORT int exi_get_glob_vars(int exoid, int time_step, int num_glob_vars,
                                     void *glob_var_vals);
 
-EXODUS_EXPORT int ex__get_glob_vars_multi_time(int exoid, int num_glob_vars, int beg_time_step,
+EXODUS_EXPORT int exi_get_glob_vars_multi_time(int exoid, int num_glob_vars, int beg_time_step,
                                                int end_time_step, void *glob_var_vals);
 
-EXODUS_EXPORT int ex__get_glob_var_time(int exoid, int glob_var_index, int beg_time_step,
+EXODUS_EXPORT int exi_get_glob_var_time(int exoid, int glob_var_index, int beg_time_step,
                                         int end_time_step, void *glob_var_vals);
 
-EXODUS_EXPORT int  ex__get_name(int exoid, int varid, size_t index, char *name, int name_size,
+EXODUS_EXPORT int  exi_get_name(int exoid, int varid, size_t index, char *name, int name_size,
                                 ex_entity_type obj_type, const char *routine);
-EXODUS_EXPORT int  ex__get_names(int exoid, int varid, size_t num_entity, char **names,
+EXODUS_EXPORT int  exi_get_names(int exoid, int varid, size_t num_entity, char **names,
                                  ex_entity_type obj_type, const char *routine);
-EXODUS_EXPORT int  ex__put_name(int exoid, int varid, size_t index, const char *name,
+EXODUS_EXPORT int  exi_put_name(int exoid, int varid, size_t index, const char *name,
                                 ex_entity_type obj_type, const char *subtype, const char *routine);
-EXODUS_EXPORT int  ex__put_names(int exoid, int varid, size_t num_entity, char *const *names,
+EXODUS_EXPORT int  exi_put_names(int exoid, int varid, size_t num_entity, char *const *names,
                                  ex_entity_type obj_type, const char *subtype, const char *routine);
-EXODUS_EXPORT void ex__trim(char *name);
-EXODUS_EXPORT void ex__update_max_name_length(int exoid, int length);
-EXODUS_EXPORT int  ex__leavedef(int         exoid,    /* NemesisI file ID         */
+EXODUS_EXPORT void exi_trim(char *name);
+EXODUS_EXPORT void exi_update_max_name_length(int exoid, int length);
+EXODUS_EXPORT int  exi_leavedef(int         exoid,    /* NemesisI file ID         */
                                 const char *call_rout /* Name of calling function */
  );
 
-EXODUS_EXPORT int ex__check_version(int run_version);
-EXODUS_EXPORT int ex__handle_mode(unsigned int my_mode, int is_parallel, int run_version);
-EXODUS_EXPORT int ex__populate_header(int exoid, const char *path, int my_mode, int is_parallel,
+EXODUS_EXPORT int exi_check_version(int run_version);
+EXODUS_EXPORT int exi_handle_mode(unsigned int my_mode, int is_parallel, int run_version);
+EXODUS_EXPORT int exi_populate_header(int exoid, const char *path, int my_mode, int is_parallel,
                                       int *comp_ws, int *io_ws);
 
-EXODUS_EXPORT int ex__get_block_param(int exoid, ex_entity_id id, int ndim,
-                                      struct ex__elem_blk_parm *elem_blk_parm);
+EXODUS_EXPORT int exi_get_block_param(int exoid, ex_entity_id id, int ndim,
+                                      struct exi_elem_blk_parm *elem_blk_parm);
 
-EXODUS_EXPORT int ex__get_file_type(int exoid, char *ftype);
+EXODUS_EXPORT int exi_get_file_type(int exoid, char *ftype);
 
-EXODUS_EXPORT int ex__put_nemesis_version(int exoid);
+EXODUS_EXPORT int exi_put_nemesis_version(int exoid);
 
-EXODUS_EXPORT int ex__put_homogenous_block_params(int exoid, size_t block_count,
+EXODUS_EXPORT int exi_put_homogenous_block_params(int exoid, size_t block_count,
                                                   const struct ex_block *blocks);
 
 EXODUS_EXPORT int ne__check_file_version(int exoid);
@@ -897,7 +897,7 @@ EXODUS_EXPORT int ne__id_lkup(int          exoid,       /* NetCDF/Exodus file ID
  * Note that this is a global setting for all databases. If you are
  * accessing multiple databases, they will all use the same value.
  */
-EXODUS_EXPORT int ex__default_max_name_length;
+EXODUS_EXPORT int exi_default_max_name_length;
 /*! @} */
 
 #ifdef __cplusplus

--- a/packages/seacas/libraries/exodus/include/exodusII_int.h
+++ b/packages/seacas/libraries/exodus/include/exodusII_int.h
@@ -870,9 +870,9 @@ EXODUS_EXPORT int exi_put_nemesis_version(int exoid);
 EXODUS_EXPORT int exi_put_homogenous_block_params(int exoid, size_t block_count,
                                                   const struct ex_block *blocks);
 
-EXODUS_EXPORT int ne__check_file_version(int exoid);
+EXODUS_EXPORT int nei_check_file_version(int exoid);
 
-EXODUS_EXPORT int ne__id_lkup(int          exoid,       /* NetCDF/Exodus file ID */
+EXODUS_EXPORT int nei_id_lkup(int          exoid,       /* NetCDF/Exodus file ID */
                               const char  *ne_var_name, /* Nemesis variable name */
                               int64_t     *idx,         /* index variable for variable, length 2 */
                               ex_entity_id ne_var_id    /* NetCDF variable ID */

--- a/packages/seacas/libraries/exodus/src/ex__get_glob_vars_multi_time.c
+++ b/packages/seacas/libraries/exodus/src/ex__get_glob_vars_multi_time.c
@@ -24,13 +24,13 @@
  *****************************************************************************/
 
 #include "exodusII.h"     // for ex_err, etc
-#include "exodusII_int.h" // for ex__comp_ws, EX_FATAL, etc
+#include "exodusII_int.h" // for exi_comp_ws, EX_FATAL, etc
 
 /*!
  Internal function. Do not use in client code.
  */
 
-int ex__get_glob_vars_multi_time(int exoid, int num_glob_vars, int beg_time_step, int end_time_step,
+int exi_get_glob_vars_multi_time(int exoid, int num_glob_vars, int beg_time_step, int end_time_step,
                                  void *glob_var_vals)
 {
   int    varid;
@@ -39,7 +39,7 @@ int ex__get_glob_vars_multi_time(int exoid, int num_glob_vars, int beg_time_step
   char   errmsg[MAX_ERR_LENGTH];
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -58,7 +58,7 @@ int ex__get_glob_vars_multi_time(int exoid, int num_glob_vars, int beg_time_step
   count[0] = end_time_step - beg_time_step;
   count[1] = num_glob_vars;
 
-  if (ex__comp_ws(exoid) == 4) {
+  if (exi_comp_ws(exoid) == 4) {
     status = nc_get_vara_float(exoid, varid, start, count, glob_var_vals);
   }
   else {

--- a/packages/seacas/libraries/exodus/src/ex__get_nodal_var_multi_time.c
+++ b/packages/seacas/libraries/exodus/src/ex__get_nodal_var_multi_time.c
@@ -15,7 +15,7 @@
 \note This function is called internally by ex_get_var_multi_time() to handle
 the reading of nodal variable values.
 
-The function ex__get_nodal_var_multi_time() reads the values of a single nodal
+The function exi_get_nodal_var_multi_time() reads the values of a single nodal
 variable for a one or more time steps. Memory must be allocated for the
 nodal variable values array before this function is invoked.
 
@@ -24,7 +24,7 @@ code must declare the array passed to be the appropriate type
 (float or double) to match the compute word size passed in
 ex_create() or ex_open().
 
-\return In case of an error, ex__get_nodal_var_multi_time() returns a negative
+\return In case of an error, exi_get_nodal_var_multi_time() returns a negative
 number; a warning will return a positive number. Possible causes of
 errors include:
 -  data file not properly opened with call to ex_create() or ex_open()
@@ -58,13 +58,13 @@ time_step = 1;
 var_index = 2;
 
 var_values = (float *) calloc (num_nodes, sizeof(float));
-error = ex__get_nodal_var_multi_time(exoid, var_index, num_nodes,
+error = exi_get_nodal_var_multi_time(exoid, var_index, num_nodes,
                                      time_step, time_step, var_values);
 ~~~
 
 */
 
-int ex__get_nodal_var_multi_time(int exoid, int nodal_var_index, int64_t num_nodes,
+int exi_get_nodal_var_multi_time(int exoid, int nodal_var_index, int64_t num_nodes,
                                  int beg_time_step, int end_time_step, void *nodal_var_vals)
 {
   int    varid;
@@ -72,7 +72,7 @@ int ex__get_nodal_var_multi_time(int exoid, int nodal_var_index, int64_t num_nod
   size_t start[3], count[3];
   char   errmsg[MAX_ERR_LENGTH];
 
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -117,7 +117,7 @@ int ex__get_nodal_var_multi_time(int exoid, int nodal_var_index, int64_t num_nod
     count[1] = num_nodes;
   }
 
-  if (ex__comp_ws(exoid) == 4) {
+  if (exi_comp_ws(exoid) == 4) {
     status = nc_get_vara_float(exoid, varid, start, count, nodal_var_vals);
   }
   else {

--- a/packages/seacas/libraries/exodus/src/ex__put_homogenous_block_params.c
+++ b/packages/seacas/libraries/exodus/src/ex__put_homogenous_block_params.c
@@ -15,14 +15,14 @@
  * Permits some optimizations and safer for N->1 parallel.
  * Arbitrary  polyhedra are handled in more general routine; not here.
  */
-int ex__put_homogenous_block_params(int exoid, size_t block_count, const struct ex_block *blocks)
+int exi_put_homogenous_block_params(int exoid, size_t block_count, const struct ex_block *blocks)
 {
 
   int  status;
   int  varid, dims[2];
   char errmsg[MAX_ERR_LENGTH];
 
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -133,7 +133,7 @@ int ex__put_homogenous_block_params(int exoid, size_t block_count, const struct 
   }
 
   for (size_t i = 0; i < block_count; i++) {
-    int blk_id_ndx = 1 + ex__inc_file_item(exoid, ex__get_counter_list(blocks[i].type));
+    int blk_id_ndx = 1 + exi_inc_file_item(exoid, exi_get_counter_list(blocks[i].type));
 
     if (blocks[i].num_entry == 0) { /* Is this a NULL element block? */
       continue;
@@ -266,7 +266,7 @@ int ex__put_homogenous_block_params(int exoid, size_t block_count, const struct 
         ex_err_fn(exoid, __func__, errmsg, status);
         goto error_ret; /* exit define mode and return */
       }
-      ex__compress_variable(exoid, varid, 2);
+      exi_compress_variable(exoid, varid, 2);
 
       /* Attribute names... */
       dims[0] = numattrdim;
@@ -305,7 +305,7 @@ int ex__put_homogenous_block_params(int exoid, size_t block_count, const struct 
         ex_err_fn(exoid, __func__, errmsg, status);
         goto error_ret; /* exit define mode and return */
       }
-      ex__compress_variable(exoid, connid, 1);
+      exi_compress_variable(exoid, connid, 1);
 
       /* store element type as attribute of connectivity variable */
       if ((status = nc_put_att_text(exoid, connid, ATT_NAME_ELB, strlen(blocks[i].topology) + 1,
@@ -345,7 +345,7 @@ int ex__put_homogenous_block_params(int exoid, size_t block_count, const struct 
   }
 
   /* leave define mode  */
-  if ((status = ex__leavedef(exoid, __func__)) != NC_NOERR) {
+  if ((status = exi_leavedef(exoid, __func__)) != NC_NOERR) {
     snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to exit define mode in file id %d", exoid);
     ex_err_fn(exoid, __func__, errmsg, status);
     return (EX_FATAL);
@@ -386,6 +386,6 @@ int ex__put_homogenous_block_params(int exoid, size_t block_count, const struct 
 
 /* Fatal error: exit definition mode and return */
 error_ret:
-  ex__leavedef(exoid, __func__);
+  exi_leavedef(exoid, __func__);
   return (EX_FATAL);
 }

--- a/packages/seacas/libraries/exodus/src/ex__put_nodal_var_multi_time.c
+++ b/packages/seacas/libraries/exodus/src/ex__put_nodal_var_multi_time.c
@@ -7,7 +7,7 @@
  */
 
 #include "exodusII.h"     // for ex_err, etc
-#include "exodusII_int.h" // for EX_WARN, ex__comp_ws, etc
+#include "exodusII_int.h" // for EX_WARN, exi_comp_ws, etc
 
 /*!
 \internal
@@ -15,7 +15,7 @@
 \note This function is called internally by ex_put_var_time() to handle
 the writing of nodal variable values.
 
-The function ex__put_nodal_var_time() writes the values of a single nodal
+The function exi_put_nodal_var_time() writes the values of a single nodal
 variable for multiple time steps. The function ex_put_variable_param()
 must be invoked before this call is made.
 
@@ -24,7 +24,7 @@ code must declare the array passed to be the appropriate type
 (float or double) to match the compute word size passed in
 ex_create() or ex_open().
 
-\return In case of an error, ex__put_nodal_var() returns a negative number; a
+\return In case of an error, exi_put_nodal_var() returns a negative number; a
 warning will return a positive number. Possible causes of errors
 include:
   -  data file not properly opened with call to ex_create() or ex_open()
@@ -75,7 +75,7 @@ for (k=1; k <= num_nod_vars; k++) {
 
 */
 
-int ex__put_nodal_var_time(int exoid, int nodal_var_index, int64_t num_nodes, int beg_time_step,
+int exi_put_nodal_var_time(int exoid, int nodal_var_index, int64_t num_nodes, int beg_time_step,
                            int end_time_step, const void *nodal_var_vals)
 
 {
@@ -96,7 +96,7 @@ int ex__put_nodal_var_time(int exoid, int nodal_var_index, int64_t num_nodes, in
   count[0] = end_time_step - beg_time_step;
   count[1] = num_nodes;
 
-  if (ex__comp_ws(exoid) == 4) {
+  if (exi_comp_ws(exoid) == 4) {
     status = nc_put_vara_float(exoid, varid, start, count, nodal_var_vals);
   }
   else {

--- a/packages/seacas/libraries/exodus/src/ex_add_attr.c
+++ b/packages/seacas/libraries/exodus/src/ex_add_attr.c
@@ -25,7 +25,7 @@ int ex_add_attr(int exoid, ex_entity_type obj_type, ex_entity_id obj_id, int64_t
   int         numattrdim;
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -38,7 +38,7 @@ int ex_add_attr(int exoid, ex_entity_type obj_type, ex_entity_id obj_id, int64_t
     obj_id_ndx = 0;
   }
   else {
-    obj_id_ndx = ex__id_lkup(exoid, obj_type, obj_id);
+    obj_id_ndx = exi_id_lkup(exoid, obj_type, obj_id);
     if (obj_id_ndx <= 0) {
       ex_get_err(NULL, NULL, &status);
 
@@ -137,7 +137,7 @@ int ex_add_attr(int exoid, ex_entity_type obj_type, ex_entity_id obj_id, int64_t
     goto error_ret; /* exit define mode and return */
   }
 
-  ex__get_dimension(exoid, dnumobjent, ex_name_of_object(obj_type), &num_obj, &numobjentdim,
+  exi_get_dimension(exoid, dnumobjent, ex_name_of_object(obj_type), &num_obj, &numobjentdim,
                     __func__);
   dims[0] = numobjentdim;
   dims[1] = numattrdim;
@@ -149,7 +149,7 @@ int ex_add_attr(int exoid, ex_entity_type obj_type, ex_entity_id obj_id, int64_t
     ex_err_fn(exoid, __func__, errmsg, status);
     goto error_ret; /* exit define mode and return */
   }
-  ex__compress_variable(exoid, varid, 2);
+  exi_compress_variable(exoid, varid, 2);
 
   /* inquire previously defined dimensions  */
   if ((status = nc_inq_dimid(exoid, DIM_STR_NAME, &strdim)) != NC_NOERR) {
@@ -172,7 +172,7 @@ int ex_add_attr(int exoid, ex_entity_type obj_type, ex_entity_id obj_id, int64_t
 
   /* leave define mode  */
 
-  if ((status = ex__leavedef(exoid, __func__)) != NC_NOERR) {
+  if ((status = exi_leavedef(exoid, __func__)) != NC_NOERR) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -199,6 +199,6 @@ int ex_add_attr(int exoid, ex_entity_type obj_type, ex_entity_id obj_id, int64_t
 
 /* Fatal error: exit definition mode and return */
 error_ret:
-  ex__leavedef(exoid, __func__);
+  exi_leavedef(exoid, __func__);
   EX_FUNC_LEAVE(EX_FATAL);
 }

--- a/packages/seacas/libraries/exodus/src/ex_close.c
+++ b/packages/seacas/libraries/exodus/src/ex_close.c
@@ -21,7 +21,7 @@
  *****************************************************************************/
 
 #include "exodusII.h"     // for ex_err, etc
-#include "exodusII_int.h" // for ex__get_counter_list, etc
+#include "exodusII_int.h" // for exi_get_counter_list, etc
 
 /*!
 \ingroup Utilities
@@ -53,14 +53,14 @@ int ex_close(int exoid)
 
   EX_FUNC_ENTER();
 
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
   /*
    * NOTE: If using netcdf-4, exoid must refer to the root group.
    * Need to determine whether there are any groups and if so,
-   * call ex__rm_file_item and ex__rm_stat_ptr on each group.
+   * call exi_rm_file_item and exi_rm_stat_ptr on each group.
    */
 
   /*
@@ -82,35 +82,35 @@ int ex_close(int exoid)
    * internal datastructures.
    */
 
-  ex__rm_file_item(exoid, ex__get_counter_list(EX_ELEM_BLOCK));
-  ex__rm_file_item(exoid, ex__get_counter_list(EX_FACE_BLOCK));
-  ex__rm_file_item(exoid, ex__get_counter_list(EX_EDGE_BLOCK));
-  ex__rm_file_item(exoid, ex__get_counter_list(EX_NODE_SET));
-  ex__rm_file_item(exoid, ex__get_counter_list(EX_EDGE_SET));
-  ex__rm_file_item(exoid, ex__get_counter_list(EX_FACE_SET));
-  ex__rm_file_item(exoid, ex__get_counter_list(EX_SIDE_SET));
-  ex__rm_file_item(exoid, ex__get_counter_list(EX_ELEM_SET));
-  ex__rm_file_item(exoid, ex__get_counter_list(EX_NODE_MAP));
-  ex__rm_file_item(exoid, ex__get_counter_list(EX_EDGE_MAP));
-  ex__rm_file_item(exoid, ex__get_counter_list(EX_FACE_MAP));
-  ex__rm_file_item(exoid, ex__get_counter_list(EX_ELEM_MAP));
-  ex__rm_file_item(exoid, ex__get_counter_list(EX_ASSEMBLY));
-  ex__rm_file_item(exoid, ex__get_counter_list(EX_BLOB));
+  exi_rm_file_item(exoid, exi_get_counter_list(EX_ELEM_BLOCK));
+  exi_rm_file_item(exoid, exi_get_counter_list(EX_FACE_BLOCK));
+  exi_rm_file_item(exoid, exi_get_counter_list(EX_EDGE_BLOCK));
+  exi_rm_file_item(exoid, exi_get_counter_list(EX_NODE_SET));
+  exi_rm_file_item(exoid, exi_get_counter_list(EX_EDGE_SET));
+  exi_rm_file_item(exoid, exi_get_counter_list(EX_FACE_SET));
+  exi_rm_file_item(exoid, exi_get_counter_list(EX_SIDE_SET));
+  exi_rm_file_item(exoid, exi_get_counter_list(EX_ELEM_SET));
+  exi_rm_file_item(exoid, exi_get_counter_list(EX_NODE_MAP));
+  exi_rm_file_item(exoid, exi_get_counter_list(EX_EDGE_MAP));
+  exi_rm_file_item(exoid, exi_get_counter_list(EX_FACE_MAP));
+  exi_rm_file_item(exoid, exi_get_counter_list(EX_ELEM_MAP));
+  exi_rm_file_item(exoid, exi_get_counter_list(EX_ASSEMBLY));
+  exi_rm_file_item(exoid, exi_get_counter_list(EX_BLOB));
 
-  ex__rm_stat_ptr(exoid, &exoII_ed);
-  ex__rm_stat_ptr(exoid, &exoII_fa);
-  ex__rm_stat_ptr(exoid, &exoII_eb);
-  ex__rm_stat_ptr(exoid, &exoII_ns);
-  ex__rm_stat_ptr(exoid, &exoII_es);
-  ex__rm_stat_ptr(exoid, &exoII_fs);
-  ex__rm_stat_ptr(exoid, &exoII_ss);
-  ex__rm_stat_ptr(exoid, &exoII_els);
-  ex__rm_stat_ptr(exoid, &exoII_nm);
-  ex__rm_stat_ptr(exoid, &exoII_edm);
-  ex__rm_stat_ptr(exoid, &exoII_fam);
-  ex__rm_stat_ptr(exoid, &exoII_em);
+  exi_rm_stat_ptr(exoid, &exoII_ed);
+  exi_rm_stat_ptr(exoid, &exoII_fa);
+  exi_rm_stat_ptr(exoid, &exoII_eb);
+  exi_rm_stat_ptr(exoid, &exoII_ns);
+  exi_rm_stat_ptr(exoid, &exoII_es);
+  exi_rm_stat_ptr(exoid, &exoII_fs);
+  exi_rm_stat_ptr(exoid, &exoII_ss);
+  exi_rm_stat_ptr(exoid, &exoII_els);
+  exi_rm_stat_ptr(exoid, &exoII_nm);
+  exi_rm_stat_ptr(exoid, &exoII_edm);
+  exi_rm_stat_ptr(exoid, &exoII_fam);
+  exi_rm_stat_ptr(exoid, &exoII_em);
 
-  ex__conv_exit(exoid);
+  exi_conv_exit(exoid);
 
   status = EX_NOERR;
   if (status1 != NC_NOERR || status2 != NC_NOERR) {

--- a/packages/seacas/libraries/exodus/src/ex_conv.c
+++ b/packages/seacas/libraries/exodus/src/ex_conv.c
@@ -7,7 +7,7 @@
  */
 
 #include "exodusII.h"     // for ex_err, etc
-#include "exodusII_int.h" // for ex__file_item, EX_FATAL, etc
+#include "exodusII_int.h" // for exi_file_item, EX_FATAL, etc
 #include "stdbool.h"
 
 /*! \file
@@ -24,13 +24,13 @@
 
 #define NC_FLOAT_WORDSIZE 4
 
-static struct ex__file_item *file_list = NULL;
+static struct exi_file_item *file_list = NULL;
 
-struct ex__file_item *ex__find_file_item(int exoid)
+struct exi_file_item *exi_find_file_item(int exoid)
 {
   /* Find base filename in case exoid refers to a group */
   int                   base_exoid = (unsigned)exoid & EX_FILE_ID_MASK;
-  struct ex__file_item *ptr        = file_list;
+  struct exi_file_item *ptr        = file_list;
   while (ptr) {
     if (ptr->file_id == base_exoid) {
       break;
@@ -41,13 +41,13 @@ struct ex__file_item *ex__find_file_item(int exoid)
 }
 
 #define EX__MAX_PATHLEN 8192
-int ex__check_multiple_open(const char *path, int mode, const char *func)
+int exi_check_multiple_open(const char *path, int mode, const char *func)
 {
   EX_FUNC_ENTER();
   bool                  is_write = mode & EX_WRITE;
   char                  tmp[EX__MAX_PATHLEN];
   size_t                pathlen;
-  struct ex__file_item *ptr = file_list;
+  struct exi_file_item *ptr = file_list;
   while (ptr) {
     nc_inq_path(ptr->file_id, &pathlen, tmp);
     /* If path is too long, assume it is ok... */
@@ -72,7 +72,7 @@ int ex__check_multiple_open(const char *path, int mode, const char *func)
   EX_FUNC_LEAVE(EX_NOERR);
 }
 
-int ex__check_valid_file_id(int exoid, const char *func)
+int exi_check_valid_file_id(int exoid, const char *func)
 {
   bool error = false;
   if (exoid <= 0) {
@@ -80,7 +80,7 @@ int ex__check_valid_file_id(int exoid, const char *func)
   }
 #if !defined BUILT_IN_SIERRA
   else {
-    struct ex__file_item *file = ex__find_file_item(exoid);
+    struct exi_file_item *file = exi_find_file_item(exoid);
 
     if (!file) {
       error = true;
@@ -107,13 +107,13 @@ int ex__check_valid_file_id(int exoid, const char *func)
   return EX_NOERR;
 }
 
-int ex__conv_init(int exoid, int *comp_wordsize, int *io_wordsize, int file_wordsize,
+int exi_conv_init(int exoid, int *comp_wordsize, int *io_wordsize, int file_wordsize,
                   int int64_status, bool is_parallel, bool is_hdf5, bool is_pnetcdf, bool is_write)
 {
   char                  errmsg[MAX_ERR_LENGTH];
-  struct ex__file_item *new_file = NULL;
+  struct exi_file_item *new_file = NULL;
 
-  /*! ex__conv_init() initializes the floating point conversion process.
+  /*! exi_conv_init() initializes the floating point conversion process.
    *
    * \param exoid         an integer uniquely identifying the file of interest.
    *
@@ -222,7 +222,7 @@ int ex__conv_init(int exoid, int *comp_wordsize, int *io_wordsize, int file_word
   int filetype = 0;
   nc_inq_format(exoid, &filetype);
 
-  if (!(new_file = malloc(sizeof(struct ex__file_item)))) {
+  if (!(new_file = malloc(sizeof(struct exi_file_item)))) {
     snprintf(errmsg, MAX_ERR_LENGTH,
              "ERROR: failed to allocate memory for internal file "
              "structure storage file id %d",
@@ -234,7 +234,7 @@ int ex__conv_init(int exoid, int *comp_wordsize, int *io_wordsize, int file_word
   new_file->file_id               = exoid;
   new_file->user_compute_wordsize = *comp_wordsize == 4 ? 0 : 1;
   new_file->int64_status          = int64_status;
-  new_file->maximum_name_length   = ex__default_max_name_length;
+  new_file->maximum_name_length   = exi_default_max_name_length;
   new_file->time_varid            = -1;
   new_file->compression_algorithm = EX_COMPRESS_GZIP;
   new_file->assembly_count        = 0;
@@ -267,20 +267,20 @@ int ex__conv_init(int exoid, int *comp_wordsize, int *io_wordsize, int file_word
 /*............................................................................*/
 /*............................................................................*/
 
-/*! ex__conv_exit() takes the structure identified by "exoid" out of the linked
+/*! exi_conv_exit() takes the structure identified by "exoid" out of the linked
  * list which describes the files that ex_conv_array() knows how to convert.
  *
- * \note it is absolutely necessary for ex__conv_exit() to be called after
+ * \note it is absolutely necessary for exi_conv_exit() to be called after
  *       ncclose(), if the parameter used as "exoid" is the id returned from
  *       an ncopen() or nccreate() call, as netCDF reuses file ids!
  *       the best place to do this is ex_close(), which is where I did it.
  *
  * \param exoid  integer which uniquely identifies the file of interest.
  */
-void ex__conv_exit(int exoid)
+void exi_conv_exit(int exoid)
 {
-  struct ex__file_item *file = file_list;
-  struct ex__file_item *prev = NULL;
+  struct exi_file_item *file = file_list;
+  struct exi_file_item *prev = NULL;
 
   EX_FUNC_ENTER();
   while (file) {
@@ -318,13 +318,13 @@ nc_type nc_flt_code(int exoid)
   /*!
    * \ingroup Utilities
    * nc_flt_code() returns either NC_FLOAT or NC_DOUBLE, based on the parameters
-   * with which ex__conv_init() was called.  nc_flt_code() is used as the nc_type
+   * with which exi_conv_init() was called.  nc_flt_code() is used as the nc_type
    * parameter on ncvardef() calls that define floating point variables.
    *
    * "exoid" is some integer which uniquely identifies the file of interest.
    */
   EX_FUNC_ENTER();
-  struct ex__file_item *file = ex__find_file_item(exoid);
+  struct exi_file_item *file = exi_find_file_item(exoid);
 
   if (!file) {
     char errmsg[MAX_ERR_LENGTH];
@@ -358,7 +358,7 @@ unsigned ex_int64_status(int exoid)
    #EX_INQ_INT64_API) |
   */
   EX_FUNC_ENTER();
-  struct ex__file_item *file = ex__find_file_item(exoid);
+  struct exi_file_item *file = exi_find_file_item(exoid);
 
   if (!file) {
     char errmsg[MAX_ERR_LENGTH];
@@ -389,7 +389,7 @@ int ex_set_int64_status(int exoid, int mode)
     #EX_INQ_INT64_API) |
   */
   EX_FUNC_ENTER();
-  struct ex__file_item *file = ex__find_file_item(exoid);
+  struct exi_file_item *file = exi_find_file_item(exoid);
 
   if (!file) {
     char errmsg[MAX_ERR_LENGTH];
@@ -413,7 +413,7 @@ int ex_set_int64_status(int exoid, int mode)
 int ex_set_option(int exoid, ex_option_type option, int option_value)
 {
   EX_FUNC_ENTER();
-  struct ex__file_item *file = ex__find_file_item(exoid);
+  struct exi_file_item *file = exi_find_file_item(exoid);
   if (!file) {
     char errmsg[MAX_ERR_LENGTH];
     snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: unknown file id %d for ex_set_option().", exoid);
@@ -473,14 +473,14 @@ int ex_set_option(int exoid, ex_option_type option, int option_value)
 
 /*!
  * \ingroup Utilities
- * ex__comp_ws() returns 4 (i.e. sizeof(float)) or 8 (i.e. sizeof(double)),
+ * exi_comp_ws() returns 4 (i.e. sizeof(float)) or 8 (i.e. sizeof(double)),
  * depending on the value of floating point word size used to initialize
  * the conversion facility for this file id (exoid).
  * \param exoid  integer which uniquely identifies the file of interest.
  */
-int ex__comp_ws(int exoid)
+int exi_comp_ws(int exoid)
 {
-  struct ex__file_item *file = ex__find_file_item(exoid);
+  struct exi_file_item *file = exi_find_file_item(exoid);
 
   if (!file) {
     char errmsg[MAX_ERR_LENGTH];
@@ -494,16 +494,16 @@ int ex__comp_ws(int exoid)
 
 /*!
  * \ingroup Utilities
- * ex__is_parallel() returns 1 (true) or 0 (false) depending on whether
+ * exi_is_parallel() returns 1 (true) or 0 (false) depending on whether
  * the file was opened in parallel or serial/file-per-processor mode.
  * Note that in this case parallel assumes the output of a single file,
  * not a parallel run using file-per-processor.
  * \param exoid  integer which uniquely identifies the file of interest.
  */
-int ex__is_parallel(int exoid)
+int exi_is_parallel(int exoid)
 {
   EX_FUNC_ENTER();
-  struct ex__file_item *file = ex__find_file_item(exoid);
+  struct exi_file_item *file = exi_find_file_item(exoid);
 
   if (!file) {
     char errmsg[MAX_ERR_LENGTH];
@@ -532,7 +532,7 @@ int ex__is_parallel(int exoid)
 int ex_set_parallel(int exoid, int is_parallel)
 {
   EX_FUNC_ENTER();
-  struct ex__file_item *file = ex__find_file_item(exoid);
+  struct exi_file_item *file = exi_find_file_item(exoid);
 
   if (!file) {
     char errmsg[MAX_ERR_LENGTH];

--- a/packages/seacas/libraries/exodus/src/ex_create.c
+++ b/packages/seacas/libraries/exodus/src/ex_create.c
@@ -142,7 +142,7 @@ int ex_create_int(const char *path, int cmode, int *comp_ws, int *io_ws, int run
 
   EX_FUNC_ENTER();
 
-  nc_mode = ex__handle_mode(my_mode, is_parallel, run_version);
+  nc_mode = exi_handle_mode(my_mode, is_parallel, run_version);
 
   if (!path || strlen(path) == 0) {
     snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: Filename is not specified.");
@@ -150,14 +150,14 @@ int ex_create_int(const char *path, int cmode, int *comp_ws, int *io_ws, int run
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
-  char *canon_path = ex__canonicalize_filename(path);
+  char *canon_path = exi_canonicalize_filename(path);
 
   /* Verify that this file is not already open for read or write...
      In theory, should be ok for the file to be open multiple times
      for read, but bad things can happen if being read and written
      at the same time...
   */
-  if (ex__check_multiple_open(canon_path, EX_WRITE, __func__)) {
+  if (exi_check_multiple_open(canon_path, EX_WRITE, __func__)) {
     free(canon_path);
     EX_FUNC_LEAVE(EX_FATAL);
   }
@@ -191,7 +191,7 @@ int ex_create_int(const char *path, int cmode, int *comp_ws, int *io_ws, int run
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
-  status = ex__populate_header(exoid, canon_path, my_mode, is_parallel, comp_ws, io_ws);
+  status = exi_populate_header(exoid, canon_path, my_mode, is_parallel, comp_ws, io_ws);
   if (status != EX_NOERR) {
     free(canon_path);
     EX_FUNC_LEAVE(status);

--- a/packages/seacas/libraries/exodus/src/ex_create_group.c
+++ b/packages/seacas/libraries/exodus/src/ex_create_group.c
@@ -22,7 +22,7 @@ int ex_create_group(int parent_id, const char *group_name)
   int status;
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(parent_id, __func__) != EX_NOERR) {
+  if (exi_check_valid_file_id(parent_id, __func__) != EX_NOERR) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -39,7 +39,7 @@ int ex_create_group(int parent_id, const char *group_name)
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
-  if ((status = ex__leavedef(parent_id, __func__)) != NC_NOERR) {
+  if ((status = exi_leavedef(parent_id, __func__)) != NC_NOERR) {
     snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to exit define mode");
     ex_err_fn(exoid, __func__, errmsg, status);
     EX_FUNC_LEAVE(EX_FATAL);

--- a/packages/seacas/libraries/exodus/src/ex_create_par.c
+++ b/packages/seacas/libraries/exodus/src/ex_create_par.c
@@ -164,19 +164,19 @@ int ex_create_par_int(const char *path, int cmode, int *comp_ws, int *io_ws, MPI
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
-  char *canon_path = ex__canonicalize_filename(path);
+  char *canon_path = exi_canonicalize_filename(path);
 
   /* Verify that this file is not already open for read or write...
      In theory, should be ok for the file to be open multiple times
      for read, but bad things can happen if being read and written
      at the same time...
   */
-  if (ex__check_multiple_open(canon_path, EX_WRITE, __func__)) {
+  if (exi_check_multiple_open(canon_path, EX_WRITE, __func__)) {
     free(canon_path);
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
-  nc_mode = ex__handle_mode(my_mode, is_parallel, run_version);
+  nc_mode = exi_handle_mode(my_mode, is_parallel, run_version);
 
 #if defined NC_NOATTCREORD
   /* Disable attribute creation order tracking if available... */
@@ -227,7 +227,7 @@ int ex_create_par_int(const char *path, int cmode, int *comp_ws, int *io_ws, MPI
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
-  status = ex__populate_header(exoid, canon_path, my_mode, is_parallel, comp_ws, io_ws);
+  status = exi_populate_header(exoid, canon_path, my_mode, is_parallel, comp_ws, io_ws);
   if (status != EX_NOERR) {
     free(canon_path);
     EX_FUNC_LEAVE(status);

--- a/packages/seacas/libraries/exodus/src/ex_cvt_nodes_to_sides.c
+++ b/packages/seacas/libraries/exodus/src/ex_cvt_nodes_to_sides.c
@@ -188,7 +188,7 @@ int ex_cvt_nodes_to_sides(int exoid, void_int *num_elem_per_set, void_int *num_n
   int int_size;
   int ids_size;
 
-  struct ex__elem_blk_parm *elem_blk_parms = NULL;
+  struct exi_elem_blk_parm *elem_blk_parms = NULL;
 
   int err_stat = EX_NOERR;
 
@@ -206,7 +206,7 @@ int ex_cvt_nodes_to_sides(int exoid, void_int *num_elem_per_set, void_int *num_n
   char errmsg[MAX_ERR_LENGTH];
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -282,7 +282,7 @@ int ex_cvt_nodes_to_sides(int exoid, void_int *num_elem_per_set, void_int *num_n
     for (i = 0; i < tot_num_ss_elem; i++) {
       elems[i] = i; /* init index array to current position */
     }
-    ex__iqsort64(side_sets_elem_list, elems, tot_num_ss_elem);
+    exi_iqsort64(side_sets_elem_list, elems, tot_num_ss_elem);
   }
   else {
     /* Sort side set element list into index array  - non-destructive */
@@ -290,7 +290,7 @@ int ex_cvt_nodes_to_sides(int exoid, void_int *num_elem_per_set, void_int *num_n
     for (i = 0; i < tot_num_ss_elem; i++) {
       elems[i] = i; /* init index array to current position */
     }
-    ex__iqsort(side_sets_elem_list, elems, tot_num_ss_elem);
+    exi_iqsort(side_sets_elem_list, elems, tot_num_ss_elem);
   }
 
   /* Allocate space for the element block ids */
@@ -315,7 +315,7 @@ int ex_cvt_nodes_to_sides(int exoid, void_int *num_elem_per_set, void_int *num_n
   }
 
   /* Allocate space for the element block params */
-  if (!(elem_blk_parms = malloc(num_elem_blks * sizeof(struct ex__elem_blk_parm)))) {
+  if (!(elem_blk_parms = malloc(num_elem_blks * sizeof(struct exi_elem_blk_parm)))) {
     snprintf(errmsg, MAX_ERR_LENGTH,
              "ERROR: failed to allocate space for element block params "
              "for file id %d",
@@ -334,7 +334,7 @@ int ex_cvt_nodes_to_sides(int exoid, void_int *num_elem_per_set, void_int *num_n
       id = ((int *)elem_blk_ids)[i];
     }
 
-    err_stat = ex__get_block_param(exoid, id, ndim, &elem_blk_parms[i]);
+    err_stat = exi_get_block_param(exoid, id, ndim, &elem_blk_parms[i]);
     if (err_stat != EX_NOERR) {
       goto cleanup;
     }

--- a/packages/seacas/libraries/exodus/src/ex_err.c
+++ b/packages/seacas/libraries/exodus/src/ex_err.c
@@ -30,7 +30,7 @@ static int  last_err_num;
   \ingroup Utilities
   \undoc
 */
-void ex__reset_error_status(void)
+void exi_reset_error_status(void)
 {
 #if !defined(EXODUS_THREADSAFE)
   exerrval   = 0;
@@ -208,7 +208,7 @@ void ex_err_fn(int exoid, const char *module_name, const char *message, int err_
   if (err_num == EX_PRTLASTMSG) {
     fprintf(stderr, "\n[%s] %s\n", EX_PNAME, EX_ERRMSG);
 
-    struct ex__file_item *file = ex__find_file_item(exoid);
+    struct exi_file_item *file = exi_find_file_item(exoid);
     if (file) {
       size_t pathlen = 0;
       nc_inq_path(exoid, &pathlen, NULL);
@@ -244,7 +244,7 @@ void ex_err_fn(int exoid, const char *module_name, const char *message, int err_
 
   else if (exoptval & EX_VERBOSE) { /* check see if we really want to hear this */
     char                 *path = NULL;
-    struct ex__file_item *file = ex__find_file_item(exoid);
+    struct exi_file_item *file = exi_find_file_item(exoid);
     if (file) {
       size_t pathlen = 0;
       nc_inq_path(exoid, &pathlen, NULL);

--- a/packages/seacas/libraries/exodus/src/ex_get_all_times.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_all_times.c
@@ -59,7 +59,7 @@ int ex_get_all_times(int exoid, void *time_values)
   char errmsg[MAX_ERR_LENGTH];
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -71,7 +71,7 @@ int ex_get_all_times(int exoid, void *time_values)
   }
 
   /*read time values */
-  if (ex__comp_ws(exoid) == 4) {
+  if (exi_comp_ws(exoid) == 4) {
     status = nc_get_var_float(exoid, varid, time_values);
   }
   else {

--- a/packages/seacas/libraries/exodus/src/ex_get_assembly.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_assembly.c
@@ -17,7 +17,7 @@
 
 int ex_get_assembly(int exoid, ex_assembly *assembly)
 {
-  struct ex__file_item *file   = NULL;
+  struct exi_file_item *file   = NULL;
   int                   status = 0;
   int                   dimid  = 0;
   size_t                len    = 0;
@@ -25,7 +25,7 @@ int ex_get_assembly(int exoid, ex_assembly *assembly)
 
   EX_FUNC_ENTER();
 
-  file = ex__find_file_item(exoid);
+  file = exi_find_file_item(exoid);
   if (!file) {
     snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: unknown file id %d.", exoid);
     ex_err_fn(exoid, __func__, errmsg, EX_BADFILEID);

--- a/packages/seacas/libraries/exodus/src/ex_get_attr.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_attr.c
@@ -39,7 +39,7 @@ int ex_get_attr(int exoid, ex_entity_type obj_type, ex_entity_id obj_id, void *a
   const char *vattrbname;
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -48,7 +48,7 @@ int ex_get_attr(int exoid, ex_entity_type obj_type, ex_entity_id obj_id, void *a
     obj_id_ndx = 0;
   }
   else {
-    obj_id_ndx = ex__id_lkup(exoid, obj_type, obj_id);
+    obj_id_ndx = exi_id_lkup(exoid, obj_type, obj_id);
     if (obj_id_ndx <= 0) {
       ex_get_err(NULL, NULL, &status);
 
@@ -97,7 +97,7 @@ int ex_get_attr(int exoid, ex_entity_type obj_type, ex_entity_id obj_id, void *a
   }
 
   /* read in the attributes */
-  if (ex__comp_ws(exoid) == 4) {
+  if (exi_comp_ws(exoid) == 4) {
     status = nc_get_var_float(exoid, attrid, attrib);
   }
   else {

--- a/packages/seacas/libraries/exodus/src/ex_get_attr_names.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_attr_names.c
@@ -39,13 +39,13 @@ int ex_get_attr_names(int exoid, ex_entity_type obj_type, ex_entity_id obj_id, c
   const char *vattrbname;
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
   /* Determine index of obj_id in vobjids array */
   if (obj_type != EX_NODAL) {
-    obj_id_ndx = ex__id_lkup(exoid, obj_type, obj_id);
+    obj_id_ndx = exi_id_lkup(exoid, obj_type, obj_id);
     if (obj_id_ndx <= 0) {
       ex_get_err(NULL, NULL, &status);
 
@@ -138,7 +138,7 @@ int ex_get_attr_names(int exoid, ex_entity_type obj_type, ex_entity_id obj_id, c
 
   if (status == NC_NOERR) {
     /* read the names */
-    status = ex__get_names(exoid, varid, num_attr, names, obj_type, __func__);
+    status = exi_get_names(exoid, varid, num_attr, names, obj_type, __func__);
     if (status != NC_NOERR) {
       EX_FUNC_LEAVE(EX_FATAL);
     }

--- a/packages/seacas/libraries/exodus/src/ex_get_attr_param.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_attr_param.c
@@ -40,7 +40,7 @@ int ex_get_attr_param(int exoid, ex_entity_type obj_type, ex_entity_id obj_id, i
   size_t lnum_attr_per_entry;
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -49,7 +49,7 @@ int ex_get_attr_param(int exoid, ex_entity_type obj_type, ex_entity_id obj_id, i
     obj_id_ndx = 0;
   }
   else {
-    obj_id_ndx = ex__id_lkup(exoid, obj_type, obj_id);
+    obj_id_ndx = exi_id_lkup(exoid, obj_type, obj_id);
     if (obj_id_ndx <= 0) {
       ex_get_err(NULL, NULL, &status);
 

--- a/packages/seacas/libraries/exodus/src/ex_get_attribute.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_attribute.c
@@ -23,7 +23,7 @@
    attributes which are currently supported in Exodus.
 */
 
-static bool ex__is_internal_attribute(const char *name, ex_entity_type obj_type)
+static bool exi_is_internal_attribute(const char *name, ex_entity_type obj_type)
 {
   if (name[0] == '_') {
     return true;
@@ -45,17 +45,17 @@ static bool ex__is_internal_attribute(const char *name, ex_entity_type obj_type)
   return false;
 }
 
-static int ex__get_varid(int exoid, ex_entity_type obj_type, ex_entity_id id)
+static int exi_get_varid(int exoid, ex_entity_type obj_type, ex_entity_id id)
 {
   char errmsg[MAX_ERR_LENGTH];
   int  status = 0;
 
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     return (EX_FATAL);
   }
 
   /* First, locate index of this objects id `obj_type` id array */
-  int id_ndx = ex__id_lkup(exoid, obj_type, id);
+  int id_ndx = exi_id_lkup(exoid, obj_type, id);
   if (id_ndx <= 0) {
     ex_get_err(NULL, NULL, &status);
     if (status != 0) {
@@ -100,7 +100,7 @@ static int ex__get_varid(int exoid, ex_entity_type obj_type, ex_entity_id id)
   return varid;
 }
 
-static int ex__get_attribute_count(int exoid, ex_entity_type obj_type, ex_entity_id id, int *varid)
+static int exi_get_attribute_count(int exoid, ex_entity_type obj_type, ex_entity_id id, int *varid)
 {
   int att_count = 0;
   int status;
@@ -117,9 +117,9 @@ static int ex__get_attribute_count(int exoid, ex_entity_type obj_type, ex_entity
     }
   }
   else {
-    *varid = ex__get_varid(exoid, obj_type, id);
+    *varid = exi_get_varid(exoid, obj_type, id);
     if (*varid <= 0) {
-      /* Error message handled in ex__get_varid */
+      /* Error message handled in exi_get_varid */
       return 0;
     }
 
@@ -146,7 +146,7 @@ int ex_get_attribute_count(int exoid, ex_entity_type obj_type, ex_entity_id id)
   EX_FUNC_ENTER();
 
   int varid;
-  int att_count = ex__get_attribute_count(exoid, obj_type, id, &varid);
+  int att_count = exi_get_attribute_count(exoid, obj_type, id, &varid);
   if (att_count < 0) {
     char errmsg[MAX_ERR_LENGTH];
     snprintf(errmsg, MAX_ERR_LENGTH,
@@ -169,7 +169,7 @@ int ex_get_attribute_count(int exoid, ex_entity_type obj_type, ex_entity_id id)
       ex_err_fn(exoid, __func__, errmsg, status);
       EX_FUNC_LEAVE(EX_FATAL);
     }
-    if (ex__is_internal_attribute(name, obj_type)) {
+    if (exi_is_internal_attribute(name, obj_type)) {
       att_count--;
     }
   }
@@ -198,7 +198,7 @@ int ex_get_attribute_param(int exoid, ex_entity_type obj_type, ex_entity_id id, 
 
   EX_FUNC_ENTER();
 
-  att_count = ex__get_attribute_count(exoid, obj_type, id, &varid);
+  att_count = exi_get_attribute_count(exoid, obj_type, id, &varid);
   if (att_count < 0) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
@@ -217,7 +217,7 @@ int ex_get_attribute_param(int exoid, ex_entity_type obj_type, ex_entity_id id, 
       ex_err_fn(exoid, __func__, errmsg, status);
       EX_FUNC_LEAVE(EX_FATAL);
     }
-    if (!ex__is_internal_attribute(name, obj_type)) {
+    if (!exi_is_internal_attribute(name, obj_type)) {
       nc_type type;
       size_t  val_count;
 
@@ -249,9 +249,9 @@ int ex_get_attribute(int exoid, ex_attribute *attr)
     varid = NC_GLOBAL;
   }
   else {
-    varid = ex__get_varid(exoid, attr->entity_type, attr->entity_id);
+    varid = exi_get_varid(exoid, attr->entity_type, attr->entity_id);
     if (varid <= 0) {
-      /* Error message handled in ex__get_varid */
+      /* Error message handled in exi_get_varid */
       EX_FUNC_LEAVE(varid);
     }
   }

--- a/packages/seacas/libraries/exodus/src/ex_get_blob.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_blob.c
@@ -17,7 +17,7 @@
 
 int ex_get_blob(int exoid, ex_blob *blob)
 {
-  struct ex__file_item *file   = NULL;
+  struct exi_file_item *file   = NULL;
   int                   status = 0;
   int                   dimid  = 0;
   size_t                len    = 0;
@@ -25,7 +25,7 @@ int ex_get_blob(int exoid, ex_blob *blob)
 
   EX_FUNC_ENTER();
 
-  file = ex__find_file_item(exoid);
+  file = exi_find_file_item(exoid);
   if (!file) {
     snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: unknown file id %d.", exoid);
     ex_err_fn(exoid, __func__, errmsg, EX_BADFILEID);

--- a/packages/seacas/libraries/exodus/src/ex_get_block_id_map.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_block_id_map.c
@@ -34,12 +34,12 @@ int ex_get_block_id_map(int exoid, ex_entity_type obj_type, ex_entity_id entity_
   ex_entity_type map_type = EX_INVALID;
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
   /* Determine index of entity_id in id array */
-  int blk_id_ndx = ex__id_lkup(exoid, obj_type, entity_id);
+  int blk_id_ndx = exi_id_lkup(exoid, obj_type, entity_id);
   if (blk_id_ndx <= 0) { /* Empty block */
     ex_get_err(NULL, NULL, &status);
     if (status != 0) {

--- a/packages/seacas/libraries/exodus/src/ex_get_block_param.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_block_param.c
@@ -48,7 +48,7 @@ int ex_get_block_param(int exoid, ex_block *block)
 
   EX_FUNC_ENTER();
 
-  struct ex__file_item *file = ex__find_file_item(exoid);
+  struct exi_file_item *file = exi_find_file_item(exoid);
   if (!file) {
     snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: unknown file id %d in ex_get_block_param().", exoid);
     ex_err_fn(exoid, __func__, errmsg, EX_BADFILEID);
@@ -56,7 +56,7 @@ int ex_get_block_param(int exoid, ex_block *block)
   }
 
   /* First, locate index of element block id in VAR_ID_EL_BLK array */
-  blk_id_ndx = ex__id_lkup(exoid, block->type, block->id);
+  blk_id_ndx = exi_id_lkup(exoid, block->type, block->id);
   if (blk_id_ndx <= 0) {
     ex_get_err(NULL, NULL, &status);
     if (status != 0) {
@@ -254,7 +254,7 @@ int ex_get_block_param(int exoid, ex_block *block)
     }
 
     /* get rid of trailing blanks */
-    ex__trim(block->topology);
+    exi_trim(block->topology);
   }
   EX_FUNC_LEAVE(EX_NOERR);
 }

--- a/packages/seacas/libraries/exodus/src/ex_get_cmap_params.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_cmap_params.c
@@ -47,7 +47,7 @@ int ex_get_cmap_params(int exoid, void_int *node_cmap_ids, void_int *node_cmap_n
   /*-----------------------------Execution begins-----------------------------*/
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 

--- a/packages/seacas/libraries/exodus/src/ex_get_cmap_params.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_cmap_params.c
@@ -134,7 +134,7 @@ int ex_get_cmap_params(int exoid, void_int *node_cmap_ids, void_int *node_cmap_n
               cmap_id = ((int *)node_cmap_ids)[cnt];
             }
 
-            if ((map_idx = ne__id_lkup(exoid, VAR_N_COMM_IDS, cmap_info_idx, cmap_id)) < 0) {
+            if ((map_idx = nei_id_lkup(exoid, VAR_N_COMM_IDS, cmap_info_idx, cmap_id)) < 0) {
               snprintf(errmsg, MAX_ERR_LENGTH,
                        "ERROR: failed to find nodal comm map with ID %" PRId64 " in file ID %d",
                        cmap_id, exoid);
@@ -295,7 +295,7 @@ int ex_get_cmap_params(int exoid, void_int *node_cmap_ids, void_int *node_cmap_n
               cmap_id = ((int *)elem_cmap_ids)[cnt];
             }
 
-            if ((map_idx = ne__id_lkup(exoid, VAR_E_COMM_IDS, cmap_info_idx, cmap_id)) < 0) {
+            if ((map_idx = nei_id_lkup(exoid, VAR_E_COMM_IDS, cmap_info_idx, cmap_id)) < 0) {
               snprintf(errmsg, MAX_ERR_LENGTH,
                        "ERROR: failed to find elemental comm map with ID %" PRId64 " in file ID %d",
                        cmap_id, exoid);

--- a/packages/seacas/libraries/exodus/src/ex_get_concat_sets.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_concat_sets.c
@@ -27,7 +27,7 @@
  *****************************************************************************/
 
 #include "exodusII.h"     // for ex_set_specs, ex_err, etc
-#include "exodusII_int.h" // for ex__check_valid_file_id, etc
+#include "exodusII_int.h" // for exi_check_valid_file_id, etc
 
 int ex_get_concat_sets(int exoid, ex_entity_type set_type, struct ex_set_specs *set_specs)
 {
@@ -46,7 +46,7 @@ int ex_get_concat_sets(int exoid, ex_entity_type set_type, struct ex_set_specs *
   ex_inquiry ex_inq_val;
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -76,7 +76,7 @@ int ex_get_concat_sets(int exoid, ex_entity_type set_type, struct ex_set_specs *
 
   /* first check if any sets are specified */
 
-  if ((status = nc_inq_dimid(exoid, ex__dim_num_objects(set_type), &dimid)) != NC_NOERR) {
+  if ((status = nc_inq_dimid(exoid, exi_dim_num_objects(set_type), &dimid)) != NC_NOERR) {
     if (status == NC_EBADDIM) {
       snprintf(errmsg, MAX_ERR_LENGTH, "Warning: no %ss defined for file id %d",
                ex_name_of_object(set_type), exoid);
@@ -199,7 +199,7 @@ int ex_get_concat_sets(int exoid, ex_entity_type set_type, struct ex_set_specs *
         num_dist = ((int *)num_dist_per_set)[i];
       }
       if (num_dist > 0) { /* only get df if they exist */
-        if (ex__comp_ws(exoid) == sizeof(float)) {
+        if (exi_comp_ws(exoid) == sizeof(float)) {
           flt_dist_fact = sets_dist_fact;
           status        = ex_get_set_dist_fact(exoid, set_type, set_id, &(flt_dist_fact[df_idx]));
         }

--- a/packages/seacas/libraries/exodus/src/ex_get_concat_side_set_node_count.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_concat_side_set_node_count.c
@@ -38,12 +38,12 @@ int ex_get_concat_side_set_node_count(int exoid, int *side_set_node_cnt_list)
   size_t       elem_ctr;
   int          status;
 
-  struct ex__elem_blk_parm *elem_blk_parms = NULL;
+  struct exi_elem_blk_parm *elem_blk_parms = NULL;
 
   char errmsg[MAX_ERR_LENGTH];
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -111,7 +111,7 @@ int ex_get_concat_side_set_node_count(int exoid, int *side_set_node_cnt_list)
   }
 
   /* Allocate space for the element block params */
-  if (!(elem_blk_parms = malloc(num_elem_blks * sizeof(struct ex__elem_blk_parm)))) {
+  if (!(elem_blk_parms = malloc(num_elem_blks * sizeof(struct exi_elem_blk_parm)))) {
     snprintf(errmsg, MAX_ERR_LENGTH,
              "ERROR: failed to allocate space for element block params "
              "for file id %d",
@@ -130,7 +130,7 @@ int ex_get_concat_side_set_node_count(int exoid, int *side_set_node_cnt_list)
       id = ((int *)elem_blk_ids)[i];
     }
 
-    if (ex__get_block_param(exoid, id, ndim, &elem_blk_parms[i]) != EX_NOERR) {
+    if (exi_get_block_param(exoid, id, ndim, &elem_blk_parms[i]) != EX_NOERR) {
       goto error_ret;
     }
 
@@ -233,7 +233,7 @@ int ex_get_concat_side_set_node_count(int exoid, int *side_set_node_cnt_list)
       for (i = 0; i < tot_num_ss_elem; i++) {
         elems[i] = i; /* init index array to current position */
       }
-      ex__iqsort64(side_set_elem_list, ss_elem_ndx, tot_num_ss_elem);
+      exi_iqsort64(side_set_elem_list, ss_elem_ndx, tot_num_ss_elem);
     }
     else {
       /* Sort side set element list into index array  - non-destructive */
@@ -241,7 +241,7 @@ int ex_get_concat_side_set_node_count(int exoid, int *side_set_node_cnt_list)
       for (i = 0; i < tot_num_ss_elem; i++) {
         elems[i] = i; /* init index array to current position */
       }
-      ex__iqsort(side_set_elem_list, ss_elem_ndx, tot_num_ss_elem);
+      exi_iqsort(side_set_elem_list, ss_elem_ndx, tot_num_ss_elem);
     }
 
     j = 0; /* The current element block... */

--- a/packages/seacas/libraries/exodus/src/ex_get_conn.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_conn.c
@@ -24,7 +24,7 @@
  *
  */
 #include "exodusII.h"     // for ex_err, etc
-#include "exodusII_int.h" // for EX_FATAL, ex__id_lkup, etc
+#include "exodusII_int.h" // for EX_FATAL, exi_id_lkup, etc
 
 int ex_get_conn(int exoid, ex_entity_type blk_type, ex_entity_id blk_id, void_int *nodeconn,
                 void_int *edgeconn, void_int *faceconn)
@@ -53,7 +53,7 @@ int ex_get_conn(int exoid, ex_entity_type blk_type, ex_entity_id blk_id, void_in
   const char *vfaceconn  = NULL;
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -67,7 +67,7 @@ int ex_get_conn(int exoid, ex_entity_type blk_type, ex_entity_id blk_id, void_in
 
   /* Locate index of element block id in VAR_ID_EL_BLK array */
 
-  blk_id_ndx = ex__id_lkup(exoid, blk_type, blk_id);
+  blk_id_ndx = exi_id_lkup(exoid, blk_type, blk_id);
   if (blk_id_ndx <= 0) {
     ex_get_err(NULL, NULL, &status);
     if (status != 0) {

--- a/packages/seacas/libraries/exodus/src/ex_get_coord.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_coord.c
@@ -7,7 +7,7 @@
  */
 
 #include "exodusII.h"     // for ex_err, etc
-#include "exodusII_int.h" // for EX_FATAL, ex__comp_ws, etc
+#include "exodusII_int.h" // for EX_FATAL, exi_comp_ws, etc
 
 /*!
 The function ex_get_coord() reads the nodal coordinates of the
@@ -79,13 +79,13 @@ int ex_get_coord(int exoid, void *x_coor, void *y_coor, void *z_coor)
   char   errmsg[MAX_ERR_LENGTH];
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
   /* inquire id's of previously defined dimensions  */
 
-  if (ex__get_dimension(exoid, DIM_NUM_DIM, "dimension count", &num_dim, &ndimdim, __func__) !=
+  if (exi_get_dimension(exoid, DIM_NUM_DIM, "dimension count", &num_dim, &ndimdim, __func__) !=
       NC_NOERR) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
@@ -123,7 +123,7 @@ int ex_get_coord(int exoid, void *x_coor, void *y_coor, void *z_coor)
 
       if (i == 0 && x_coor != NULL) {
         which = "X";
-        if (ex__comp_ws(exoid) == 4) {
+        if (exi_comp_ws(exoid) == 4) {
           status = nc_get_vara_float(exoid, coordid, start, count, x_coor);
         }
         else {
@@ -132,7 +132,7 @@ int ex_get_coord(int exoid, void *x_coor, void *y_coor, void *z_coor)
       }
       else if (i == 1 && y_coor != NULL) {
         which = "Y";
-        if (ex__comp_ws(exoid) == 4) {
+        if (exi_comp_ws(exoid) == 4) {
           status = nc_get_vara_float(exoid, coordid, start, count, y_coor);
         }
         else {
@@ -141,7 +141,7 @@ int ex_get_coord(int exoid, void *x_coor, void *y_coor, void *z_coor)
       }
       else if (i == 2 && z_coor != NULL) {
         which = "Z";
-        if (ex__comp_ws(exoid) == 4) {
+        if (exi_comp_ws(exoid) == 4) {
           status = nc_get_vara_float(exoid, coordid, start, count, z_coor);
         }
         else {
@@ -211,7 +211,7 @@ int ex_get_coord(int exoid, void *x_coor, void *y_coor, void *z_coor)
       }
 
       if (coor != NULL && coordid != -1) {
-        if (ex__comp_ws(exoid) == 4) {
+        if (exi_comp_ws(exoid) == 4) {
           status = nc_get_var_float(exoid, coordid, coor);
         }
         else {

--- a/packages/seacas/libraries/exodus/src/ex_get_coord_names.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_coord_names.c
@@ -51,7 +51,7 @@ int ex_get_coord_names(int exoid, char **coord_names)
   char   errmsg[MAX_ERR_LENGTH];
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -79,7 +79,7 @@ int ex_get_coord_names(int exoid, char **coord_names)
   }
 
   /* read the coordinate names */
-  status = ex__get_names(exoid, varid, num_dim, coord_names, EX_COORDINATE, __func__);
+  status = exi_get_names(exoid, varid, num_dim, coord_names, EX_COORDINATE, __func__);
   if (status != NC_NOERR) {
     EX_FUNC_LEAVE(EX_FATAL);
   }

--- a/packages/seacas/libraries/exodus/src/ex_get_coordinate_frames.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_coordinate_frames.c
@@ -106,7 +106,7 @@ int ex_get_coordinate_frames(int exoid, int *nframes, void_int *cf_ids, void *pt
   size_t count = 0; /* number vars to put in varput   */
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -166,7 +166,7 @@ int ex_get_coordinate_frames(int exoid, int *nframes, void_int *cf_ids, void *pt
       EX_FUNC_LEAVE(EX_FATAL);
     }
 
-    if (ex__comp_ws(exoid) == 4) {
+    if (exi_comp_ws(exoid) == 4) {
       status = nc_get_var_float(exoid, varids, pt_coordinates);
     }
     else {

--- a/packages/seacas/libraries/exodus/src/ex_get_eb_info_global.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_eb_info_global.c
@@ -33,7 +33,7 @@ int ex_get_eb_info_global(int exoid, void_int *el_blk_ids, void_int *el_blk_cnts
   /*-----------------------------Execution begins-----------------------------*/
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 

--- a/packages/seacas/libraries/exodus/src/ex_get_elem_cmap.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_elem_cmap.c
@@ -57,11 +57,11 @@ int ex_get_elem_cmap(int exoid, ex_entity_id map_id, void_int *elem_ids, void_in
 
   /*
    * no need to check if the second index is -1 that is handled
-   * in ne__id_lkup, where the dimension must be looked up anyways
+   * in nei_id_lkup, where the dimension must be looked up anyways
    */
 
   /* Get the index of the elemental comm map with the given ID */
-  if ((map_idx = ne__id_lkup(exoid, VAR_E_COMM_IDS, varidx, map_id)) < 0) {
+  if ((map_idx = nei_id_lkup(exoid, VAR_E_COMM_IDS, varidx, map_id)) < 0) {
     snprintf(errmsg, MAX_ERR_LENGTH,
              "ERROR: failed to find elemental comm map with ID %" PRId64 " in file \
 ID %d",

--- a/packages/seacas/libraries/exodus/src/ex_get_elem_cmap.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_elem_cmap.c
@@ -42,7 +42,7 @@ int ex_get_elem_cmap(int exoid, ex_entity_id map_id, void_int *elem_ids, void_in
   /*-----------------------------Execution begins-----------------------------*/
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 

--- a/packages/seacas/libraries/exodus/src/ex_get_elem_type.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_elem_type.c
@@ -40,12 +40,12 @@ int ex_get_elem_type(int exoid, ex_entity_id elem_blk_id, char *elem_type)
   /*****************************************************************************/
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
   /* inquire id's of previously defined dimensions */
-  if ((el_blk_id_ndx = ex__id_lkup(exoid, EX_ELEM_BLOCK, elem_blk_id)) == -1) {
+  if ((el_blk_id_ndx = exi_id_lkup(exoid, EX_ELEM_BLOCK, elem_blk_id)) == -1) {
     snprintf(errmsg, MAX_ERR_LENGTH,
              "ERROR: failed to find element block ID %" PRId64 " in file %d", elem_blk_id, exoid);
     ex_err_fn(exoid, __func__, errmsg, EX_LASTERR);

--- a/packages/seacas/libraries/exodus/src/ex_get_entity_count_per_polyhedra.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_entity_count_per_polyhedra.c
@@ -12,7 +12,7 @@
  *****************************************************************************/
 
 #include "exodusII.h"     // for ex_err, etc
-#include "exodusII_int.h" // for EX_FATAL, ex__id_lkup, etc
+#include "exodusII_int.h" // for EX_FATAL, exi_id_lkup, etc
 
 /*!
  * reads in the number of entities (nodes/faces) per polyhedra
@@ -30,11 +30,11 @@ int ex_get_entity_count_per_polyhedra(int exoid, ex_entity_type blk_type, ex_ent
   char errmsg[MAX_ERR_LENGTH];
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
-  blk_id_ndx = ex__id_lkup(exoid, blk_type, blk_id);
+  blk_id_ndx = exi_id_lkup(exoid, blk_type, blk_id);
   if (blk_id_ndx <= 0) {
     ex_get_err(NULL, NULL, &status);
 

--- a/packages/seacas/libraries/exodus/src/ex_get_glob_var_time_int.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_glob_var_time_int.c
@@ -7,7 +7,7 @@
  */
 
 #include "exodusII.h"     // for ex_err, etc
-#include "exodusII_int.h" // for ex__comp_ws, EX_FATAL, etc
+#include "exodusII_int.h" // for exi_comp_ws, EX_FATAL, etc
 
 /*!
  The function ex_get_glob_var_time() reads the values of a
@@ -71,7 +71,7 @@ error = ex_get_glob_var_time(exoid, var_index, beg_time,
 
 */
 
-int ex__get_glob_var_time(int exoid, int glob_var_index, int beg_time_step, int end_time_step,
+int exi_get_glob_var_time(int exoid, int glob_var_index, int beg_time_step, int end_time_step,
                           void *glob_var_vals)
 {
   int    status;
@@ -80,7 +80,7 @@ int ex__get_glob_var_time(int exoid, int glob_var_index, int beg_time_step, int 
   char   errmsg[MAX_ERR_LENGTH];
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -136,7 +136,7 @@ int ex__get_glob_var_time(int exoid, int glob_var_index, int beg_time_step, int 
     EX_FUNC_LEAVE(EX_WARN);
   }
 
-  if (ex__comp_ws(exoid) == 4) {
+  if (exi_comp_ws(exoid) == 4) {
     status = nc_get_vara_float(exoid, varid, start, count, glob_var_vals);
   }
   else {

--- a/packages/seacas/libraries/exodus/src/ex_get_glob_vars_int.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_glob_vars_int.c
@@ -24,13 +24,13 @@
  *****************************************************************************/
 
 #include "exodusII.h"     // for ex_err, etc
-#include "exodusII_int.h" // for ex__comp_ws, EX_FATAL, etc
+#include "exodusII_int.h" // for exi_comp_ws, EX_FATAL, etc
 
 /*!
  Internal function. Do not use in client code.
  */
 
-int ex__get_glob_vars(int exoid, int time_step, int num_glob_vars, void *glob_var_vals)
+int exi_get_glob_vars(int exoid, int time_step, int num_glob_vars, void *glob_var_vals)
 {
   int    varid;
   int    status;
@@ -38,7 +38,7 @@ int ex__get_glob_vars(int exoid, int time_step, int num_glob_vars, void *glob_va
   char   errmsg[MAX_ERR_LENGTH];
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -57,7 +57,7 @@ int ex__get_glob_vars(int exoid, int time_step, int num_glob_vars, void *glob_va
   count[0] = 1;
   count[1] = num_glob_vars;
 
-  if (ex__comp_ws(exoid) == 4) {
+  if (exi_comp_ws(exoid) == 4) {
     status = nc_get_vara_float(exoid, varid, start, count, glob_var_vals);
   }
   else {

--- a/packages/seacas/libraries/exodus/src/ex_get_group_ids.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_group_ids.c
@@ -23,7 +23,7 @@ int ex_get_group_ids(int parent_id, int *num_groups, int *group_ids)
   int status;
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(parent_id, __func__) != EX_NOERR) {
+  if (exi_check_valid_file_id(parent_id, __func__) != EX_NOERR) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 

--- a/packages/seacas/libraries/exodus/src/ex_get_id_map.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_id_map.c
@@ -35,7 +35,7 @@ int ex_get_id_map(int exoid, ex_entity_type map_type, void_int *map)
   const char *tname;
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 

--- a/packages/seacas/libraries/exodus/src/ex_get_ids.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_ids.c
@@ -29,7 +29,7 @@ static int ex_get_nonstandard_ids(int exoid, ex_entity_type obj_type, void_int *
 {
 
   int64_t               count = 0;
-  struct ex__file_item *file  = ex__find_file_item(exoid);
+  struct exi_file_item *file  = exi_find_file_item(exoid);
   if (file) {
     if (obj_type == EX_ASSEMBLY) {
       count = file->assembly_count;
@@ -100,7 +100,7 @@ int ex_get_ids(int exoid, ex_entity_type obj_type, void_int *ids)
   const char *varidobj;
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -133,7 +133,7 @@ int ex_get_ids(int exoid, ex_entity_type obj_type, void_int *ids)
   }
 
   /* Determine if there are any 'obj-type' objects */
-  if ((status = nc_inq_dimid(exoid, ex__dim_num_objects(obj_type), &varid)) != NC_NOERR) {
+  if ((status = nc_inq_dimid(exoid, exi_dim_num_objects(obj_type), &varid)) != NC_NOERR) {
     char errmsg[MAX_ERR_LENGTH];
     snprintf(errmsg, MAX_ERR_LENGTH, "Warning: no %s defined in file id %d",
              ex_name_of_object(obj_type), exoid);

--- a/packages/seacas/libraries/exodus/src/ex_get_info.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_info.c
@@ -7,7 +7,7 @@
  */
 
 #include "exodusII.h"     // for ex_err, etc
-#include "exodusII_int.h" // for EX_FATAL, ex__trim, etc
+#include "exodusII_int.h" // for EX_FATAL, exi_trim, etc
 
 /*!
   \ingroup Utilities
@@ -50,7 +50,7 @@ int ex_get_info(int exoid, char **info)
   int status;
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -98,7 +98,7 @@ int ex_get_info(int exoid, char **info)
         EX_FUNC_LEAVE(EX_FATAL);
       }
       info[i][MAX_LINE_LENGTH] = '\0';
-      ex__trim(info[i]);
+      exi_trim(info[i]);
     }
   }
   EX_FUNC_LEAVE(EX_NOERR);

--- a/packages/seacas/libraries/exodus/src/ex_get_init.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_init.c
@@ -79,7 +79,7 @@ int ex_get_init(int exoid, char *title, void_int *num_dim, void_int *num_nodes, 
   int            errval;
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 

--- a/packages/seacas/libraries/exodus/src/ex_get_init_ext.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_init_ext.c
@@ -24,7 +24,7 @@
 #include "exodusII.h"     // for ex_init_params, etc
 #include "exodusII_int.h" // for EX_FATAL, EX_NOERR, etc
 
-static void ex__get_entity_count(int exoid, ex_init_params *info)
+static void exi_get_entity_count(int exoid, ex_init_params *info)
 {
   int ndims;
   nc_inq(exoid, &ndims, NULL, NULL, NULL);
@@ -76,7 +76,7 @@ static int ex_get_dim_value(int exoid, const char *name, const char *dimension_n
 int ex_get_init_ext(int exoid, ex_init_params *info)
 {
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -109,7 +109,7 @@ int ex_get_init_ext(int exoid, ex_init_params *info)
   }
 
   /* Counts for assemblies and blobs */
-  ex__get_entity_count(exoid, info);
+  exi_get_entity_count(exoid, info);
 
   if (ex_get_dim_value(exoid, "edges", DIM_NUM_EDGE, dimid, &info->num_edge) != EX_NOERR) {
     EX_FUNC_LEAVE(EX_FATAL);
@@ -208,9 +208,9 @@ int ex_get_init_ext(int exoid, ex_init_params *info)
     info->title[0] = '\0';
   }
 
-  /* Update settings in ex__file_item struct */
+  /* Update settings in exi_file_item struct */
   {
-    struct ex__file_item *file = ex__find_file_item(exoid);
+    struct exi_file_item *file = exi_find_file_item(exoid);
     if (file) {
       file->has_nodes      = info->num_nodes > 0;
       file->has_edges      = info->num_edge > 0;

--- a/packages/seacas/libraries/exodus/src/ex_get_init_global.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_init_global.c
@@ -71,7 +71,7 @@ int ex_get_init_global(int exoid, void_int *num_nodes_g, void_int *num_elems_g,
 
   /* Check the file version information */
   int dimid;
-  if ((dimid = ne__check_file_version(exoid)) != EX_NOERR) {
+  if ((dimid = nei_check_file_version(exoid)) != EX_NOERR) {
     EX_FUNC_LEAVE(dimid);
   }
 

--- a/packages/seacas/libraries/exodus/src/ex_get_init_global.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_init_global.c
@@ -65,7 +65,7 @@ int ex_get_init_global(int exoid, void_int *num_nodes_g, void_int *num_elems_g,
                        void_int *num_side_sets_g)
 {
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 

--- a/packages/seacas/libraries/exodus/src/ex_get_init_info.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_init_info.c
@@ -39,7 +39,7 @@ int ex_get_init_info(int exoid, int *num_proc, int *num_proc_in_f, char *ftype)
   /*-----------------------------Execution begins-----------------------------*/
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -48,7 +48,7 @@ int ex_get_init_info(int exoid, int *num_proc, int *num_proc_in_f, char *ftype)
   *num_proc_in_f = 1;
 
   /* Get the file type */
-  if (ex__get_file_type(exoid, ftype) != EX_NOERR) {
+  if (exi_get_file_type(exoid, ftype) != EX_NOERR) {
     snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to get file type for file ID %d", exoid);
     ex_err_fn(exoid, __func__, errmsg, EX_LASTERR);
 

--- a/packages/seacas/libraries/exodus/src/ex_get_loadbal_param.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_loadbal_param.c
@@ -48,7 +48,7 @@ int ex_get_loadbal_param(int exoid, void_int *num_int_nodes, void_int *num_bor_n
   char errmsg[MAX_ERR_LENGTH];
   /*-----------------------------Execution begins-----------------------------*/
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -77,7 +77,7 @@ int ex_get_loadbal_param(int exoid, void_int *num_int_nodes, void_int *num_bor_n
   }
 
   /* Get the file type */
-  if (ex__get_file_type(exoid, ftype) != EX_NOERR) {
+  if (exi_get_file_type(exoid, ftype) != EX_NOERR) {
     snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: unable to find file type for file ID %d", exoid);
     ex_err_fn(exoid, __func__, errmsg, EX_LASTERR);
 

--- a/packages/seacas/libraries/exodus/src/ex_get_loadbal_param.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_loadbal_param.c
@@ -72,7 +72,7 @@ int ex_get_loadbal_param(int exoid, void_int *num_int_nodes, void_int *num_bor_n
   }
 
   /* Check the file version information */
-  if ((dimid = ne__check_file_version(exoid)) != EX_NOERR) {
+  if ((dimid = nei_check_file_version(exoid)) != EX_NOERR) {
     EX_FUNC_LEAVE(dimid);
   }
 

--- a/packages/seacas/libraries/exodus/src/ex_get_map.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_map.c
@@ -46,7 +46,7 @@ int ex_get_map(int exoid, void_int *elem_map)
   int status;
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 

--- a/packages/seacas/libraries/exodus/src/ex_get_map_param.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_map_param.c
@@ -36,7 +36,7 @@ int ex_get_map_param(int exoid, int *num_node_maps, int *num_elem_maps)
   char   errmsg[MAX_ERR_LENGTH];
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 

--- a/packages/seacas/libraries/exodus/src/ex_get_name.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_name.c
@@ -34,7 +34,7 @@ int ex_get_name(int exoid, ex_entity_type obj_type, ex_entity_id entity_id, char
 {
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -70,7 +70,7 @@ int ex_get_name(int exoid, ex_entity_type obj_type, ex_entity_id entity_id, char
     /* If this is a null entity, then 'ent_ndx' will be negative.
      * We don't care in this __func__, so make it positive and continue...
      */
-    int ent_ndx = ex__id_lkup(exoid, obj_type, entity_id);
+    int ent_ndx = exi_id_lkup(exoid, obj_type, entity_id);
     if (ent_ndx < 0) {
       ent_ndx = -ent_ndx;
     }
@@ -81,7 +81,7 @@ int ex_get_name(int exoid, ex_entity_type obj_type, ex_entity_id entity_id, char
       int api_name_size = ex_inquire_int(exoid, EX_INQ_MAX_READ_NAME_LENGTH);
       int name_size     = db_name_size < api_name_size ? db_name_size : api_name_size;
 
-      int status = ex__get_name(exoid, varid, ent_ndx - 1, name, name_size, obj_type, __func__);
+      int status = exi_get_name(exoid, varid, ent_ndx - 1, name, name_size, obj_type, __func__);
       if (status != NC_NOERR) {
         EX_FUNC_LEAVE(EX_FATAL);
       }

--- a/packages/seacas/libraries/exodus/src/ex_get_names.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_names.c
@@ -23,7 +23,7 @@
  *****************************************************************************/
 
 #include "exodusII.h"     // for ex_err, etc
-#include "exodusII_int.h" // for ex__get_dimension, EX_NOERR, etc
+#include "exodusII_int.h" // for exi_get_dimension, EX_NOERR, etc
 
 /*
  * reads the entity names from the database
@@ -32,7 +32,7 @@
 int ex_get_names(int exoid, ex_entity_type obj_type, char **names)
 {
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -75,55 +75,55 @@ int ex_get_names(int exoid, ex_entity_type obj_type, char **names)
   }
   /*  ======== BLOCKS ========= */
   case EX_EDGE_BLOCK:
-    ex__get_dimension(exoid, DIM_NUM_ED_BLK, "edge block", &num_entity, &temp, __func__);
+    exi_get_dimension(exoid, DIM_NUM_ED_BLK, "edge block", &num_entity, &temp, __func__);
     status = nc_inq_varid(exoid, VAR_NAME_ED_BLK, &varid);
     break;
   case EX_FACE_BLOCK:
-    ex__get_dimension(exoid, DIM_NUM_FA_BLK, "face block", &num_entity, &temp, __func__);
+    exi_get_dimension(exoid, DIM_NUM_FA_BLK, "face block", &num_entity, &temp, __func__);
     status = nc_inq_varid(exoid, VAR_NAME_FA_BLK, &varid);
     break;
   case EX_ELEM_BLOCK:
-    ex__get_dimension(exoid, DIM_NUM_EL_BLK, "element block", &num_entity, &temp, __func__);
+    exi_get_dimension(exoid, DIM_NUM_EL_BLK, "element block", &num_entity, &temp, __func__);
     status = nc_inq_varid(exoid, VAR_NAME_EL_BLK, &varid);
     break;
 
   /*  ======== SETS ========= */
   case EX_NODE_SET:
-    ex__get_dimension(exoid, DIM_NUM_NS, "nodeset", &num_entity, &temp, __func__);
+    exi_get_dimension(exoid, DIM_NUM_NS, "nodeset", &num_entity, &temp, __func__);
     status = nc_inq_varid(exoid, VAR_NAME_NS, &varid);
     break;
   case EX_EDGE_SET:
-    ex__get_dimension(exoid, DIM_NUM_ES, "edgeset", &num_entity, &temp, __func__);
+    exi_get_dimension(exoid, DIM_NUM_ES, "edgeset", &num_entity, &temp, __func__);
     status = nc_inq_varid(exoid, VAR_NAME_ES, &varid);
     break;
   case EX_FACE_SET:
-    ex__get_dimension(exoid, DIM_NUM_FS, "faceset", &num_entity, &temp, __func__);
+    exi_get_dimension(exoid, DIM_NUM_FS, "faceset", &num_entity, &temp, __func__);
     status = nc_inq_varid(exoid, VAR_NAME_FS, &varid);
     break;
   case EX_SIDE_SET:
-    ex__get_dimension(exoid, DIM_NUM_SS, "sideset", &num_entity, &temp, __func__);
+    exi_get_dimension(exoid, DIM_NUM_SS, "sideset", &num_entity, &temp, __func__);
     status = nc_inq_varid(exoid, VAR_NAME_SS, &varid);
     break;
   case EX_ELEM_SET:
-    ex__get_dimension(exoid, DIM_NUM_ELS, "elemset", &num_entity, &temp, __func__);
+    exi_get_dimension(exoid, DIM_NUM_ELS, "elemset", &num_entity, &temp, __func__);
     status = nc_inq_varid(exoid, VAR_NAME_ELS, &varid);
     break;
 
   /*  ======== MAPS ========= */
   case EX_NODE_MAP:
-    ex__get_dimension(exoid, DIM_NUM_NM, "node map", &num_entity, &temp, __func__);
+    exi_get_dimension(exoid, DIM_NUM_NM, "node map", &num_entity, &temp, __func__);
     status = nc_inq_varid(exoid, VAR_NAME_NM, &varid);
     break;
   case EX_EDGE_MAP:
-    ex__get_dimension(exoid, DIM_NUM_EDM, "edge map", &num_entity, &temp, __func__);
+    exi_get_dimension(exoid, DIM_NUM_EDM, "edge map", &num_entity, &temp, __func__);
     status = nc_inq_varid(exoid, VAR_NAME_EDM, &varid);
     break;
   case EX_FACE_MAP:
-    ex__get_dimension(exoid, DIM_NUM_FAM, "face map", &num_entity, &temp, __func__);
+    exi_get_dimension(exoid, DIM_NUM_FAM, "face map", &num_entity, &temp, __func__);
     status = nc_inq_varid(exoid, VAR_NAME_FAM, &varid);
     break;
   case EX_ELEM_MAP:
-    ex__get_dimension(exoid, DIM_NUM_EM, "element map", &num_entity, &temp, __func__);
+    exi_get_dimension(exoid, DIM_NUM_EM, "element map", &num_entity, &temp, __func__);
     status = nc_inq_varid(exoid, VAR_NAME_EM, &varid);
     break;
 
@@ -137,7 +137,7 @@ int ex_get_names(int exoid, ex_entity_type obj_type, char **names)
   }
 
   if (status == NC_NOERR) {
-    if ((status = ex__get_names(exoid, varid, num_entity, names, obj_type, "ex_get_names")) !=
+    if ((status = exi_get_names(exoid, varid, num_entity, names, obj_type, "ex_get_names")) !=
         EX_NOERR) {
       EX_FUNC_LEAVE(status);
     }

--- a/packages/seacas/libraries/exodus/src/ex_get_nodal_var_time_int.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_nodal_var_time_int.c
@@ -7,7 +7,7 @@
  */
 
 #include "exodusII.h"     // for ex_err, etc
-#include "exodusII_int.h" // for EX_WARN, ex__comp_ws, etc
+#include "exodusII_int.h" // for EX_WARN, exi_comp_ws, etc
 
 /*!
 The function ex_get_nodal_var_time() reads the values of a nodal
@@ -78,7 +78,7 @@ error = ex_get_var_time(exoid, EX_NODAL, var_index, node_num, beg_time,
 ~~~
 */
 
-int ex__get_nodal_var_time(int exoid, int nodal_var_index, int64_t node_number, int beg_time_step,
+int exi_get_nodal_var_time(int exoid, int nodal_var_index, int64_t node_number, int beg_time_step,
                            int end_time_step, void *nodal_var_vals)
 {
   int    status;
@@ -87,7 +87,7 @@ int ex__get_nodal_var_time(int exoid, int nodal_var_index, int64_t node_number, 
   char   errmsg[MAX_ERR_LENGTH];
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
   /* Check that times are in range */
@@ -170,7 +170,7 @@ int ex__get_nodal_var_time(int exoid, int nodal_var_index, int64_t node_number, 
     count[1] = 1;
   }
 
-  if (ex__comp_ws(exoid) == 4) {
+  if (exi_comp_ws(exoid) == 4) {
     status = nc_get_vara_float(exoid, varid, start, count, nodal_var_vals);
   }
   else {

--- a/packages/seacas/libraries/exodus/src/ex_get_node_cmap.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_node_cmap.c
@@ -38,7 +38,7 @@ int ex_get_node_cmap(int exoid, ex_entity_id map_id, void_int *node_ids, void_in
   char errmsg[MAX_ERR_LENGTH];
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 

--- a/packages/seacas/libraries/exodus/src/ex_get_node_cmap.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_node_cmap.c
@@ -53,11 +53,11 @@ int ex_get_node_cmap(int exoid, ex_entity_id map_id, void_int *node_ids, void_in
 
   /*
    * no need to check if the second index is -1 that is handled
-   * in ne__id_lkup, where the dimension must be looked up anyways
+   * in nei_id_lkup, where the dimension must be looked up anyways
    */
 
   /* Get the index of the nodal comm map with the given ID */
-  if ((map_idx = ne__id_lkup(exoid, VAR_N_COMM_IDS, varidx, map_id)) < 0) {
+  if ((map_idx = nei_id_lkup(exoid, VAR_N_COMM_IDS, varidx, map_id)) < 0) {
     snprintf(errmsg, MAX_ERR_LENGTH,
              "ERROR: failed to find nodal comm map with ID %" PRId64 " in file ID %d", map_id,
              exoid);

--- a/packages/seacas/libraries/exodus/src/ex_get_ns_param_global.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_ns_param_global.c
@@ -35,7 +35,7 @@ int ex_get_ns_param_global(int exoid, void_int *global_ids, void_int *node_cnts,
   /*-----------------------------Execution begins-----------------------------*/
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 

--- a/packages/seacas/libraries/exodus/src/ex_get_num_map.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_num_map.c
@@ -38,7 +38,7 @@ int ex_get_num_map(int exoid, ex_entity_type map_type, ex_entity_id map_id, void
   const char *dim_num_maps;
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -79,7 +79,7 @@ int ex_get_num_map(int exoid, ex_entity_type map_type, ex_entity_id map_id, void
   }
 
   /* Lookup index of map id property array */
-  id_ndx = ex__id_lkup(exoid, map_type, map_id);
+  id_ndx = exi_id_lkup(exoid, map_type, map_id);
   if (id_ndx <= 0) {
     snprintf(errmsg, MAX_ERR_LENGTH,
              "ERROR: failed to locate %s id %" PRId64 " in id variable in file id %d",
@@ -89,7 +89,7 @@ int ex_get_num_map(int exoid, ex_entity_type map_type, ex_entity_id map_id, void
   }
 
   /* inquire id's of previously defined dimensions and variables */
-  if ((status = nc_inq_varid(exoid, ex__name_of_map(map_type, id_ndx), &var_id)) != NC_NOERR) {
+  if ((status = nc_inq_varid(exoid, exi_name_of_map(map_type, id_ndx), &var_id)) != NC_NOERR) {
     snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to locate %s %" PRId64 " in file id %d",
              ex_name_of_object(map_type), map_id, exoid);
     ex_err_fn(exoid, __func__, errmsg, status);

--- a/packages/seacas/libraries/exodus/src/ex_get_object_truth_vector.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_object_truth_vector.c
@@ -15,7 +15,7 @@
  *****************************************************************************/
 
 #include "exodusII.h"     // for ex_err, etc
-#include "exodusII_int.h" // for ex__get_dimension, EX_FATAL, etc
+#include "exodusII_int.h" // for exi_get_dimension, EX_FATAL, etc
 
 /*!
  * reads the EXODUS specified variable truth vector from the database
@@ -38,62 +38,62 @@ int ex_get_object_truth_vector(int exoid, ex_entity_type obj_type, ex_entity_id 
   const char *var_name = NULL;
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
   switch (obj_type) {
   case EX_EDGE_BLOCK:
     status =
-        ex__get_dimension(exoid, DIM_NUM_EDG_VAR, "edge variables", &num_var_db, &varid, __func__);
+        exi_get_dimension(exoid, DIM_NUM_EDG_VAR, "edge variables", &num_var_db, &varid, __func__);
     statust  = nc_inq_varid(exoid, VAR_EBLK_TAB, &tabid);
     var_name = "vals_edge_var";
     ent_type = "eb";
     break;
   case EX_FACE_BLOCK:
     status =
-        ex__get_dimension(exoid, DIM_NUM_FAC_VAR, "face variables", &num_var_db, &varid, __func__);
+        exi_get_dimension(exoid, DIM_NUM_FAC_VAR, "face variables", &num_var_db, &varid, __func__);
     statust  = nc_inq_varid(exoid, VAR_FBLK_TAB, &tabid);
     var_name = "vals_face_var";
     ent_type = "fb";
     break;
   case EX_ELEM_BLOCK:
-    status   = ex__get_dimension(exoid, DIM_NUM_ELE_VAR, "element variables", &num_var_db, &varid,
+    status   = exi_get_dimension(exoid, DIM_NUM_ELE_VAR, "element variables", &num_var_db, &varid,
                                  __func__);
     statust  = nc_inq_varid(exoid, VAR_ELEM_TAB, &tabid);
     var_name = "vals_elem_var";
     ent_type = "eb";
     break;
   case EX_NODE_SET:
-    status   = ex__get_dimension(exoid, DIM_NUM_NSET_VAR, "nodeset variables", &num_var_db, &varid,
+    status   = exi_get_dimension(exoid, DIM_NUM_NSET_VAR, "nodeset variables", &num_var_db, &varid,
                                  __func__);
     statust  = nc_inq_varid(exoid, VAR_NSET_TAB, &tabid);
     var_name = "vals_nset_var";
     ent_type = "ns";
     break;
   case EX_EDGE_SET:
-    status   = ex__get_dimension(exoid, DIM_NUM_ESET_VAR, "edgeset variables", &num_var_db, &varid,
+    status   = exi_get_dimension(exoid, DIM_NUM_ESET_VAR, "edgeset variables", &num_var_db, &varid,
                                  __func__);
     statust  = nc_inq_varid(exoid, VAR_ESET_TAB, &tabid);
     var_name = "vals_eset_var";
     ent_type = "es";
     break;
   case EX_FACE_SET:
-    status   = ex__get_dimension(exoid, DIM_NUM_FSET_VAR, "faceset variables", &num_var_db, &varid,
+    status   = exi_get_dimension(exoid, DIM_NUM_FSET_VAR, "faceset variables", &num_var_db, &varid,
                                  __func__);
     statust  = nc_inq_varid(exoid, VAR_FSET_TAB, &tabid);
     var_name = "vals_fset_var";
     ent_type = "fs";
     break;
   case EX_SIDE_SET:
-    status   = ex__get_dimension(exoid, DIM_NUM_SSET_VAR, "sideset variables", &num_var_db, &varid,
+    status   = exi_get_dimension(exoid, DIM_NUM_SSET_VAR, "sideset variables", &num_var_db, &varid,
                                  __func__);
     statust  = nc_inq_varid(exoid, VAR_SSET_TAB, &tabid);
     var_name = "vals_sset_var";
     ent_type = "ss";
     break;
   case EX_ELEM_SET:
-    status   = ex__get_dimension(exoid, DIM_NUM_ELSET_VAR, "elemset variables", &num_var_db, &varid,
+    status   = exi_get_dimension(exoid, DIM_NUM_ELSET_VAR, "elemset variables", &num_var_db, &varid,
                                  __func__);
     statust  = nc_inq_varid(exoid, VAR_ELSET_TAB, &tabid);
     var_name = "vals_elset_var";
@@ -101,7 +101,7 @@ int ex_get_object_truth_vector(int exoid, ex_entity_type obj_type, ex_entity_id 
     break;
   case EX_BLOB:
     status =
-        ex__get_dimension(exoid, DIM_NUM_BLOB_VAR, "blob variables", &num_var_db, &varid, __func__);
+        exi_get_dimension(exoid, DIM_NUM_BLOB_VAR, "blob variables", &num_var_db, &varid, __func__);
     statust  = nc_inq_varid(exoid, VAR_BLOB_TAB, &tabid);
     var_name = "vals_blob_var";
     ent_type = "blob";
@@ -118,7 +118,7 @@ int ex_get_object_truth_vector(int exoid, ex_entity_type obj_type, ex_entity_id 
   }
 
   /* Determine index of entity_id in id array */
-  int ent_ndx = ex__id_lkup(exoid, obj_type, entity_id);
+  int ent_ndx = exi_id_lkup(exoid, obj_type, entity_id);
   if (ent_ndx <= 0) {
     ex_get_err(NULL, NULL, &status);
     if (status != 0) {
@@ -150,7 +150,7 @@ int ex_get_object_truth_vector(int exoid, ex_entity_type obj_type, ex_entity_id 
      */
     for (int i = 0; i < num_var; i++) {
       /* NOTE: names are 1-based */
-      if (nc_inq_varid(exoid, ex__catstr2(var_name, i + 1, ent_type, ent_ndx), &tabid) !=
+      if (nc_inq_varid(exoid, exi_catstr2(var_name, i + 1, ent_type, ent_ndx), &tabid) !=
           NC_NOERR) {
         /* variable doesn't exist; put a 0 in the truth vector */
         var_vec[i] = 0;

--- a/packages/seacas/libraries/exodus/src/ex_get_one_attr.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_one_attr.c
@@ -24,7 +24,7 @@
  *****************************************************************************/
 
 #include "exodusII.h"     // for ex_err, etc
-#include "exodusII_int.h" // for EX_FATAL, ex__get_dimension, etc
+#include "exodusII_int.h" // for EX_FATAL, exi_get_dimension, etc
 
 /*
  * reads the attributes for an edge, face, or element block
@@ -45,13 +45,13 @@ int ex_get_one_attr(int exoid, ex_entity_type obj_type, ex_entity_id obj_id, int
   const char *vattrbname;
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
   /* Determine index of obj_id in vobjids array */
   if (obj_type != EX_NODAL) {
-    obj_id_ndx = ex__id_lkup(exoid, obj_type, obj_id);
+    obj_id_ndx = exi_id_lkup(exoid, obj_type, obj_id);
     if (obj_id_ndx <= 0) {
       ex_get_err(NULL, NULL, &status);
 
@@ -127,12 +127,12 @@ int ex_get_one_attr(int exoid, ex_entity_type obj_type, ex_entity_id obj_id, int
   }
 
   /* inquire id's of previously defined dimensions  */
-  if (ex__get_dimension(exoid, dnumobjent, "entries", &num_entries_this_obj, &temp, __func__) !=
+  if (exi_get_dimension(exoid, dnumobjent, "entries", &num_entries_this_obj, &temp, __func__) !=
       NC_NOERR) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
-  if (ex__get_dimension(exoid, dnumobjatt, "attributes", &num_attr, &temp, __func__) != NC_NOERR) {
+  if (exi_get_dimension(exoid, dnumobjatt, "attributes", &num_attr, &temp, __func__) != NC_NOERR) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -163,7 +163,7 @@ int ex_get_one_attr(int exoid, ex_entity_type obj_type, ex_entity_id obj_id, int
   stride[0] = 1;
   stride[1] = num_attr;
 
-  if (ex__comp_ws(exoid) == 4) {
+  if (exi_comp_ws(exoid) == 4) {
     status = nc_get_vars_float(exoid, attrid, start, count, stride, attrib);
   }
   else {

--- a/packages/seacas/libraries/exodus/src/ex_get_partial_attr.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_partial_attr.c
@@ -28,7 +28,7 @@
  *****************************************************************************/
 
 #include "exodusII.h"     // for ex_err, etc
-#include "exodusII_int.h" // for EX_FATAL, ex__get_dimension, etc
+#include "exodusII_int.h" // for EX_FATAL, exi_get_dimension, etc
 
 /*!
  * reads the specified attribute for a subsect of a block
@@ -57,7 +57,7 @@ int ex_get_partial_attr(int exoid, ex_entity_type obj_type, ex_entity_id obj_id,
   const char *vattrbname;
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -69,7 +69,7 @@ int ex_get_partial_attr(int exoid, ex_entity_type obj_type, ex_entity_id obj_id,
 
   /* Determine index of obj_id in vobjids array */
   if (obj_type != EX_NODAL) {
-    obj_id_ndx = ex__id_lkup(exoid, obj_type, obj_id);
+    obj_id_ndx = exi_id_lkup(exoid, obj_type, obj_id);
     if (obj_id_ndx <= 0) {
       ex_get_err(NULL, NULL, &status);
 
@@ -145,7 +145,7 @@ int ex_get_partial_attr(int exoid, ex_entity_type obj_type, ex_entity_id obj_id,
   }
 
   /* inquire id's of previously defined dimensions  */
-  if (ex__get_dimension(exoid, dnumobjent, "entries", &num_entries_this_obj, &temp, __func__) !=
+  if (exi_get_dimension(exoid, dnumobjent, "entries", &num_entries_this_obj, &temp, __func__) !=
       NC_NOERR) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
@@ -159,7 +159,7 @@ int ex_get_partial_attr(int exoid, ex_entity_type obj_type, ex_entity_id obj_id,
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
-  if (ex__get_dimension(exoid, dnumobjatt, "attributes", &num_attr, &temp, __func__) != NC_NOERR) {
+  if (exi_get_dimension(exoid, dnumobjatt, "attributes", &num_attr, &temp, __func__) != NC_NOERR) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -181,7 +181,7 @@ int ex_get_partial_attr(int exoid, ex_entity_type obj_type, ex_entity_id obj_id,
     start[0] = 0;
   }
 
-  if (ex__comp_ws(exoid) == 4) {
+  if (exi_comp_ws(exoid) == 4) {
     status = nc_get_vara_float(exoid, attrid, start, count, attrib);
   }
   else {

--- a/packages/seacas/libraries/exodus/src/ex_get_partial_conn.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_partial_conn.c
@@ -29,7 +29,7 @@
  */
 
 #include "exodusII.h"     // for ex_err, ex_name_of_object, etc
-#include "exodusII_int.h" // for ex__check_valid_file_id, etc
+#include "exodusII_int.h" // for exi_check_valid_file_id, etc
 
 /*
  * reads the connectivity array for an element block
@@ -62,7 +62,7 @@ int ex_get_partial_conn(int exoid, ex_entity_type blk_type, ex_entity_id blk_id,
   const char *vfaceconn  = NULL;
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -79,7 +79,7 @@ int ex_get_partial_conn(int exoid, ex_entity_type blk_type, ex_entity_id blk_id,
 
   /* Locate index of element block id in VAR_ID_EL_BLK array */
 
-  blk_id_ndx = ex__id_lkup(exoid, blk_type, blk_id);
+  blk_id_ndx = exi_id_lkup(exoid, blk_type, blk_id);
   if (blk_id_ndx <= 0) {
     ex_get_err(NULL, NULL, &status);
 

--- a/packages/seacas/libraries/exodus/src/ex_get_partial_coord.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_partial_coord.c
@@ -27,7 +27,7 @@
  *****************************************************************************/
 
 #include "exodusII.h"     // for ex_err, etc
-#include "exodusII_int.h" // for EX_FATAL, ex__comp_ws, etc
+#include "exodusII_int.h" // for EX_FATAL, exi_comp_ws, etc
 
 /*!
  * reads the coordinates of the nodes.
@@ -62,7 +62,7 @@ int ex_get_partial_coord(int exoid, int64_t start_node_num, int64_t num_nodes, v
   char   errmsg[MAX_ERR_LENGTH];
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -90,7 +90,7 @@ int ex_get_partial_coord(int exoid, int64_t start_node_num, int64_t num_nodes, v
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
-  if (ex__get_dimension(exoid, DIM_NUM_DIM, "dimension count", &num_dim, &ndimdim, __func__) !=
+  if (exi_get_dimension(exoid, DIM_NUM_DIM, "dimension count", &num_dim, &ndimdim, __func__) !=
       NC_NOERR) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
@@ -117,7 +117,7 @@ int ex_get_partial_coord(int exoid, int64_t start_node_num, int64_t num_nodes, v
 
       if (i == 0 && x_coor != NULL) {
         which = "X";
-        if (ex__comp_ws(exoid) == 4) {
+        if (exi_comp_ws(exoid) == 4) {
           status = nc_get_vara_float(exoid, coordid, start, count, x_coor);
         }
         else {
@@ -126,7 +126,7 @@ int ex_get_partial_coord(int exoid, int64_t start_node_num, int64_t num_nodes, v
       }
       else if (i == 1 && y_coor != NULL) {
         which = "Y";
-        if (ex__comp_ws(exoid) == 4) {
+        if (exi_comp_ws(exoid) == 4) {
           status = nc_get_vara_float(exoid, coordid, start, count, y_coor);
         }
         else {
@@ -135,7 +135,7 @@ int ex_get_partial_coord(int exoid, int64_t start_node_num, int64_t num_nodes, v
       }
       else if (i == 2 && z_coor != NULL) {
         which = "Z";
-        if (ex__comp_ws(exoid) == 4) {
+        if (exi_comp_ws(exoid) == 4) {
           status = nc_get_vara_float(exoid, coordid, start, count, z_coor);
         }
         else {
@@ -211,7 +211,7 @@ int ex_get_partial_coord(int exoid, int64_t start_node_num, int64_t num_nodes, v
       }
 
       if (coor != NULL && coordid != -1) {
-        if (ex__comp_ws(exoid) == 4) {
+        if (exi_comp_ws(exoid) == 4) {
           status = nc_get_vara_float(exoid, coordid, start, count, coor);
         }
         else {

--- a/packages/seacas/libraries/exodus/src/ex_get_partial_coord_component.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_partial_coord_component.c
@@ -7,7 +7,7 @@
  */
 
 #include "exodusII.h"     // for ex_err, etc
-#include "exodusII_int.h" // for EX_FATAL, ex__comp_ws, etc
+#include "exodusII_int.h" // for EX_FATAL, exi_comp_ws, etc
 
 /*!
  * reads the coordinates of some of the nodes in the model for the specified component
@@ -38,7 +38,7 @@ int ex_get_partial_coord_component(int exoid, int64_t start_node_num, int64_t nu
   const char *which = "XYZ";
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -66,7 +66,7 @@ int ex_get_partial_coord_component(int exoid, int64_t start_node_num, int64_t nu
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
-  if (ex__get_dimension(exoid, DIM_NUM_DIM, "dimensions", &num_dim, &ndimdim, __func__) !=
+  if (exi_get_dimension(exoid, DIM_NUM_DIM, "dimensions", &num_dim, &ndimdim, __func__) !=
       NC_NOERR) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
@@ -99,7 +99,7 @@ int ex_get_partial_coord_component(int exoid, int64_t start_node_num, int64_t nu
         start[1] = 0;
       }
 
-      if (ex__comp_ws(exoid) == 4) {
+      if (exi_comp_ws(exoid) == 4) {
         status = nc_get_vara_float(exoid, coordid, start, count, coor);
       }
       else {
@@ -132,7 +132,7 @@ int ex_get_partial_coord_component(int exoid, int64_t start_node_num, int64_t nu
         EX_FUNC_LEAVE(EX_FATAL);
       }
 
-      if (ex__comp_ws(exoid) == 4) {
+      if (exi_comp_ws(exoid) == 4) {
         status = nc_get_vara_float(exoid, coordid, start, count, coor);
       }
       else {

--- a/packages/seacas/libraries/exodus/src/ex_get_partial_id_map.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_partial_id_map.c
@@ -32,7 +32,7 @@ int ex_get_partial_id_map(int exoid, ex_entity_type map_type, int64_t start_enti
   char errmsg[MAX_ERR_LENGTH];
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 

--- a/packages/seacas/libraries/exodus/src/ex_get_partial_nodal_var_int.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_partial_nodal_var_int.c
@@ -28,7 +28,7 @@
  *****************************************************************************/
 
 #include <exodusII.h>     // for ex_err, etc
-#include <exodusII_int.h> // for EX_WARN, ex__comp_ws, etc
+#include <exodusII_int.h> // for EX_WARN, exi_comp_ws, etc
 
 /*!
   \internal
@@ -37,7 +37,7 @@
   the reading of nodal variable values.
  */
 
-int ex__get_partial_nodal_var(int exoid, int time_step, int nodal_var_index, int64_t start_node,
+int exi_get_partial_nodal_var(int exoid, int time_step, int nodal_var_index, int64_t start_node,
                               int64_t num_nodes, void *var_vals)
 {
   int    varid;
@@ -46,7 +46,7 @@ int ex__get_partial_nodal_var(int exoid, int time_step, int nodal_var_index, int
   char   errmsg[MAX_ERR_LENGTH];
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -87,7 +87,7 @@ int ex__get_partial_nodal_var(int exoid, int time_step, int nodal_var_index, int
     }
   }
 
-  if (ex__comp_ws(exoid) == 4) {
+  if (exi_comp_ws(exoid) == 4) {
     status = nc_get_vara_float(exoid, varid, start, count, var_vals);
   }
   else {

--- a/packages/seacas/libraries/exodus/src/ex_get_partial_num_map.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_partial_num_map.c
@@ -41,7 +41,7 @@ int ex_get_partial_num_map(int exoid, ex_entity_type map_type, ex_entity_id map_
   const char *dim_num_maps;
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -109,7 +109,7 @@ int ex_get_partial_num_map(int exoid, ex_entity_type map_type, ex_entity_id map_
   }
 
   /* Lookup index of element map id property array */
-  id_ndx = ex__id_lkup(exoid, map_type, map_id);
+  id_ndx = exi_id_lkup(exoid, map_type, map_id);
   if (id_ndx <= 0) {
     snprintf(errmsg, MAX_ERR_LENGTH,
              "ERROR: failed to locate %s id %" PRId64 " in id variable in file id %d",
@@ -119,7 +119,7 @@ int ex_get_partial_num_map(int exoid, ex_entity_type map_type, ex_entity_id map_
   }
 
   /* inquire id's of previously defined dimensions and variables */
-  if ((status = nc_inq_varid(exoid, ex__name_of_map(map_type, id_ndx), &var_id)) != NC_NOERR) {
+  if ((status = nc_inq_varid(exoid, exi_name_of_map(map_type, id_ndx), &var_id)) != NC_NOERR) {
     snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to locate %s %" PRId64 " in file id %d",
              ex_name_of_object(map_type), map_id, exoid);
     ex_err_fn(exoid, __func__, errmsg, status);

--- a/packages/seacas/libraries/exodus/src/ex_get_partial_one_attr.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_partial_one_attr.c
@@ -28,7 +28,7 @@
  *****************************************************************************/
 
 #include "exodusII.h"     // for ex_err, etc
-#include "exodusII_int.h" // for EX_FATAL, ex__get_dimension, etc
+#include "exodusII_int.h" // for EX_FATAL, exi_get_dimension, etc
 
 /*!
  * reads the specified attribute for a subsect of a block
@@ -59,7 +59,7 @@ int ex_get_partial_one_attr(int exoid, ex_entity_type obj_type, ex_entity_id obj
   const char *vattrbname;
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -71,7 +71,7 @@ int ex_get_partial_one_attr(int exoid, ex_entity_type obj_type, ex_entity_id obj
 
   /* Determine index of obj_id in vobjids array */
   if (obj_type != EX_NODAL) {
-    obj_id_ndx = ex__id_lkup(exoid, obj_type, obj_id);
+    obj_id_ndx = exi_id_lkup(exoid, obj_type, obj_id);
     if (obj_id_ndx <= 0) {
       ex_get_err(NULL, NULL, &status);
 
@@ -147,7 +147,7 @@ int ex_get_partial_one_attr(int exoid, ex_entity_type obj_type, ex_entity_id obj
   }
 
   /* inquire id's of previously defined dimensions  */
-  if (ex__get_dimension(exoid, dnumobjent, "entries", &num_entries_this_obj, &temp, __func__) !=
+  if (exi_get_dimension(exoid, dnumobjent, "entries", &num_entries_this_obj, &temp, __func__) !=
       NC_NOERR) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
@@ -161,7 +161,7 @@ int ex_get_partial_one_attr(int exoid, ex_entity_type obj_type, ex_entity_id obj
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
-  if (ex__get_dimension(exoid, dnumobjatt, "attributes", &num_attr, &temp, __func__) != NC_NOERR) {
+  if (exi_get_dimension(exoid, dnumobjatt, "attributes", &num_attr, &temp, __func__) != NC_NOERR) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -195,7 +195,7 @@ int ex_get_partial_one_attr(int exoid, ex_entity_type obj_type, ex_entity_id obj
   if (count[0] == 0) {
     start[0] = 0;
   }
-  if (ex__comp_ws(exoid) == 4) {
+  if (exi_comp_ws(exoid) == 4) {
     status = nc_get_vars_float(exoid, attrid, start, count, stride, attrib);
   }
   else {

--- a/packages/seacas/libraries/exodus/src/ex_get_partial_set.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_partial_set.c
@@ -7,7 +7,7 @@
  */
 
 #include "exodusII.h"     // for ex_err, ex_name_of_object, etc
-#include "exodusII_int.h" // for ex__is_parallel, etc
+#include "exodusII_int.h" // for exi_is_parallel, etc
 
 /*!
  * reads a portion of the set entry list and set extra list for a single set
@@ -33,12 +33,12 @@ int ex_get_partial_set(int exoid, ex_entity_type set_type, ex_entity_id set_id, 
   char  *extraptr = NULL;
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
   /* first check if any sets are specified */
-  if ((status = nc_inq_dimid(exoid, ex__dim_num_objects(set_type), &dimid)) != NC_NOERR) {
+  if ((status = nc_inq_dimid(exoid, exi_dim_num_objects(set_type), &dimid)) != NC_NOERR) {
     snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: no %ss defined in file id %d",
              ex_name_of_object(set_type), exoid);
     ex_err_fn(exoid, __func__, errmsg, status);
@@ -46,7 +46,7 @@ int ex_get_partial_set(int exoid, ex_entity_type set_type, ex_entity_id set_id, 
   }
 
   /* Lookup index of set id in VAR_*S_IDS array */
-  set_id_ndx = ex__id_lkup(exoid, set_type, set_id);
+  set_id_ndx = exi_id_lkup(exoid, set_type, set_id);
   if (set_id_ndx <= 0) {
     ex_get_err(NULL, NULL, &status);
 
@@ -98,7 +98,7 @@ int ex_get_partial_set(int exoid, ex_entity_type set_type, ex_entity_id set_id, 
   }
 
   /* read the entry list and extra list arrays */
-  if (set_entry_list != NULL || ex__is_parallel(exoid)) {
+  if (set_entry_list != NULL || exi_is_parallel(exoid)) {
     start[0] = offset - 1;
     count[0] = num_to_get;
     if (count[0] == 0) {
@@ -122,7 +122,7 @@ int ex_get_partial_set(int exoid, ex_entity_type set_type, ex_entity_id set_id, 
   }
 
   /* only do for edge, face and side sets */
-  if (extraptr && (set_extra_list != NULL || ex__is_parallel(exoid))) {
+  if (extraptr && (set_extra_list != NULL || exi_is_parallel(exoid))) {
     if ((status = nc_inq_varid(exoid, extraptr, &extra_list_id)) != NC_NOERR) {
       snprintf(errmsg, MAX_ERR_LENGTH,
                "ERROR: failed to locate extra list for %s %" PRId64 " in file id %d",

--- a/packages/seacas/libraries/exodus/src/ex_get_partial_set_dist_fact.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_partial_set_dist_fact.c
@@ -7,7 +7,7 @@
  */
 
 #include "exodusII.h"     // for ex_err, ex_name_of_object, etc
-#include "exodusII_int.h" // for ex__check_valid_file_id, etc
+#include "exodusII_int.h" // for exi_check_valid_file_id, etc
 
 /*!
  * reads the distribution factors for a single set
@@ -24,12 +24,12 @@ int ex_get_partial_set_dist_fact(int exoid, ex_entity_type set_type, ex_entity_i
   char  *factptr = NULL;
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
   /* first check if any sets are specified */
-  if ((status = nc_inq_dimid(exoid, ex__dim_num_objects(set_type), &dimid)) != NC_NOERR) {
+  if ((status = nc_inq_dimid(exoid, exi_dim_num_objects(set_type), &dimid)) != NC_NOERR) {
     snprintf(errmsg, MAX_ERR_LENGTH, "Warning: no %s sets stored in file id %d",
              ex_name_of_object(set_type), exoid);
     ex_err_fn(exoid, __func__, errmsg, status);
@@ -37,7 +37,7 @@ int ex_get_partial_set_dist_fact(int exoid, ex_entity_type set_type, ex_entity_i
   }
 
   /* Lookup index of set id in VAR_*S_IDS array */
-  set_id_ndx = ex__id_lkup(exoid, set_type, set_id);
+  set_id_ndx = exi_id_lkup(exoid, set_type, set_id);
   if (set_id_ndx <= 0) {
     ex_get_err(NULL, NULL, &status);
 
@@ -99,7 +99,7 @@ int ex_get_partial_set_dist_fact(int exoid, ex_entity_type set_type, ex_entity_i
   if (count[0] == 0) {
     start[0] = 0;
   }
-  if (ex__comp_ws(exoid) == 4) {
+  if (exi_comp_ws(exoid) == 4) {
     status = nc_get_vara_float(exoid, dist_id, start, count, set_dist_fact);
   }
   else {

--- a/packages/seacas/libraries/exodus/src/ex_get_partial_var.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_partial_var.c
@@ -7,7 +7,7 @@
  */
 
 #include "exodusII.h"     // for ex_err, ex_name_of_object, etc
-#include "exodusII_int.h" // for ex__check_valid_file_id, etc
+#include "exodusII_int.h" // for exi_check_valid_file_id, etc
 
 /*
  * reads the values of a single element variable for one element block at
@@ -52,21 +52,21 @@ int ex_get_partial_var(int exoid, int time_step, ex_entity_type var_type, int va
     /* FIXME: Special case: ignore obj_id, possible large_file complications,
      * etc. */
     status =
-        ex__get_partial_nodal_var(exoid, time_step, var_index, start_index, num_entities, var_vals);
+        exi_get_partial_nodal_var(exoid, time_step, var_index, start_index, num_entities, var_vals);
     EX_FUNC_LEAVE(status);
   }
   if (var_type == EX_GLOBAL) {
     /* FIXME: Special case: all vars stored in 2-D single array. */
-    status = ex__get_glob_vars(exoid, time_step, num_entities, var_vals);
+    status = exi_get_glob_vars(exoid, time_step, num_entities, var_vals);
     EX_FUNC_LEAVE(status);
   }
 
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
   /* Determine index of obj_id in VAR_ID_EL_BLK array */
-  obj_id_ndx = ex__id_lkup(exoid, var_type, obj_id);
+  obj_id_ndx = exi_id_lkup(exoid, var_type, obj_id);
   if (obj_id_ndx <= 0) {
     ex_get_err(NULL, NULL, &status);
 
@@ -88,7 +88,7 @@ int ex_get_partial_var(int exoid, int time_step, ex_entity_type var_type, int va
 
   /* inquire previously defined variable */
 
-  if ((status = nc_inq_varid(exoid, ex__name_var_of_object(var_type, var_index, obj_id_ndx),
+  if ((status = nc_inq_varid(exoid, exi_name_var_of_object(var_type, var_index, obj_id_ndx),
                              &varid)) != NC_NOERR) {
     snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to locate %s %" PRId64 " var %d in file id %d",
              ex_name_of_object(var_type), obj_id, var_index, exoid);
@@ -106,7 +106,7 @@ int ex_get_partial_var(int exoid, int time_step, ex_entity_type var_type, int va
     start[1] = 0;
   }
 
-  if (ex__comp_ws(exoid) == 4) {
+  if (exi_comp_ws(exoid) == 4) {
     status = nc_get_vara_float(exoid, varid, start, count, var_vals);
   }
   else {

--- a/packages/seacas/libraries/exodus/src/ex_get_processor_elem_maps.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_processor_elem_maps.c
@@ -37,12 +37,12 @@ int ex_get_processor_elem_maps(int exoid, void_int *elem_mapi, void_int *elem_ma
   char errmsg[MAX_ERR_LENGTH];
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
   /* Get the file type */
-  if (ex__get_file_type(exoid, ftype) != EX_NOERR) {
+  if (exi_get_file_type(exoid, ftype) != EX_NOERR) {
     snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: unable to find file type for file ID %d", exoid);
     ex_err_fn(exoid, __func__, errmsg, EX_LASTERR);
 

--- a/packages/seacas/libraries/exodus/src/ex_get_processor_node_maps.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_processor_node_maps.c
@@ -42,12 +42,12 @@ int ex_get_processor_node_maps(int exoid, void_int *node_mapi, void_int *node_ma
   /*-----------------------------Execution begins-----------------------------*/
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
   /* Get the file type */
-  if (ex__get_file_type(exoid, ftype) != EX_NOERR) {
+  if (exi_get_file_type(exoid, ftype) != EX_NOERR) {
     snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: unable to find file type for file ID %d", exoid);
     ex_err_fn(exoid, __func__, errmsg, EX_LASTERR);
     EX_FUNC_LEAVE(EX_FATAL);

--- a/packages/seacas/libraries/exodus/src/ex_get_prop.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_prop.c
@@ -65,7 +65,7 @@ int ex_get_prop(int exoid, ex_entity_type obj_type, ex_entity_id obj_id, const c
   char errmsg[MAX_ERR_LENGTH];
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -123,9 +123,9 @@ int ex_get_prop(int exoid, ex_entity_type obj_type, ex_entity_id obj_id, const c
   }
 
   /* find index into property array using obj_id; read value from property */
-  /* array at proper index; ex__id_lkup returns an index that is 1-based,   */
+  /* array at proper index; exi_id_lkup returns an index that is 1-based,   */
   /* but netcdf expects 0-based arrays so subtract 1                       */
-  status = ex__id_lkup(exoid, obj_type, obj_id);
+  status = exi_id_lkup(exoid, obj_type, obj_id);
   if (status > 0) {
     start[0] = status - 1;
   }

--- a/packages/seacas/libraries/exodus/src/ex_get_prop_array.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_prop_array.c
@@ -94,7 +94,7 @@ int ex_get_prop_array(int exoid, ex_entity_type obj_type, const char *prop_name,
   char errmsg[MAX_ERR_LENGTH];
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 

--- a/packages/seacas/libraries/exodus/src/ex_get_prop_names.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_prop_names.c
@@ -78,7 +78,7 @@ for (i=0; i < num_props; i++) {
 int ex_get_prop_names(int exoid, ex_entity_type obj_type, char **prop_names)
 {
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 

--- a/packages/seacas/libraries/exodus/src/ex_get_qa.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_qa.c
@@ -7,7 +7,7 @@
  */
 
 #include "exodusII.h"     // for ex_err, etc
-#include "exodusII_int.h" // for EX_FATAL, ex__trim, etc
+#include "exodusII_int.h" // for EX_FATAL, exi_trim, etc
 
 /*!
 \ingroup Utilities
@@ -56,7 +56,7 @@ error = ex_get_qa (exoid, qa_record);
 int ex_get_qa(int exoid, char *qa_record[][4])
 {
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -104,7 +104,7 @@ int ex_get_qa(int exoid, char *qa_record[][4])
           EX_FUNC_LEAVE(EX_FATAL);
         }
         qa_record[i][j][MAX_STR_LENGTH] = '\0';
-        ex__trim(qa_record[i][j]);
+        exi_trim(qa_record[i][j]);
       }
     }
   }

--- a/packages/seacas/libraries/exodus/src/ex_get_reduction_variable_name.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_reduction_variable_name.c
@@ -23,7 +23,7 @@ int ex_get_reduction_variable_name(int exoid, ex_entity_type obj_type, int var_n
   const char *vname = NULL;
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -61,7 +61,7 @@ int ex_get_reduction_variable_name(int exoid, ex_entity_type obj_type, int var_n
     int api_name_size = ex_inquire_int(exoid, EX_INQ_MAX_READ_NAME_LENGTH);
     int name_size     = db_name_size < api_name_size ? db_name_size : api_name_size;
 
-    status = ex__get_name(exoid, varid, var_num - 1, var_name, name_size, obj_type, __func__);
+    status = exi_get_name(exoid, varid, var_num - 1, var_name, name_size, obj_type, __func__);
     if (status != NC_NOERR) {
       EX_FUNC_LEAVE(EX_FATAL);
     }

--- a/packages/seacas/libraries/exodus/src/ex_get_reduction_variable_names.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_reduction_variable_names.c
@@ -71,7 +71,7 @@ int ex_get_reduction_variable_names(int exoid, ex_entity_type obj_type, int num_
   const char *vvarname;
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -103,7 +103,7 @@ int ex_get_reduction_variable_names(int exoid, ex_entity_type obj_type, int num_
   }
 
   /* read the variable names */
-  status = ex__get_names(exoid, varid, num_vars, var_names, obj_type, __func__);
+  status = exi_get_names(exoid, varid, num_vars, var_names, obj_type, __func__);
   if (status != NC_NOERR) {
     EX_FUNC_LEAVE(EX_FATAL);
   }

--- a/packages/seacas/libraries/exodus/src/ex_get_reduction_variable_param.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_reduction_variable_param.c
@@ -62,7 +62,7 @@ int ex_get_reduction_variable_param(int exoid, ex_entity_type obj_type, int *num
   int         status;
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 

--- a/packages/seacas/libraries/exodus/src/ex_get_reduction_vars.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_reduction_vars.c
@@ -7,7 +7,7 @@
  */
 
 #include "exodusII.h"     // for ex_err, ex_name_of_object, etc
-#include "exodusII_int.h" // for ex__check_valid_file_id, etc
+#include "exodusII_int.h" // for exi_check_valid_file_id, etc
 
 /*!
 \ingroup ResultsData
@@ -72,18 +72,18 @@ int ex_get_reduction_vars(int exoid, int time_step, ex_entity_type var_type, ex_
   char   errmsg[MAX_ERR_LENGTH];
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
   if (var_type == EX_GLOBAL) {
     /* FIXME: Special case: all vars stored in 2-D single array. */
-    status = ex__get_glob_vars(exoid, time_step, num_variables, var_vals);
+    status = exi_get_glob_vars(exoid, time_step, num_variables, var_vals);
     EX_FUNC_LEAVE(status);
   }
 
   /* Determine index of obj_id in VAR_ID_XXX array */
-  obj_id_ndx = ex__id_lkup(exoid, var_type, obj_id);
+  obj_id_ndx = exi_id_lkup(exoid, var_type, obj_id);
   if (obj_id_ndx <= 0) {
     ex_get_err(NULL, NULL, &status);
 
@@ -96,7 +96,7 @@ int ex_get_reduction_vars(int exoid, int time_step, ex_entity_type var_type, ex_
   }
 
   /* inquire previously defined variable */
-  if ((status = nc_inq_varid(exoid, ex__name_red_var_of_object(var_type, obj_id_ndx), &varid)) !=
+  if ((status = nc_inq_varid(exoid, exi_name_red_var_of_object(var_type, obj_id_ndx), &varid)) !=
       NC_NOERR) {
     snprintf(errmsg, MAX_ERR_LENGTH,
              "Warning: no reduction variables for %s %" PRId64 " in file id %d",
@@ -112,7 +112,7 @@ int ex_get_reduction_vars(int exoid, int time_step, ex_entity_type var_type, ex_
   count[0] = 1;
   count[1] = num_variables;
 
-  if (ex__comp_ws(exoid) == 4) {
+  if (exi_comp_ws(exoid) == 4) {
     status = nc_get_vara_float(exoid, varid, start, count, var_vals);
   }
   else {

--- a/packages/seacas/libraries/exodus/src/ex_get_set.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_set.c
@@ -7,7 +7,7 @@
  */
 
 #include "exodusII.h"     // for ex_err, ex_name_of_object, etc
-#include "exodusII_int.h" // for ex__check_valid_file_id, etc
+#include "exodusII_int.h" // for exi_check_valid_file_id, etc
 
 /*!
  * reads the set entry list and set extra list for a single set
@@ -31,12 +31,12 @@ int ex_get_set(int exoid, ex_entity_type set_type, ex_entity_id set_id, void_int
   char *extraptr = NULL;
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
   /* first check if any sets are specified */
-  if ((status = nc_inq_dimid(exoid, ex__dim_num_objects(set_type), &dimid)) != NC_NOERR) {
+  if ((status = nc_inq_dimid(exoid, exi_dim_num_objects(set_type), &dimid)) != NC_NOERR) {
     snprintf(errmsg, MAX_ERR_LENGTH, "Warning: no %ss stored in file id %d",
              ex_name_of_object(set_type), exoid);
     ex_err_fn(exoid, __func__, errmsg, status);
@@ -44,7 +44,7 @@ int ex_get_set(int exoid, ex_entity_type set_type, ex_entity_id set_id, void_int
   }
 
   /* Lookup index of set id in VAR_*S_IDS array */
-  set_id_ndx = ex__id_lkup(exoid, set_type, set_id);
+  set_id_ndx = exi_id_lkup(exoid, set_type, set_id);
   if (set_id_ndx <= 0) {
     ex_get_err(NULL, NULL, &status);
 

--- a/packages/seacas/libraries/exodus/src/ex_get_set_dist_fact.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_set_dist_fact.c
@@ -40,12 +40,12 @@ int ex_get_set_dist_fact(int exoid, ex_entity_type set_type, ex_entity_id set_id
   char *factptr = NULL;
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
   /* first check if any sets are specified */
-  if ((status = nc_inq_dimid(exoid, ex__dim_num_objects(set_type), &dimid)) != NC_NOERR) {
+  if ((status = nc_inq_dimid(exoid, exi_dim_num_objects(set_type), &dimid)) != NC_NOERR) {
     snprintf(errmsg, MAX_ERR_LENGTH, "Warning: no %s sets stored in file id %d",
              ex_name_of_object(set_type), exoid);
     ex_err_fn(exoid, __func__, errmsg, status);
@@ -53,7 +53,7 @@ int ex_get_set_dist_fact(int exoid, ex_entity_type set_type, ex_entity_id set_id
   }
 
   /* Lookup index of set id in VAR_*S_IDS array */
-  set_id_ndx = ex__id_lkup(exoid, set_type, set_id);
+  set_id_ndx = exi_id_lkup(exoid, set_type, set_id);
   if (set_id_ndx <= 0) {
     ex_get_err(NULL, NULL, &status);
 
@@ -110,7 +110,7 @@ int ex_get_set_dist_fact(int exoid, ex_entity_type set_type, ex_entity_id set_id
   }
 
   /* read in the distribution factors array */
-  if (ex__comp_ws(exoid) == 4) {
+  if (exi_comp_ws(exoid) == 4) {
     status = nc_get_var_float(exoid, dist_id, set_dist_fact);
   }
   else {

--- a/packages/seacas/libraries/exodus/src/ex_get_set_param.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_set_param.c
@@ -45,7 +45,7 @@ int ex_get_set_param(int exoid, ex_entity_type set_type, ex_entity_id set_id,
   char  *numdfptr    = NULL;
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -66,7 +66,7 @@ int ex_get_set_param(int exoid, ex_entity_type set_type, ex_entity_id set_id,
     }
   }
   /* first check if any sets are specified */
-  if ((status = nc_inq_dimid(exoid, ex__dim_num_objects(set_type), &dimid)) != NC_NOERR) {
+  if ((status = nc_inq_dimid(exoid, exi_dim_num_objects(set_type), &dimid)) != NC_NOERR) {
     snprintf(errmsg, MAX_ERR_LENGTH, "Warning: no %ss stored in file id %d",
              ex_name_of_object(set_type), exoid);
     ex_err_fn(exoid, __func__, errmsg, status);
@@ -74,7 +74,7 @@ int ex_get_set_param(int exoid, ex_entity_type set_type, ex_entity_id set_id,
   }
 
   /* Lookup index of set id in VAR_*S_IDS array */
-  set_id_ndx = ex__id_lkup(exoid, set_type, set_id);
+  set_id_ndx = exi_id_lkup(exoid, set_type, set_id);
   if (set_id_ndx <= 0) {
     ex_get_err(NULL, NULL, &status);
 
@@ -114,7 +114,7 @@ int ex_get_set_param(int exoid, ex_entity_type set_type, ex_entity_id set_id,
   }
 
   /* inquire values of dimension for number of entities in set */
-  if (ex__get_dimension(exoid, numentryptr, "entries", &lnum_entry_in_set, &dimid, __func__) !=
+  if (exi_get_dimension(exoid, numentryptr, "entries", &lnum_entry_in_set, &dimid, __func__) !=
       NC_NOERR) {
     EX_FUNC_LEAVE(EX_FATAL);
   }

--- a/packages/seacas/libraries/exodus/src/ex_get_sets.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_sets.c
@@ -7,7 +7,7 @@
  */
 
 #include "exodusII.h"     // for ex_set, EX_FATAL, EX_NOERR, etc
-#include "exodusII_int.h" // for ex__check_valid_file_id
+#include "exodusII_int.h" // for exi_check_valid_file_id
 
 int ex_get_sets(int exoid, size_t set_count, struct ex_set *sets)
 {
@@ -16,7 +16,7 @@ int ex_get_sets(int exoid, size_t set_count, struct ex_set *sets)
   int    stat;
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 

--- a/packages/seacas/libraries/exodus/src/ex_get_side_set_node_count.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_side_set_node_count.c
@@ -37,13 +37,13 @@ int ex_get_side_set_node_count(int exoid, ex_entity_id side_set_id, int *side_se
   void_int *side_set_side_list = NULL;
   size_t    elem_ctr;
 
-  struct ex__elem_blk_parm *elem_blk_parms = NULL;
+  struct exi_elem_blk_parm *elem_blk_parms = NULL;
 
   char errmsg[MAX_ERR_LENGTH];
   int  err_stat = EX_NOERR;
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -64,7 +64,7 @@ int ex_get_side_set_node_count(int exoid, ex_entity_id side_set_id, int *side_se
   }
 
   /* Lookup index of side set id in VAR_SS_IDS array */
-  if (ex__id_lkup(exoid, EX_SIDE_SET, side_set_id) <= 0) {
+  if (exi_id_lkup(exoid, EX_SIDE_SET, side_set_id) <= 0) {
     ;
   }
   ex_get_err(NULL, NULL, &status);
@@ -174,7 +174,7 @@ int ex_get_side_set_node_count(int exoid, ex_entity_id side_set_id, int *side_se
       for (i = 0; i < tot_num_ss_elem; i++) {
         elems[i] = i; /* init index array to current position */
       }
-      ex__iqsort64(side_set_elem_list, elems, tot_num_ss_elem);
+      exi_iqsort64(side_set_elem_list, elems, tot_num_ss_elem);
     }
     else {
       /* Sort side set element list into index array  - non-destructive */
@@ -182,7 +182,7 @@ int ex_get_side_set_node_count(int exoid, ex_entity_id side_set_id, int *side_se
       for (i = 0; i < tot_num_ss_elem; i++) {
         elems[i] = i; /* init index array to current position */
       }
-      ex__iqsort(side_set_elem_list, elems, tot_num_ss_elem);
+      exi_iqsort(side_set_elem_list, elems, tot_num_ss_elem);
     }
   }
 
@@ -213,7 +213,7 @@ int ex_get_side_set_node_count(int exoid, ex_entity_id side_set_id, int *side_se
   }
 
   /* Allocate space for the element block params */
-  if (!(elem_blk_parms = malloc(num_elem_blks * sizeof(struct ex__elem_blk_parm)))) {
+  if (!(elem_blk_parms = malloc(num_elem_blks * sizeof(struct exi_elem_blk_parm)))) {
     snprintf(errmsg, MAX_ERR_LENGTH,
              "ERROR: failed to allocate space for element block params "
              "for file id %d",
@@ -233,7 +233,7 @@ int ex_get_side_set_node_count(int exoid, ex_entity_id side_set_id, int *side_se
       id = ((int *)elem_blk_ids)[i];
     }
 
-    err_stat = ex__get_block_param(exoid, id, ndim, &elem_blk_parms[i]);
+    err_stat = exi_get_block_param(exoid, id, ndim, &elem_blk_parms[i]);
     if (err_stat != EX_NOERR) {
       goto cleanup;
     }

--- a/packages/seacas/libraries/exodus/src/ex_get_side_set_node_list.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_side_set_node_list.c
@@ -77,7 +77,7 @@ int ex_get_side_set_node_list(int exoid, ex_entity_id side_set_id, void_int *sid
   int err_stat = EX_NOERR;
   int status;
 
-  struct ex__elem_blk_parm *elem_blk_parms = NULL;
+  struct exi_elem_blk_parm *elem_blk_parms = NULL;
 
   /* side to node translation tables -
      These tables are used to look up the side number based on the
@@ -91,7 +91,7 @@ int ex_get_side_set_node_list(int exoid, ex_entity_id side_set_id, void_int *sid
   char errmsg[MAX_ERR_LENGTH];
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -113,7 +113,7 @@ int ex_get_side_set_node_list(int exoid, ex_entity_id side_set_id, void_int *sid
   }
 
   /* Lookup index of side set id in VAR_SS_IDS array */
-  if (ex__id_lkup(exoid, EX_SIDE_SET, side_set_id) <= 0) {
+  if (exi_id_lkup(exoid, EX_SIDE_SET, side_set_id) <= 0) {
     ex_get_err(NULL, NULL, &status);
 
     if (status != 0) {
@@ -231,7 +231,7 @@ int ex_get_side_set_node_list(int exoid, ex_entity_id side_set_id, void_int *sid
     for (i = 0; i < tot_num_ss_elem; i++) {
       elems[i] = i; /* init index array to current position */
     }
-    ex__iqsort64(side_set_elem_list, ss_elem_ndx, tot_num_ss_elem);
+    exi_iqsort64(side_set_elem_list, ss_elem_ndx, tot_num_ss_elem);
   }
   else {
     /* Sort side set element list into index array  - non-destructive */
@@ -239,7 +239,7 @@ int ex_get_side_set_node_list(int exoid, ex_entity_id side_set_id, void_int *sid
     for (i = 0; i < tot_num_ss_elem; i++) {
       elems[i] = i; /* init index array to current position */
     }
-    ex__iqsort(side_set_elem_list, ss_elem_ndx, tot_num_ss_elem);
+    exi_iqsort(side_set_elem_list, ss_elem_ndx, tot_num_ss_elem);
   }
 
   /* Allocate space for the element block ids */
@@ -259,7 +259,7 @@ int ex_get_side_set_node_list(int exoid, ex_entity_id side_set_id, void_int *sid
   }
 
   /* Allocate space for the element block params */
-  if (!(elem_blk_parms = malloc(num_elem_blks * sizeof(struct ex__elem_blk_parm)))) {
+  if (!(elem_blk_parms = malloc(num_elem_blks * sizeof(struct exi_elem_blk_parm)))) {
     snprintf(errmsg, MAX_ERR_LENGTH,
              "ERROR: failed to allocate space for element block params "
              "for file id %d",
@@ -279,7 +279,7 @@ int ex_get_side_set_node_list(int exoid, ex_entity_id side_set_id, void_int *sid
       id = ((int *)elem_blk_ids)[i];
     }
 
-    err_stat = ex__get_block_param(exoid, id, ndim, &elem_blk_parms[i]);
+    err_stat = exi_get_block_param(exoid, id, ndim, &elem_blk_parms[i]);
     if (err_stat != EX_NOERR) {
       goto cleanup;
     }

--- a/packages/seacas/libraries/exodus/src/ex_get_side_set_node_list_len.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_side_set_node_list_len.c
@@ -51,12 +51,12 @@ int ex_get_side_set_node_list_len(int exoid, ex_entity_id side_set_id,
   int err_stat = EX_NOERR;
   int status;
 
-  struct ex__elem_blk_parm *elem_blk_parms = NULL;
+  struct exi_elem_blk_parm *elem_blk_parms = NULL;
 
   char errmsg[MAX_ERR_LENGTH];
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -192,13 +192,13 @@ int ex_get_side_set_node_list_len(int exoid, ex_entity_id side_set_id,
     for (i = 0; i < tot_num_ss_elem; i++) {
       ss_elem_ndx_64[i] = i; /* init index array to current position */
     }
-    ex__iqsort64(side_set_elem_list, ss_elem_ndx_64, tot_num_ss_elem);
+    exi_iqsort64(side_set_elem_list, ss_elem_ndx_64, tot_num_ss_elem);
   }
   else {
     for (i = 0; i < tot_num_ss_elem; i++) {
       ss_elem_ndx[i] = i; /* init index array to current position */
     }
-    ex__iqsort(side_set_elem_list, ss_elem_ndx, tot_num_ss_elem);
+    exi_iqsort(side_set_elem_list, ss_elem_ndx, tot_num_ss_elem);
   }
 
   /* Allocate space for the element block ids */
@@ -227,7 +227,7 @@ int ex_get_side_set_node_list_len(int exoid, ex_entity_id side_set_id,
   }
 
   /* Allocate space for the element block params */
-  if (!(elem_blk_parms = calloc(num_elem_blks, sizeof(struct ex__elem_blk_parm)))) {
+  if (!(elem_blk_parms = calloc(num_elem_blks, sizeof(struct exi_elem_blk_parm)))) {
     snprintf(errmsg, MAX_ERR_LENGTH,
              "ERROR: failed to allocate space for element block params "
              "for file id %d",
@@ -247,7 +247,7 @@ int ex_get_side_set_node_list_len(int exoid, ex_entity_id side_set_id,
       id = ((int *)elem_blk_ids)[i];
     }
 
-    err_stat = ex__get_block_param(exoid, id, ndim, &elem_blk_parms[i]);
+    err_stat = exi_get_block_param(exoid, id, ndim, &elem_blk_parms[i]);
     if (err_stat != EX_NOERR) {
       goto cleanup;
     }

--- a/packages/seacas/libraries/exodus/src/ex_get_ss_param_global.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_ss_param_global.c
@@ -35,7 +35,7 @@ int ex_get_ss_param_global(int exoid, void_int *global_ids, void_int *side_cnts,
   /*-----------------------------Execution begins-----------------------------*/
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 

--- a/packages/seacas/libraries/exodus/src/ex_get_time.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_time.c
@@ -7,7 +7,7 @@
  */
 
 #include "exodusII.h"     // for ex_err, etc
-#include "exodusII_int.h" // for EX_FATAL, ex__comp_ws, etc
+#include "exodusII_int.h" // for EX_FATAL, exi_comp_ws, etc
 
 /*!
 \ingroup ResultsData
@@ -54,11 +54,11 @@ int ex_get_time(int exoid, int time_step, void *time_value)
   int                   varid;
   size_t                start[1];
   char                  errmsg[MAX_ERR_LENGTH];
-  struct ex__file_item *file = NULL;
+  struct exi_file_item *file = NULL;
 
   EX_FUNC_ENTER();
 
-  file = ex__find_file_item(exoid);
+  file = exi_find_file_item(exoid);
   if (!file) {
     snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: unknown file id %d.", exoid);
     ex_err_fn(exoid, __func__, errmsg, EX_BADFILEID);
@@ -105,7 +105,7 @@ int ex_get_time(int exoid, int time_step, void *time_value)
   /* read time value */
   start[0] = --time_step;
 
-  if (ex__comp_ws(exoid) == 4) {
+  if (exi_comp_ws(exoid) == 4) {
     status = nc_get_var1_float(exoid, varid, start, time_value);
   }
   else {

--- a/packages/seacas/libraries/exodus/src/ex_get_truth_table.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_truth_table.c
@@ -22,7 +22,7 @@
  *****************************************************************************/
 
 #include "exodusII.h"     // for ex_err, etc
-#include "exodusII_int.h" // for ex__get_dimension, EX_FATAL, etc
+#include "exodusII_int.h" // for exi_get_dimension, EX_FATAL, etc
 
 /*!
  * \ingroup ResultsData
@@ -49,62 +49,62 @@ int ex_get_truth_table(int exoid, ex_entity_type obj_type, int num_blk, int num_
   const char *var_name = NULL;
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
   switch (obj_type) {
   case EX_EDGE_BLOCK:
     status =
-        ex__get_dimension(exoid, DIM_NUM_EDG_VAR, "edge variables", &num_var_db, &varid, __func__);
+        exi_get_dimension(exoid, DIM_NUM_EDG_VAR, "edge variables", &num_var_db, &varid, __func__);
     status1  = nc_inq_varid(exoid, VAR_EBLK_TAB, &tabid);
     var_name = "vals_edge_var";
     ent_type = "eb";
     break;
   case EX_FACE_BLOCK:
     status =
-        ex__get_dimension(exoid, DIM_NUM_FAC_VAR, "face variables", &num_var_db, &varid, __func__);
+        exi_get_dimension(exoid, DIM_NUM_FAC_VAR, "face variables", &num_var_db, &varid, __func__);
     status1  = nc_inq_varid(exoid, VAR_FBLK_TAB, &tabid);
     var_name = "vals_face_var";
     ent_type = "fb";
     break;
   case EX_ELEM_BLOCK:
-    status   = ex__get_dimension(exoid, DIM_NUM_ELE_VAR, "element variables", &num_var_db, &varid,
+    status   = exi_get_dimension(exoid, DIM_NUM_ELE_VAR, "element variables", &num_var_db, &varid,
                                  __func__);
     status1  = nc_inq_varid(exoid, VAR_ELEM_TAB, &tabid);
     var_name = "vals_elem_var";
     ent_type = "eb";
     break;
   case EX_NODE_SET:
-    status   = ex__get_dimension(exoid, DIM_NUM_NSET_VAR, "nodeset variables", &num_var_db, &varid,
+    status   = exi_get_dimension(exoid, DIM_NUM_NSET_VAR, "nodeset variables", &num_var_db, &varid,
                                  __func__);
     status1  = nc_inq_varid(exoid, VAR_NSET_TAB, &tabid);
     var_name = "vals_nset_var";
     ent_type = "ns";
     break;
   case EX_EDGE_SET:
-    status   = ex__get_dimension(exoid, DIM_NUM_ESET_VAR, "edgeset variables", &num_var_db, &varid,
+    status   = exi_get_dimension(exoid, DIM_NUM_ESET_VAR, "edgeset variables", &num_var_db, &varid,
                                  __func__);
     status1  = nc_inq_varid(exoid, VAR_ESET_TAB, &tabid);
     var_name = "vals_eset_var";
     ent_type = "es";
     break;
   case EX_FACE_SET:
-    status   = ex__get_dimension(exoid, DIM_NUM_FSET_VAR, "faceset variables", &num_var_db, &varid,
+    status   = exi_get_dimension(exoid, DIM_NUM_FSET_VAR, "faceset variables", &num_var_db, &varid,
                                  __func__);
     status1  = nc_inq_varid(exoid, VAR_FSET_TAB, &tabid);
     var_name = "vals_fset_var";
     ent_type = "fs";
     break;
   case EX_SIDE_SET:
-    status   = ex__get_dimension(exoid, DIM_NUM_SSET_VAR, "sideset variables", &num_var_db, &varid,
+    status   = exi_get_dimension(exoid, DIM_NUM_SSET_VAR, "sideset variables", &num_var_db, &varid,
                                  __func__);
     status1  = nc_inq_varid(exoid, VAR_SSET_TAB, &tabid);
     var_name = "vals_sset_var";
     ent_type = "ss";
     break;
   case EX_ELEM_SET:
-    status   = ex__get_dimension(exoid, DIM_NUM_ELSET_VAR, "elemset variables", &num_var_db, &varid,
+    status   = exi_get_dimension(exoid, DIM_NUM_ELSET_VAR, "elemset variables", &num_var_db, &varid,
                                  __func__);
     status1  = nc_inq_varid(exoid, VAR_ELSET_TAB, &tabid);
     var_name = "vals_elset_var";
@@ -112,7 +112,7 @@ int ex_get_truth_table(int exoid, ex_entity_type obj_type, int num_blk, int num_
     break;
   case EX_BLOB:
     status =
-        ex__get_dimension(exoid, DIM_NUM_BLOB_VAR, "blob variables", &num_var_db, &varid, __func__);
+        exi_get_dimension(exoid, DIM_NUM_BLOB_VAR, "blob variables", &num_var_db, &varid, __func__);
     status1  = nc_inq_varid(exoid, VAR_BLOB_TAB, &tabid);
     var_name = "vals_blob_var";
     ent_type = "blob";
@@ -133,7 +133,7 @@ int ex_get_truth_table(int exoid, ex_entity_type obj_type, int num_blk, int num_
     num_entity = ex_inquire_int(exoid, EX_INQ_BLOB);
   }
   else {
-    status = ex__get_dimension(exoid, ex__dim_num_objects(obj_type), ex_name_of_object(obj_type),
+    status = exi_get_dimension(exoid, exi_dim_num_objects(obj_type), ex_name_of_object(obj_type),
                                &num_entity, &dimid, __func__);
     if (status != NC_NOERR) {
       EX_FUNC_LEAVE(EX_FATAL);
@@ -161,7 +161,7 @@ int ex_get_truth_table(int exoid, ex_entity_type obj_type, int num_blk, int num_
 
       for (int i = 0; i < num_var; i++) {
         /* NOTE: names are 1-based */
-        if (nc_inq_varid(exoid, ex__catstr2(var_name, i + 1, ent_type, j + 1), &tabid) ==
+        if (nc_inq_varid(exoid, exi_catstr2(var_name, i + 1, ent_type, j + 1), &tabid) ==
             NC_NOERR) {
           /* variable exists; put a 1 in the truth table */
           var_tab[j * num_var + i] = 1;

--- a/packages/seacas/libraries/exodus/src/ex_get_var.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_var.c
@@ -7,7 +7,7 @@
  */
 
 #include "exodusII.h"     // for ex_err, ex_name_of_object, etc
-#include "exodusII_int.h" // for ex__check_valid_file_id, etc
+#include "exodusII_int.h" // for exi_check_valid_file_id, etc
 
 /*!
 \ingroup ResultsData

--- a/packages/seacas/libraries/exodus/src/ex_get_var_multi_time.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_var_multi_time.c
@@ -7,7 +7,7 @@
  */
 
 #include "exodusII.h"     // for ex_err, ex_name_of_object, etc
-#include "exodusII_int.h" // for ex__check_valid_file_id, etc
+#include "exodusII_int.h" // for exi_check_valid_file_id, etc
 
 /*!
 \ingroup ResultsData
@@ -74,26 +74,26 @@ int ex_get_var_multi_time(int exoid, ex_entity_type var_type, int var_index, ex_
   char   errmsg[MAX_ERR_LENGTH];
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
   if (var_type == EX_NODAL) {
     /* FIXME: Special case: ignore obj_id, possible large_file complications,
      * etc. */
-    status = ex__get_nodal_var_multi_time(exoid, var_index, num_entry_this_obj, beg_time_step,
+    status = exi_get_nodal_var_multi_time(exoid, var_index, num_entry_this_obj, beg_time_step,
                                           end_time_step, var_vals);
     EX_FUNC_LEAVE(status);
   }
   if (var_type == EX_GLOBAL) {
     /* FIXME: Special case: all vars stored in 2-D single array. */
-    status = ex__get_glob_vars_multi_time(exoid, num_entry_this_obj, beg_time_step, end_time_step,
+    status = exi_get_glob_vars_multi_time(exoid, num_entry_this_obj, beg_time_step, end_time_step,
                                           var_vals);
     EX_FUNC_LEAVE(status);
   }
 
   /* Determine index of obj_id in VAR_ID_EL_BLK array */
-  obj_id_ndx = ex__id_lkup(exoid, var_type, obj_id);
+  obj_id_ndx = exi_id_lkup(exoid, var_type, obj_id);
   if (obj_id_ndx <= 0) {
     ex_get_err(NULL, NULL, &status);
 
@@ -115,7 +115,7 @@ int ex_get_var_multi_time(int exoid, ex_entity_type var_type, int var_index, ex_
 
   /* inquire previously defined variable */
 
-  if ((status = nc_inq_varid(exoid, ex__name_var_of_object(var_type, var_index, obj_id_ndx),
+  if ((status = nc_inq_varid(exoid, exi_name_var_of_object(var_type, var_index, obj_id_ndx),
                              &varid)) != NC_NOERR) {
     snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to locate %s %" PRId64 " var %d in file id %d",
              ex_name_of_object(var_type), obj_id, var_index, exoid);
@@ -130,7 +130,7 @@ int ex_get_var_multi_time(int exoid, ex_entity_type var_type, int var_index, ex_
   count[0] = end_time_step - beg_time_step;
   count[1] = num_entry_this_obj;
 
-  if (ex__comp_ws(exoid) == 4) {
+  if (exi_comp_ws(exoid) == 4) {
     status = nc_get_vara_float(exoid, varid, start, count, var_vals);
   }
   else {

--- a/packages/seacas/libraries/exodus/src/ex_get_var_time.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_var_time.c
@@ -56,16 +56,16 @@ int ex_get_var_time(int exoid, ex_entity_type var_type, int var_index, int64_t i
   const char *varobstat;
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
   switch (var_type) {
   case EX_GLOBAL:
-    status = ex__get_glob_var_time(exoid, var_index, beg_time_step, end_time_step, var_vals);
+    status = exi_get_glob_var_time(exoid, var_index, beg_time_step, end_time_step, var_vals);
     EX_FUNC_LEAVE(status);
   case EX_NODAL:
-    status = ex__get_nodal_var_time(exoid, var_index, id, beg_time_step, end_time_step, var_vals);
+    status = exi_get_nodal_var_time(exoid, var_index, id, beg_time_step, end_time_step, var_vals);
     EX_FUNC_LEAVE(status);
   case EX_EDGE_BLOCK:
     varobjids = VAR_ID_ED_BLK;
@@ -114,7 +114,7 @@ int ex_get_var_time(int exoid, ex_entity_type var_type, int var_index, int64_t i
   /* find what object the entry is in */
 
   /* first, find out how many objects there are */
-  status = ex__get_dimension(exoid, ex__dim_num_objects(var_type), ex_name_of_object(var_type),
+  status = exi_get_dimension(exoid, exi_dim_num_objects(var_type), ex_name_of_object(var_type),
                              &num_obj, &dimid, __func__);
   if (status != NC_NOERR) {
     EX_FUNC_LEAVE(status);
@@ -169,7 +169,7 @@ int ex_get_var_time(int exoid, ex_entity_type var_type, int var_index, int64_t i
 
   i = 0;
   if (stat_vals[i] != 0) {
-    if ((status = nc_inq_dimid(exoid, ex__dim_num_entries_in_object(var_type, i + 1), &dimid)) !=
+    if ((status = nc_inq_dimid(exoid, exi_dim_num_entries_in_object(var_type, i + 1), &dimid)) !=
         NC_NOERR) {
       snprintf(errmsg, MAX_ERR_LENGTH,
                "ERROR: failed to locate number of entries in %zuth %s in file id %d", i,
@@ -193,7 +193,7 @@ int ex_get_var_time(int exoid, ex_entity_type var_type, int var_index, int64_t i
 
   while (numel <= id) {
     if (stat_vals[++i] != 0) {
-      if ((status = nc_inq_dimid(exoid, ex__dim_num_entries_in_object(var_type, i + 1), &dimid)) !=
+      if ((status = nc_inq_dimid(exoid, exi_dim_num_entries_in_object(var_type, i + 1), &dimid)) !=
           NC_NOERR) {
         snprintf(errmsg, MAX_ERR_LENGTH,
                  "ERROR: failed to locate number of entries in %zuth %s in file id %d", i,
@@ -217,7 +217,7 @@ int ex_get_var_time(int exoid, ex_entity_type var_type, int var_index, int64_t i
   size_t offset = id - (numel - num_entries_this_obj);
 
   /* inquire previously defined variable */
-  if ((status = nc_inq_varid(exoid, ex__name_var_of_object(var_type, var_index, i + 1), &varid)) !=
+  if ((status = nc_inq_varid(exoid, exi_name_var_of_object(var_type, var_index, i + 1), &varid)) !=
       NC_NOERR) {
     snprintf(errmsg, MAX_ERR_LENGTH,
              "ERROR: failed to locate variable %zu for %dth %s in file id %d", i, var_index,
@@ -274,7 +274,7 @@ int ex_get_var_time(int exoid, ex_entity_type var_type, int var_index, int64_t i
   count[0] = end_time_step - beg_time_step + 1;
   count[1] = 1;
 
-  if (ex__comp_ws(exoid) == 4) {
+  if (exi_comp_ws(exoid) == 4) {
     status = nc_get_vara_float(exoid, varid, start, count, var_vals);
   }
   else {

--- a/packages/seacas/libraries/exodus/src/ex_get_variable_name.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_variable_name.c
@@ -40,7 +40,7 @@ int ex_get_variable_name(int exoid, ex_entity_type obj_type, int var_num, char *
   const char *vname = NULL;
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -79,7 +79,7 @@ int ex_get_variable_name(int exoid, ex_entity_type obj_type, int var_num, char *
     int api_name_size = ex_inquire_int(exoid, EX_INQ_MAX_READ_NAME_LENGTH);
     int name_size     = db_name_size < api_name_size ? db_name_size : api_name_size;
 
-    status = ex__get_name(exoid, varid, var_num - 1, var_name, name_size, obj_type, __func__);
+    status = exi_get_name(exoid, varid, var_num - 1, var_name, name_size, obj_type, __func__);
     if (status != NC_NOERR) {
       EX_FUNC_LEAVE(EX_FATAL);
     }

--- a/packages/seacas/libraries/exodus/src/ex_get_variable_names.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_variable_names.c
@@ -71,7 +71,7 @@ int ex_get_variable_names(int exoid, ex_entity_type obj_type, int num_vars, char
   const char *vvarname;
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -104,7 +104,7 @@ int ex_get_variable_names(int exoid, ex_entity_type obj_type, int num_vars, char
   }
 
   /* read the variable names */
-  status = ex__get_names(exoid, varid, num_vars, var_names, obj_type, __func__);
+  status = exi_get_names(exoid, varid, num_vars, var_names, obj_type, __func__);
   if (status != NC_NOERR) {
     EX_FUNC_LEAVE(EX_FATAL);
   }

--- a/packages/seacas/libraries/exodus/src/ex_get_variable_param.c
+++ b/packages/seacas/libraries/exodus/src/ex_get_variable_param.c
@@ -79,7 +79,7 @@ int ex_get_variable_param(int exoid, ex_entity_type obj_type, int *num_vars)
   int         status;
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 

--- a/packages/seacas/libraries/exodus/src/ex_inquire.c
+++ b/packages/seacas/libraries/exodus/src/ex_inquire.c
@@ -10,7 +10,7 @@
 #include "exodusII_int.h"
 
 /*! \cond INTERNAL */
-static int ex__get_dimension_value(int exoid, int64_t *var, int default_value,
+static int exi_get_dimension_value(int exoid, int64_t *var, int default_value,
                                    const char *dimension_name, int missing_ok)
 {
   int status;
@@ -97,7 +97,7 @@ static int ex_get_concat_set_len(int exoid, int64_t *set_length, const char *set
       }
 
       size_t idum;
-      if (nc_inq_dimid(exoid, ex__catstr(set_size_root, i + 1), &dimid) != NC_NOERR) {
+      if (nc_inq_dimid(exoid, exi_catstr(set_size_root, i + 1), &dimid) != NC_NOERR) {
         if (missing_ok) {
           idum = 0;
         }
@@ -137,7 +137,7 @@ static int ex_inquire_internal(int exoid, int req_info, int64_t *ret_int, float 
   int    status;
   int    num_var;
 
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     return (EX_FATAL);
   }
 
@@ -269,7 +269,7 @@ static int ex_inquire_internal(int exoid, int req_info, int64_t *ret_int, float 
      * default if not set by the client is 32 characters. The value
      * does not include the trailing null.
      */
-    struct ex__file_item *file = ex__find_file_item(rootid);
+    struct exi_file_item *file = exi_find_file_item(rootid);
 
     if (!file) {
       snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: unknown file id %d for ex_inquire_int().", rootid);
@@ -307,7 +307,7 @@ static int ex_inquire_internal(int exoid, int req_info, int64_t *ret_int, float 
 
   case EX_INQ_DIM:
     /* returns the dimensionality (2 or 3, for 2-d or 3-d) of the database */
-    if (ex__get_dimension(exoid, DIM_NUM_DIM, "database dimensionality", &ldum, &dimid, __func__) !=
+    if (exi_get_dimension(exoid, DIM_NUM_DIM, "database dimensionality", &ldum, &dimid, __func__) !=
         NC_NOERR) {
       return (EX_FATAL);
     }
@@ -318,7 +318,7 @@ static int ex_inquire_internal(int exoid, int req_info, int64_t *ret_int, float 
     /* returns the number of assemblies */
     {
       *ret_int                   = 0;
-      struct ex__file_item *file = ex__find_file_item(exoid);
+      struct exi_file_item *file = exi_find_file_item(exoid);
       if (file) {
         *ret_int = file->assembly_count;
       }
@@ -329,7 +329,7 @@ static int ex_inquire_internal(int exoid, int req_info, int64_t *ret_int, float 
     /* returns the number of blobs */
     {
       *ret_int                   = 0;
-      struct ex__file_item *file = ex__find_file_item(exoid);
+      struct exi_file_item *file = exi_find_file_item(exoid);
       if (file) {
         *ret_int = file->blob_count;
       }
@@ -338,7 +338,7 @@ static int ex_inquire_internal(int exoid, int req_info, int64_t *ret_int, float 
 
   case EX_INQ_NODES:
     /* returns the number of nodes */
-    if (ex__get_dimension(exoid, DIM_NUM_NODES, "nodes", &ldum, &dimid, NULL) != NC_NOERR) {
+    if (exi_get_dimension(exoid, DIM_NUM_NODES, "nodes", &ldum, &dimid, NULL) != NC_NOERR) {
       *ret_int = 0;
     }
     else {
@@ -348,7 +348,7 @@ static int ex_inquire_internal(int exoid, int req_info, int64_t *ret_int, float 
 
   case EX_INQ_ELEM:
     /* returns the number of elements */
-    if (ex__get_dimension(exoid, DIM_NUM_ELEM, "elements", &ldum, &dimid, NULL) != NC_NOERR) {
+    if (exi_get_dimension(exoid, DIM_NUM_ELEM, "elements", &ldum, &dimid, NULL) != NC_NOERR) {
       *ret_int = 0;
     }
     else {
@@ -358,7 +358,7 @@ static int ex_inquire_internal(int exoid, int req_info, int64_t *ret_int, float 
 
   case EX_INQ_ELEM_BLK:
     /* returns the number of element blocks */
-    if (ex__get_dimension(exoid, DIM_NUM_EL_BLK, "element blocks", &ldum, &dimid, NULL) !=
+    if (exi_get_dimension(exoid, DIM_NUM_EL_BLK, "element blocks", &ldum, &dimid, NULL) !=
         NC_NOERR) {
       *ret_int = 0;
     }
@@ -369,7 +369,7 @@ static int ex_inquire_internal(int exoid, int req_info, int64_t *ret_int, float 
 
   case EX_INQ_NODE_SETS:
     /* returns the number of node sets */
-    if (ex__get_dimension(exoid, DIM_NUM_NS, "node sets", &ldum, &dimid, NULL) != NC_NOERR) {
+    if (exi_get_dimension(exoid, DIM_NUM_NS, "node sets", &ldum, &dimid, NULL) != NC_NOERR) {
       *ret_int = 0;
     }
     else {
@@ -446,7 +446,7 @@ static int ex_inquire_internal(int exoid, int req_info, int64_t *ret_int, float 
 
   case EX_INQ_SIDE_SETS:
     /* returns the number of side sets */
-    if (ex__get_dimension(exoid, DIM_NUM_SS, "side sets", &ldum, &dimid, NULL) != NC_NOERR) {
+    if (exi_get_dimension(exoid, DIM_NUM_SS, "side sets", &ldum, &dimid, NULL) != NC_NOERR) {
       *ret_int = 0;
     }
     else {
@@ -619,7 +619,7 @@ static int ex_inquire_internal(int exoid, int req_info, int64_t *ret_int, float 
 
   case EX_INQ_QA:
     /* returns the number of QA records */
-    if (ex__get_dimension(rootid, DIM_NUM_QA, "QA records", &ldum, &dimid, NULL) != NC_NOERR) {
+    if (exi_get_dimension(rootid, DIM_NUM_QA, "QA records", &ldum, &dimid, NULL) != NC_NOERR) {
       *ret_int = 0;
     }
     else {
@@ -629,7 +629,7 @@ static int ex_inquire_internal(int exoid, int req_info, int64_t *ret_int, float 
 
   case EX_INQ_INFO:
     /* returns the number of information records */
-    if (ex__get_dimension(rootid, DIM_NUM_INFO, "info records", &ldum, &dimid, NULL) != NC_NOERR) {
+    if (exi_get_dimension(rootid, DIM_NUM_INFO, "info records", &ldum, &dimid, NULL) != NC_NOERR) {
       *ret_int = 0;
     }
     else {
@@ -639,7 +639,7 @@ static int ex_inquire_internal(int exoid, int req_info, int64_t *ret_int, float 
 
   case EX_INQ_TIME:
     /*     returns the number of time steps stored in the database */
-    if (ex__get_dimension(exoid, DIM_TIME, "time dimension", &ldum, &dimid, __func__) != NC_NOERR) {
+    if (exi_get_dimension(exoid, DIM_TIME, "time dimension", &ldum, &dimid, __func__) != NC_NOERR) {
       return (EX_FATAL);
     }
     *ret_int = ldum;
@@ -662,7 +662,7 @@ static int ex_inquire_internal(int exoid, int req_info, int64_t *ret_int, float 
 
   case EX_INQ_ELEM_MAP:
     /* returns the number of element maps */
-    if (ex__get_dimension(exoid, DIM_NUM_EM, "element maps", &ldum, &dimid, NULL) != NC_NOERR) {
+    if (exi_get_dimension(exoid, DIM_NUM_EM, "element maps", &ldum, &dimid, NULL) != NC_NOERR) {
       *ret_int = 0;
     }
     else {
@@ -677,7 +677,7 @@ static int ex_inquire_internal(int exoid, int req_info, int64_t *ret_int, float 
 
   case EX_INQ_NODE_MAP:
     /* returns the number of node maps */
-    if (ex__get_dimension(exoid, DIM_NUM_NM, "node maps", &ldum, &dimid, NULL) != NC_NOERR) {
+    if (exi_get_dimension(exoid, DIM_NUM_NM, "node maps", &ldum, &dimid, NULL) != NC_NOERR) {
       *ret_int = 0;
     }
     else {
@@ -692,21 +692,21 @@ static int ex_inquire_internal(int exoid, int req_info, int64_t *ret_int, float 
 
   case EX_INQ_EDGE:
     /* returns the number of edges (defined across all edge blocks). */
-    if (ex__get_dimension_value(exoid, ret_int, 0, DIM_NUM_EDGE, 1) != EX_NOERR) {
+    if (exi_get_dimension_value(exoid, ret_int, 0, DIM_NUM_EDGE, 1) != EX_NOERR) {
       return (EX_FATAL);
     }
     break;
 
   case EX_INQ_EDGE_BLK:
     /* returns the number of edge blocks. */
-    if (ex__get_dimension_value(exoid, ret_int, 0, DIM_NUM_ED_BLK, 1) != EX_NOERR) {
+    if (exi_get_dimension_value(exoid, ret_int, 0, DIM_NUM_ED_BLK, 1) != EX_NOERR) {
       return (EX_FATAL);
     }
     break;
 
   case EX_INQ_EDGE_SETS:
     /* returns the number of edge sets. */
-    if (ex__get_dimension_value(exoid, ret_int, 0, DIM_NUM_ES, 1) != EX_NOERR) {
+    if (exi_get_dimension_value(exoid, ret_int, 0, DIM_NUM_ES, 1) != EX_NOERR) {
       return (EX_FATAL);
     }
     break;
@@ -736,21 +736,21 @@ static int ex_inquire_internal(int exoid, int req_info, int64_t *ret_int, float 
 
   case EX_INQ_FACE:
     /* returns the number of faces (defined across all face blocks). */
-    if (ex__get_dimension_value(exoid, ret_int, 0, DIM_NUM_FACE, 1) != EX_NOERR) {
+    if (exi_get_dimension_value(exoid, ret_int, 0, DIM_NUM_FACE, 1) != EX_NOERR) {
       return (EX_FATAL);
     }
     break;
 
   case EX_INQ_FACE_BLK:
     /* returns the number of face blocks. */
-    if (ex__get_dimension_value(exoid, ret_int, 0, DIM_NUM_FA_BLK, 1) != EX_NOERR) {
+    if (exi_get_dimension_value(exoid, ret_int, 0, DIM_NUM_FA_BLK, 1) != EX_NOERR) {
       return (EX_FATAL);
     }
     break;
 
   case EX_INQ_FACE_SETS:
     /* returns the number of face sets. */
-    if (ex__get_dimension_value(exoid, ret_int, 0, DIM_NUM_FS, 1) != EX_NOERR) {
+    if (exi_get_dimension_value(exoid, ret_int, 0, DIM_NUM_FS, 1) != EX_NOERR) {
       return (EX_FATAL);
     }
     break;
@@ -780,7 +780,7 @@ static int ex_inquire_internal(int exoid, int req_info, int64_t *ret_int, float 
 
   case EX_INQ_ELEM_SETS:
     /* returns the number of element sets. */
-    if (ex__get_dimension_value(exoid, ret_int, 0, DIM_NUM_ELS, 1) != EX_NOERR) {
+    if (exi_get_dimension_value(exoid, ret_int, 0, DIM_NUM_ELS, 1) != EX_NOERR) {
       return (EX_FATAL);
     }
     break;
@@ -803,14 +803,14 @@ static int ex_inquire_internal(int exoid, int req_info, int64_t *ret_int, float 
 
   case EX_INQ_EDGE_MAP:
     /* returns the number of edge maps. */
-    if (ex__get_dimension_value(exoid, ret_int, 0, DIM_NUM_EDM, 1) != EX_NOERR) {
+    if (exi_get_dimension_value(exoid, ret_int, 0, DIM_NUM_EDM, 1) != EX_NOERR) {
       return (EX_FATAL);
     }
     break;
 
   case EX_INQ_FACE_MAP:
     /*     returns the number of face maps. */
-    if (ex__get_dimension_value(exoid, ret_int, 0, DIM_NUM_FAM, 1) != EX_NOERR) {
+    if (exi_get_dimension_value(exoid, ret_int, 0, DIM_NUM_FAM, 1) != EX_NOERR) {
       return (EX_FATAL);
     }
     break;
@@ -887,7 +887,7 @@ static int ex_inquire_internal(int exoid, int req_info, int64_t *ret_int, float 
 
   case EX_INQ_COORD_FRAMES:
     /* return the number of coordinate frames */
-    if (ex__get_dimension_value(exoid, ret_int, 0, DIM_NUM_CFRAMES, 1) != EX_NOERR) {
+    if (exi_get_dimension_value(exoid, ret_int, 0, DIM_NUM_CFRAMES, 1) != EX_NOERR) {
       return (EX_FATAL);
     }
     break;

--- a/packages/seacas/libraries/exodus/src/ex_int_get_block_param.c
+++ b/packages/seacas/libraries/exodus/src/ex_int_get_block_param.c
@@ -11,7 +11,7 @@
 #include <ctype.h>
 
 /* Generic error message for element type/node count mapping...*/
-static int el_node_count_error(int exoid, struct ex__elem_blk_parm elem_blk_parms)
+static int el_node_count_error(int exoid, struct exi_elem_blk_parm elem_blk_parms)
 {
   char errmsg[MAX_ERR_LENGTH];
   snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: An element of type '%s' with %d nodes is not valid.",
@@ -20,8 +20,8 @@ static int el_node_count_error(int exoid, struct ex__elem_blk_parm elem_blk_parm
   return (EX_FATAL);
 }
 
-int ex__get_block_param(int exoid, ex_entity_id id, int ndim,
-                        struct ex__elem_blk_parm *elem_blk_parm)
+int exi_get_block_param(int exoid, ex_entity_id id, int ndim,
+                        struct exi_elem_blk_parm *elem_blk_parm)
 {
   EX_FUNC_ENTER();
 
@@ -29,7 +29,7 @@ int ex__get_block_param(int exoid, ex_entity_id id, int ndim,
   block.id   = id;
   block.type = EX_ELEM_BLOCK;
 
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 

--- a/packages/seacas/libraries/exodus/src/ex_ne_util.c
+++ b/packages/seacas/libraries/exodus/src/ex_ne_util.c
@@ -11,10 +11,10 @@
 /*****************************************************************************/
 /* Function(s) contained in this file:
  *
- *     ex__leavedef()
+ *     exi_leavedef()
  *     ne__id_lkup()
- *     ex__get_file_type()
- *     ex__put_nemesis_version()
+ *     exi_get_file_type()
+ *     exi_put_nemesis_version()
  *     ne__check_file_version()
  *     ex_get_idx()
  *
@@ -111,7 +111,7 @@ int ne__id_lkup(int exoid, const char *ne_var_name, int64_t *idx, ex_entity_id n
 /* This function retrieves the file type from a Nemesis file.
  */
 /*****************************************************************************/
-int ex__get_file_type(int exoid, char *ftype)
+int exi_get_file_type(int exoid, char *ftype)
 {
   EX_FUNC_ENTER();
 
@@ -152,7 +152,7 @@ int ex__get_file_type(int exoid, char *ftype)
 /* This function outputs the Nemesis version information to the file.
  */
 /*****************************************************************************/
-int ex__put_nemesis_version(int exoid)
+int exi_put_nemesis_version(int exoid)
 {
   EX_FUNC_ENTER();
 

--- a/packages/seacas/libraries/exodus/src/ex_ne_util.c
+++ b/packages/seacas/libraries/exodus/src/ex_ne_util.c
@@ -12,10 +12,10 @@
 /* Function(s) contained in this file:
  *
  *     exi_leavedef()
- *     ne__id_lkup()
+ *     nei_id_lkup()
  *     exi_get_file_type()
  *     exi_put_nemesis_version()
- *     ne__check_file_version()
+ *     nei_check_file_version()
  *     ex_get_idx()
  *
  *****************************************************************************
@@ -37,7 +37,7 @@ char *ne_ret_string;
 /* Note: This function assumes a 1-d vector of data for "ne_var_name".
  */
 /*****************************************************************************/
-int ne__id_lkup(int exoid, const char *ne_var_name, int64_t *idx, ex_entity_id ne_var_id)
+int nei_id_lkup(int exoid, const char *ne_var_name, int64_t *idx, ex_entity_id ne_var_id)
 {
   int status;
   int varid;
@@ -192,7 +192,7 @@ int exi_put_nemesis_version(int exoid)
 /* This function checks that the version info is correct.
  */
 /*****************************************************************************/
-int ne__check_file_version(int exoid)
+int nei_check_file_version(int exoid)
 {
 #if 0
   float  file_ver;

--- a/packages/seacas/libraries/exodus/src/ex_open.c
+++ b/packages/seacas/libraries/exodus/src/ex_open.c
@@ -118,7 +118,7 @@ int ex_open_int(const char *path, int mode, int *comp_ws, int *io_ws, float *ver
   /* set error handling mode to no messages, non-fatal errors */
   ex_opts(exoptval); /* call required to set ncopts first time through */
 
-  ex__check_version(run_version);
+  exi_check_version(run_version);
 
   if ((mode & EX_READ) && (mode & EX_WRITE)) {
     snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: Cannot specify both EX_READ and EX_WRITE");
@@ -132,14 +132,14 @@ int ex_open_int(const char *path, int mode, int *comp_ws, int *io_ws, float *ver
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
-  char *canon_path = ex__canonicalize_filename(path);
+  char *canon_path = exi_canonicalize_filename(path);
 
   /* Verify that this file is not already open for read or write...
      In theory, should be ok for the file to be open multiple times
      for read, but bad things can happen if being read and written
      at the same time...
   */
-  if (ex__check_multiple_open(canon_path, mode, __func__)) {
+  if (exi_check_multiple_open(canon_path, mode, __func__)) {
     free(canon_path);
     EX_FUNC_LEAVE(EX_FATAL);
   }
@@ -176,7 +176,7 @@ int ex_open_int(const char *path, int mode, int *comp_ws, int *io_ws, float *ver
       int type = 0;
       ex_opts(EX_VERBOSE);
 
-      ex__check_file_type(canon_path, &type);
+      exi_check_file_type(canon_path, &type);
 
       if (type == 0) {
         /* Error message printed at lower level */
@@ -322,7 +322,7 @@ int ex_open_int(const char *path, int mode, int *comp_ws, int *io_ws, float *ver
        * add it now. */
       if (stat_dim != NC_NOERR) {
         /* Not found; set to default value of 32+1. */
-        int max_name = ex__default_max_name_length < 32 ? 32 : ex__default_max_name_length;
+        int max_name = exi_default_max_name_length < 32 ? 32 : exi_default_max_name_length;
         if ((status = nc_def_dim(exoid, DIM_STR_NAME, max_name + 1, &dim_str_name)) != NC_NOERR) {
           snprintf(errmsg, MAX_ERR_LENGTH,
                    "ERROR: failed to define string name dimension in file id %d named %s", exoid,
@@ -332,7 +332,7 @@ int ex_open_int(const char *path, int mode, int *comp_ws, int *io_ws, float *ver
           EX_FUNC_LEAVE(EX_FATAL);
         }
       }
-      if ((status = ex__leavedef(exoid, __func__)) != NC_NOERR) {
+      if ((status = exi_leavedef(exoid, __func__)) != NC_NOERR) {
         snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to exit define mode in file id %d", exoid);
         ex_err_fn(exoid, __func__, errmsg, status);
         free(canon_path);
@@ -394,7 +394,7 @@ int ex_open_int(const char *path, int mode, int *comp_ws, int *io_ws, float *ver
      not know that file was closed and possibly new file opened for
      this exoid
   */
-  if (ex__find_file_item(exoid) != NULL) {
+  if (exi_find_file_item(exoid) != NULL) {
     snprintf(errmsg, MAX_ERR_LENGTH,
              "ERROR: There is an existing file already using the file "
              "id %d which was also assigned to file %s.\n\tWas "
@@ -408,7 +408,7 @@ int ex_open_int(const char *path, int mode, int *comp_ws, int *io_ws, float *ver
   }
 
   /* initialize floating point and integer size conversion. */
-  if (ex__conv_init(exoid, comp_ws, io_ws, file_wordsize, int64_status, false, false, false,
+  if (exi_conv_init(exoid, comp_ws, io_ws, file_wordsize, int64_status, false, false, false,
                     mode & EX_WRITE) != EX_NOERR) {
     snprintf(errmsg, MAX_ERR_LENGTH,
              "ERROR: failed to initialize conversion routines in file id %d named %s", exoid,

--- a/packages/seacas/libraries/exodus/src/ex_open_par.c
+++ b/packages/seacas/libraries/exodus/src/ex_open_par.c
@@ -138,7 +138,7 @@ int ex_open_par_int(const char *path, int mode, int *comp_ws, int *io_ws, float 
   /* set error handling mode to no messages, non-fatal errors */
   ex_opts(exoptval); /* call required to set ncopts first time through */
 
-  ex__check_version(run_version);
+  exi_check_version(run_version);
 
   if ((mode & EX_READ) && (mode & EX_WRITE)) {
     snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: Cannot specify both EX_READ and EX_WRITE");
@@ -152,14 +152,14 @@ int ex_open_par_int(const char *path, int mode, int *comp_ws, int *io_ws, float 
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
-  char *canon_path = ex__canonicalize_filename(path);
+  char *canon_path = exi_canonicalize_filename(path);
 
   /* Verify that this file is not already open for read or write...
      In theory, should be ok for the file to be open multiple times
      for read, but bad things can happen if being read and written
      at the same time...
   */
-  if (ex__check_multiple_open(canon_path, mode, __func__)) {
+  if (exi_check_multiple_open(canon_path, mode, __func__)) {
     free(canon_path);
     EX_FUNC_LEAVE(EX_FATAL);
   }
@@ -208,7 +208,7 @@ int ex_open_par_int(const char *path, int mode, int *comp_ws, int *io_ws, float 
        we have the define that shows it is enabled, then assume other error...
     */
     int type = 0;
-    ex__check_file_type(path, &type);
+    exi_check_file_type(path, &type);
 
     if (type == 0) {
       /* Error message printed at lower level */
@@ -302,7 +302,7 @@ int ex_open_par_int(const char *path, int mode, int *comp_ws, int *io_ws, float 
 
   /* File opened correctly */
   int type = 0;
-  ex__check_file_type(canon_path, &type);
+  exi_check_file_type(canon_path, &type);
   if (type == 5) {
     is_hdf5 = true;
   }
@@ -353,13 +353,13 @@ int ex_open_par_int(const char *path, int mode, int *comp_ws, int *io_ws, float 
        * add it now. */
       if (stat_dim != NC_NOERR) {
         /* Not found; set to default value of 32+1. */
-        int max_name = ex__default_max_name_length < 32 ? 32 : ex__default_max_name_length;
+        int max_name = exi_default_max_name_length < 32 ? 32 : exi_default_max_name_length;
         nc_def_dim(exoid, DIM_STR_NAME, max_name + 1, &dim_str_name);
       }
     }
 
     if (in_redef) {
-      if ((status = ex__leavedef(exoid, __func__)) != NC_NOERR) {
+      if ((status = exi_leavedef(exoid, __func__)) != NC_NOERR) {
         free(canon_path);
         EX_FUNC_LEAVE(EX_FATAL);
       }
@@ -456,7 +456,7 @@ int ex_open_par_int(const char *path, int mode, int *comp_ws, int *io_ws, float 
      not know that file was closed and possibly new file opened for
      this exoid
   */
-  if (ex__find_file_item(exoid) != NULL) {
+  if (exi_find_file_item(exoid) != NULL) {
     snprintf(errmsg, MAX_ERR_LENGTH,
              "ERROR: There is an existing file already using the file "
              "id %d which was also assigned to file %s.\n\tWas "
@@ -470,7 +470,7 @@ int ex_open_par_int(const char *path, int mode, int *comp_ws, int *io_ws, float 
   }
 
   /* initialize floating point and integer size conversion. */
-  if (ex__conv_init(exoid, comp_ws, io_ws, file_wordsize, int64_status, 1, is_hdf5, is_pnetcdf,
+  if (exi_conv_init(exoid, comp_ws, io_ws, file_wordsize, int64_status, 1, is_hdf5, is_pnetcdf,
                     mode & EX_WRITE) != EX_NOERR) {
     snprintf(errmsg, MAX_ERR_LENGTH,
              "ERROR: failed to initialize conversion routines in file id %d", exoid);

--- a/packages/seacas/libraries/exodus/src/ex_opts.c
+++ b/packages/seacas/libraries/exodus/src/ex_opts.c
@@ -10,7 +10,7 @@
 #include "exodusII_int.h"
 
 /*! \cond INTERNAL */
-int ex__default_max_name_length = 32; /* For default compatibility with older clients */
+int exi_default_max_name_length = 32; /* For default compatibility with older clients */
 
 #if defined(VERBOSE)
 int exoptval = EX_VERBOSE; /* loud mode: set EX_VERBOSE */

--- a/packages/seacas/libraries/exodus/src/ex_put_all_var_param_ext.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_all_var_param_ext.c
@@ -19,7 +19,7 @@
  *****************************************************************************/
 
 #include "exodusII.h"     // for ex_err, etc
-#include "exodusII_int.h" // for ex__get_dimension, etc
+#include "exodusII_int.h" // for exi_get_dimension, etc
 
 static int  define_dimension(int exoid, const char *DIMENSION, int count, const char *label,
                              int *dimid);
@@ -37,7 +37,7 @@ static int  ex_define_vars(int exoid, ex_entity_type obj_type, const char *entit
 
 #define EX_GET_IDS_STATUS(TNAME, NUMVAR, DNAME, DID, DVAL, VIDS, EIDS, VSTAT, VSTATVAL)            \
   if (NUMVAR > 0) {                                                                                \
-    status = ex__get_dimension(exoid, DNAME, TNAME "s", &DVAL, &DID, __func__);                    \
+    status = exi_get_dimension(exoid, DNAME, TNAME "s", &DVAL, &DID, __func__);                    \
     if (status != NC_NOERR)                                                                        \
       goto error_ret;                                                                              \
                                                                                                    \
@@ -103,7 +103,7 @@ int ex_put_all_var_param_ext(int exoid, const ex_var_params *vp)
   char errmsg[MAX_ERR_LENGTH];
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -166,7 +166,7 @@ int ex_put_all_var_param_ext(int exoid, const ex_var_params *vp)
       ex_err_fn(exoid, __func__, errmsg, status);
       goto error_ret; /* exit define mode and return */
     }
-    ex__compress_variable(exoid, varid, 2);
+    exi_compress_variable(exoid, varid, 2);
 
     /* Now define global variable name variable */
     if (define_variable_name_variable(exoid, VAR_NAME_GLO_VAR, dimid, "global") != NC_NOERR) {
@@ -190,7 +190,7 @@ int ex_put_all_var_param_ext(int exoid, const ex_var_params *vp)
           ex_err_fn(exoid, __func__, errmsg, status);
           goto error_ret; /* exit define mode and return */
         }
-        ex__compress_variable(exoid, varid, 2);
+        exi_compress_variable(exoid, varid, 2);
       }
     }
 
@@ -252,7 +252,7 @@ int ex_put_all_var_param_ext(int exoid, const ex_var_params *vp)
   /* leave define mode  */
 
   in_define = 0;
-  if ((status = ex__leavedef(exoid, __func__)) != NC_NOERR) {
+  if ((status = exi_leavedef(exoid, __func__)) != NC_NOERR) {
     snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to exit define mode");
     ex_err_fn(exoid, __func__, errmsg, status);
     goto error_ret;
@@ -312,7 +312,7 @@ int ex_put_all_var_param_ext(int exoid, const ex_var_params *vp)
 /* Fatal error: exit definition mode and return */
 error_ret:
   if (in_define == 1) {
-    ex__leavedef(exoid, __func__);
+    exi_leavedef(exoid, __func__);
   }
   free(eblk_ids);
   free(edblk_ids);
@@ -381,7 +381,7 @@ static int define_variable_name_variable(int exoid, const char *VARIABLE, int di
       ex_err_fn(exoid, __func__, errmsg, status);
     }
   }
-  ex__set_compact_storage(exoid, variable);
+  exi_set_compact_storage(exoid, variable);
 #if defined(EX_CAN_USE_NC_DEF_VAR_FILL)
   int fill = NC_FILL_CHAR;
   nc_def_var_fill(exoid, variable, 0, &fill);
@@ -481,7 +481,7 @@ static int define_truth_table(ex_entity_type obj_type, int exoid, int num_ent, i
 
           /* Determine number of entities in entity */
           /* Need way to make this more generic... */
-          status = nc_inq_dimid(exoid, ex__dim_num_entries_in_object(obj_type, i + 1), &dims[1]);
+          status = nc_inq_dimid(exoid, exi_dim_num_entries_in_object(obj_type, i + 1), &dims[1]);
           if (status != NC_NOERR) {
             char errmsg[MAX_ERR_LENGTH];
             snprintf(errmsg, MAX_ERR_LENGTH,
@@ -496,7 +496,7 @@ static int define_truth_table(ex_entity_type obj_type, int exoid, int num_ent, i
            * that the index of the EXODUS variable (which is part of
            * the name of the netCDF variable) will begin at 1 instead of 0
            */
-          status = nc_def_var(exoid, ex__name_var_of_object(obj_type, j, i + 1), nc_flt_code(exoid),
+          status = nc_def_var(exoid, exi_name_var_of_object(obj_type, j, i + 1), nc_flt_code(exoid),
                               2, dims, &varid);
           if (status != NC_NOERR) {
             if (status != NC_ENAMEINUSE) {
@@ -508,7 +508,7 @@ static int define_truth_table(ex_entity_type obj_type, int exoid, int num_ent, i
               return (status);
             }
           }
-          ex__compress_variable(exoid, varid, 2);
+          exi_compress_variable(exoid, varid, 2);
         }
       }    /* if */
       k++; /* increment truth table pointer */
@@ -555,7 +555,7 @@ static int ex_define_vars(int exoid, ex_entity_type obj_type, const char *entity
       ex_err_fn(exoid, __func__, errmsg, status);
       return status;
     }
-    ex__set_compact_storage(exoid, *truth_table_var);
+    exi_set_compact_storage(exoid, *truth_table_var);
   }
   return NC_NOERR;
 }

--- a/packages/seacas/libraries/exodus/src/ex_put_assemblies.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_assemblies.c
@@ -25,7 +25,7 @@ int ex_put_assemblies(int exoid, size_t count, const struct ex_assembly *assembl
 
   EX_FUNC_ENTER();
 
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -106,7 +106,7 @@ int ex_put_assemblies(int exoid, size_t count, const struct ex_assembly *assembl
         }
         goto error_ret; /* exit define mode and return */
       }
-      ex__compress_variable(exoid, entlst_id[i], 1);
+      exi_compress_variable(exoid, entlst_id[i], 1);
 
       if (ex_int64_status(exoid) & EX_IDS_INT64_DB) {
         long long tmp = assemblies[i].id;
@@ -158,7 +158,7 @@ int ex_put_assemblies(int exoid, size_t count, const struct ex_assembly *assembl
       }
 
       /* Increment assembly count */
-      struct ex__file_item *file = ex__find_file_item(exoid);
+      struct exi_file_item *file = exi_find_file_item(exoid);
       if (file) {
         file->assembly_count++;
       }
@@ -166,7 +166,7 @@ int ex_put_assemblies(int exoid, size_t count, const struct ex_assembly *assembl
   }
   /* leave define mode  */
   if (in_define) {
-    if ((status = ex__leavedef(exoid, __func__)) != NC_NOERR) {
+    if ((status = exi_leavedef(exoid, __func__)) != NC_NOERR) {
       snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to exit define mode in file id %d", exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       free(entlst_id);
@@ -176,7 +176,7 @@ int ex_put_assemblies(int exoid, size_t count, const struct ex_assembly *assembl
   }
 
   /* Update the maximum_name_length attribute on the file. */
-  ex__update_max_name_length(exoid, max_name_len - 1);
+  exi_update_max_name_length(exoid, max_name_len - 1);
 
   /* Assembly are now all defined; see if any set data needs to be output... */
   for (size_t i = 0; i < count; i++) {
@@ -198,7 +198,7 @@ int ex_put_assemblies(int exoid, size_t count, const struct ex_assembly *assembl
 /* Fatal error: exit definition mode and return */
 error_ret:
   if (in_define) {
-    ex__leavedef(exoid, __func__);
+    exi_leavedef(exoid, __func__);
   }
   free(entlst_id);
   EX_FUNC_LEAVE(EX_FATAL);

--- a/packages/seacas/libraries/exodus/src/ex_put_attr.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_attr.c
@@ -24,7 +24,7 @@
  *****************************************************************************/
 
 #include "exodusII.h"     // for ex_err, etc
-#include "exodusII_int.h" // for EX_FATAL, ex__comp_ws, etc
+#include "exodusII_int.h" // for EX_FATAL, exi_comp_ws, etc
 
 /*!
  * writes the attributes for an edge/face/element block
@@ -41,13 +41,13 @@ int ex_put_attr(int exoid, ex_entity_type blk_type, ex_entity_id blk_id, const v
   char errmsg[MAX_ERR_LENGTH];
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
   if (blk_type != EX_NODAL) {
     /* Determine index of blk_id in VAR_ID_EL_BLK array */
-    blk_id_ndx = ex__id_lkup(exoid, blk_type, blk_id);
+    blk_id_ndx = exi_id_lkup(exoid, blk_type, blk_id);
     if (blk_id_ndx <= 0) {
       ex_get_err(NULL, NULL, &status);
 
@@ -94,7 +94,7 @@ int ex_put_attr(int exoid, ex_entity_type blk_type, ex_entity_id blk_id, const v
   }
 
   /* write out the attributes  */
-  if (ex__comp_ws(exoid) == 4) {
+  if (exi_comp_ws(exoid) == 4) {
     status = nc_put_var_float(exoid, attrid, attrib);
   }
   else {

--- a/packages/seacas/libraries/exodus/src/ex_put_attr_names.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_attr_names.c
@@ -25,7 +25,7 @@
 *****************************************************************************/
 
 #include "exodusII.h"     // for ex_err, ex_name_of_object, etc
-#include "exodusII_int.h" // for EX_FATAL, ex__id_lkup, etc
+#include "exodusII_int.h" // for EX_FATAL, exi_id_lkup, etc
 
 /*!
  * writes the attribute names for a block
@@ -43,11 +43,11 @@ int ex_put_attr_names(int exoid, ex_entity_type blk_type, ex_entity_id blk_id, c
   char errmsg[MAX_ERR_LENGTH];
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
-  blk_id_ndx = ex__id_lkup(exoid, blk_type, blk_id);
+  blk_id_ndx = exi_id_lkup(exoid, blk_type, blk_id);
   if (blk_id_ndx <= 0) {
     ex_get_err(NULL, NULL, &status);
 
@@ -136,7 +136,7 @@ int ex_put_attr_names(int exoid, ex_entity_type blk_type, ex_entity_id blk_id, c
   }
 
   /* write out the attributes  */
-  status = ex__put_names(exoid, varid, num_attr, names, blk_type, "attribute", __func__);
+  status = exi_put_names(exoid, varid, num_attr, names, blk_type, "attribute", __func__);
 
   EX_FUNC_LEAVE(status);
 }

--- a/packages/seacas/libraries/exodus/src/ex_put_attr_param.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_attr_param.c
@@ -48,7 +48,7 @@ int ex_put_attr_param(int exoid, ex_entity_type obj_type, ex_entity_id obj_id, i
   int         numattrdim;
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -57,7 +57,7 @@ int ex_put_attr_param(int exoid, ex_entity_type obj_type, ex_entity_id obj_id, i
     obj_id_ndx = 0;
   }
   else {
-    obj_id_ndx = ex__id_lkup(exoid, obj_type, obj_id);
+    obj_id_ndx = exi_id_lkup(exoid, obj_type, obj_id);
     if (obj_id_ndx <= 0) {
       ex_get_err(NULL, NULL, &status);
 
@@ -173,7 +173,7 @@ int ex_put_attr_param(int exoid, ex_entity_type obj_type, ex_entity_id obj_id, i
     ex_err_fn(exoid, __func__, errmsg, status);
     goto error_ret; /* exit define mode and return */
   }
-  ex__compress_variable(exoid, varid, 2);
+  exi_compress_variable(exoid, varid, 2);
 
   /* inquire previously defined dimensions  */
   if ((status = nc_inq_dimid(exoid, DIM_STR_NAME, &strdim)) != NC_NOERR) {
@@ -199,7 +199,7 @@ int ex_put_attr_param(int exoid, ex_entity_type obj_type, ex_entity_id obj_id, i
 #endif
 
   /* leave define mode  */
-  if ((status = ex__leavedef(exoid, __func__)) != NC_NOERR) {
+  if ((status = exi_leavedef(exoid, __func__)) != NC_NOERR) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -207,6 +207,6 @@ int ex_put_attr_param(int exoid, ex_entity_type obj_type, ex_entity_id obj_id, i
 
 /* Fatal error: exit definition mode and return */
 error_ret:
-  ex__leavedef(exoid, __func__);
+  exi_leavedef(exoid, __func__);
   EX_FUNC_LEAVE(EX_FATAL);
 }

--- a/packages/seacas/libraries/exodus/src/ex_put_attribute.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_attribute.c
@@ -22,7 +22,7 @@
    attributes which are currently supported in Exodus.
 */
 
-static int ex__get_varid(int exoid, ex_entity_type obj_type, ex_entity_id id)
+static int exi_get_varid(int exoid, ex_entity_type obj_type, ex_entity_id id)
 {
   const char *entryptr = NULL;
   char        errmsg[MAX_ERR_LENGTH];
@@ -31,7 +31,7 @@ static int ex__get_varid(int exoid, ex_entity_type obj_type, ex_entity_id id)
   int status = 0;
   int varid  = 0;
 
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -63,7 +63,7 @@ static int ex__get_varid(int exoid, ex_entity_type obj_type, ex_entity_id id)
 
   /* Everything else ... */
   /* First, locate index of this objects id `obj_type` id array */
-  id_ndx = ex__id_lkup(exoid, obj_type, id);
+  id_ndx = exi_id_lkup(exoid, obj_type, id);
   if (id_ndx <= 0) {
     ex_get_err(NULL, NULL, &status);
     if (status != 0) {
@@ -113,9 +113,9 @@ int ex_put_double_attribute(int exoid, ex_entity_type obj_type, ex_entity_id id,
   int  varid;
 
   EX_FUNC_ENTER();
-  varid = ex__get_varid(exoid, obj_type, id);
+  varid = exi_get_varid(exoid, obj_type, id);
   if (varid <= 0 && obj_type != EX_GLOBAL) {
-    /* Error message handled in ex__get_varid */
+    /* Error message handled in exi_get_varid */
     EX_FUNC_LEAVE(varid);
   }
 
@@ -136,7 +136,7 @@ int ex_put_double_attribute(int exoid, ex_entity_type obj_type, ex_entity_id id,
   }
 
   /* leave define mode  */
-  if ((status = ex__leavedef(exoid, __func__)) != NC_NOERR) {
+  if ((status = exi_leavedef(exoid, __func__)) != NC_NOERR) {
     snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to exit define mode");
     ex_err_fn(exoid, __func__, errmsg, status);
     EX_FUNC_LEAVE(EX_FATAL);
@@ -146,7 +146,7 @@ int ex_put_double_attribute(int exoid, ex_entity_type obj_type, ex_entity_id id,
 
 /* Fatal error: exit definition mode and return */
 error_ret:
-  ex__leavedef(exoid, __func__);
+  exi_leavedef(exoid, __func__);
   EX_FUNC_LEAVE(EX_FATAL);
 }
 
@@ -159,9 +159,9 @@ int ex_put_integer_attribute(int exoid, ex_entity_type obj_type, ex_entity_id id
   int  varid;
 
   EX_FUNC_ENTER();
-  varid = ex__get_varid(exoid, obj_type, id);
+  varid = exi_get_varid(exoid, obj_type, id);
   if (varid <= 0 && obj_type != EX_GLOBAL) {
-    /* Error message handled in ex__get_varid */
+    /* Error message handled in exi_get_varid */
     EX_FUNC_LEAVE(varid);
   }
 
@@ -188,7 +188,7 @@ int ex_put_integer_attribute(int exoid, ex_entity_type obj_type, ex_entity_id id
   }
 
   /* leave define mode  */
-  if ((status = ex__leavedef(exoid, __func__)) != NC_NOERR) {
+  if ((status = exi_leavedef(exoid, __func__)) != NC_NOERR) {
     snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to exit define mode");
     ex_err_fn(exoid, __func__, errmsg, status);
     EX_FUNC_LEAVE(EX_FATAL);
@@ -198,7 +198,7 @@ int ex_put_integer_attribute(int exoid, ex_entity_type obj_type, ex_entity_id id
 
 /* Fatal error: exit definition mode and return */
 error_ret:
-  ex__leavedef(exoid, __func__);
+  exi_leavedef(exoid, __func__);
   EX_FUNC_LEAVE(EX_FATAL);
 }
 
@@ -212,9 +212,9 @@ int ex_put_text_attribute(int exoid, ex_entity_type obj_type, ex_entity_id id, c
 
   EX_FUNC_ENTER();
 
-  varid = ex__get_varid(exoid, obj_type, id);
+  varid = exi_get_varid(exoid, obj_type, id);
   if (varid <= 0 && obj_type != EX_GLOBAL) {
-    /* Error message handled in ex__get_varid */
+    /* Error message handled in exi_get_varid */
     EX_FUNC_LEAVE(varid);
   }
 
@@ -234,7 +234,7 @@ int ex_put_text_attribute(int exoid, ex_entity_type obj_type, ex_entity_id id, c
   }
 
   /* leave define mode  */
-  if ((status = ex__leavedef(exoid, __func__)) != NC_NOERR) {
+  if ((status = exi_leavedef(exoid, __func__)) != NC_NOERR) {
     snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to exit define mode");
     ex_err_fn(exoid, __func__, errmsg, status);
     EX_FUNC_LEAVE(EX_FATAL);
@@ -244,7 +244,7 @@ int ex_put_text_attribute(int exoid, ex_entity_type obj_type, ex_entity_id id, c
 
 /* Fatal error: exit definition mode and return */
 error_ret:
-  ex__leavedef(exoid, __func__);
+  exi_leavedef(exoid, __func__);
   EX_FUNC_LEAVE(EX_FATAL);
 }
 

--- a/packages/seacas/libraries/exodus/src/ex_put_blobs.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_blobs.c
@@ -23,7 +23,7 @@ int ex_put_blobs(int exoid, size_t count, const struct ex_blob *blobs)
 
   EX_FUNC_ENTER();
 
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -85,7 +85,7 @@ int ex_put_blobs(int exoid, size_t count, const struct ex_blob *blobs)
       }
       goto error_ret; /* exit define mode and return */
     }
-    ex__compress_variable(exoid, entlst_id[i], 1);
+    exi_compress_variable(exoid, entlst_id[i], 1);
 
     if (ex_int64_status(exoid) & EX_IDS_INT64_DB) {
       long long id = blobs[i].id;
@@ -111,13 +111,13 @@ int ex_put_blobs(int exoid, size_t count, const struct ex_blob *blobs)
     }
 
     /* Increment blob count */
-    struct ex__file_item *file = ex__find_file_item(exoid);
+    struct exi_file_item *file = exi_find_file_item(exoid);
     if (file) {
       file->blob_count++;
     }
   }
   /* leave define mode  */
-  if ((status = ex__leavedef(exoid, __func__)) != NC_NOERR) {
+  if ((status = exi_leavedef(exoid, __func__)) != NC_NOERR) {
     snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to exit define mode in file id %d", exoid);
     ex_err_fn(exoid, __func__, errmsg, status);
     free(entlst_id);
@@ -141,7 +141,7 @@ int ex_put_blobs(int exoid, size_t count, const struct ex_blob *blobs)
 
 /* Fatal error: exit definition mode and return */
 error_ret:
-  ex__leavedef(exoid, __func__);
+  exi_leavedef(exoid, __func__);
   free(entlst_id);
   EX_FUNC_LEAVE(EX_FATAL);
 }

--- a/packages/seacas/libraries/exodus/src/ex_put_block_params.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_block_params.c
@@ -59,7 +59,7 @@ int ex_put_block_params(int exoid, size_t block_count, const struct ex_block *bl
   }
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -112,7 +112,7 @@ int ex_put_block_params(int exoid, size_t block_count, const struct ex_block *bl
       ex_err_fn(exoid, __func__, errmsg, EX_BADPARAM);
       EX_FUNC_LEAVE(EX_FATAL);
     }
-    if ((status = ex__get_dimension(exoid, dnumblk, ex_name_of_object(last_type), &num_blk, &dimid,
+    if ((status = exi_get_dimension(exoid, dnumblk, ex_name_of_object(last_type), &num_blk, &dimid,
                                     __func__)) != NC_NOERR) {
       snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: No %ss defined in file id %d",
                ex_name_of_object(last_type), exoid);
@@ -121,7 +121,7 @@ int ex_put_block_params(int exoid, size_t block_count, const struct ex_block *bl
     }
 
     if (block_count == num_blk) {
-      status = ex__put_homogenous_block_params(exoid, block_count, blocks);
+      status = exi_put_homogenous_block_params(exoid, block_count, blocks);
       EX_FUNC_LEAVE(status);
     }
   }
@@ -162,7 +162,7 @@ int ex_put_block_params(int exoid, size_t block_count, const struct ex_block *bl
     }
 
     /* first check if any blocks of that type are specified */
-    if ((status = ex__get_dimension(exoid, dnumblk, ex_name_of_object(blocks[i].type), &num_blk,
+    if ((status = exi_get_dimension(exoid, dnumblk, ex_name_of_object(blocks[i].type), &num_blk,
                                     &dimid, __func__)) != NC_NOERR) {
       snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: No %ss defined in file id %d",
                ex_name_of_object(blocks[i].type), exoid);
@@ -186,7 +186,7 @@ int ex_put_block_params(int exoid, size_t block_count, const struct ex_block *bl
       EX_FUNC_LEAVE(EX_FATAL);
     }
 
-    status = ex__id_lkup(exoid, blocks[i].type, blocks[i].id);
+    status = exi_id_lkup(exoid, blocks[i].type, blocks[i].id);
     if (-status != EX_LOOKUPFAIL) { /* found the element block id */
       snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: %s id %" PRId64 " already exists in file id %d",
                ex_name_of_object(blocks[i].type), blocks[i].id, exoid);
@@ -197,10 +197,10 @@ int ex_put_block_params(int exoid, size_t block_count, const struct ex_block *bl
 
     /* Keep track of the total number of element blocks defined using a counter
        stored in a linked list keyed by exoid.
-       NOTE: ex__get_file_item  is a function that finds the number of element
+       NOTE: exi_get_file_item  is a function that finds the number of element
        blocks for a specific file and returns that value.
     */
-    cur_num_blk = ex__get_file_item(exoid, ex__get_counter_list(blocks[i].type));
+    cur_num_blk = exi_get_file_item(exoid, exi_get_counter_list(blocks[i].type));
     if (cur_num_blk >= (int)num_blk) {
       snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: exceeded number of %ss (%d) defined in file id %d",
                ex_name_of_object(blocks[i].type), (int)num_blk, exoid);
@@ -209,9 +209,9 @@ int ex_put_block_params(int exoid, size_t block_count, const struct ex_block *bl
       EX_FUNC_LEAVE(EX_FATAL);
     }
 
-    /*   NOTE: ex__inc_file_item  is a function that finds the number of element
+    /*   NOTE: exi_inc_file_item  is a function that finds the number of element
          blocks for a specific file and returns that value incremented. */
-    cur_num_blk = ex__inc_file_item(exoid, ex__get_counter_list(blocks[i].type));
+    cur_num_blk = exi_inc_file_item(exoid, exi_get_counter_list(blocks[i].type));
     start[0]    = cur_num_blk;
 
     /* write out block id to previously defined id array variable*/
@@ -380,7 +380,7 @@ int ex_put_block_params(int exoid, size_t block_count, const struct ex_block *bl
         ex_err_fn(exoid, __func__, errmsg, status);
         goto error_ret; /* exit define mode and return */
       }
-      ex__compress_variable(exoid, varid, 2);
+      exi_compress_variable(exoid, varid, 2);
 
       /* inquire previously defined dimensions  */
       if ((status = nc_inq_dimid(exoid, DIM_STR_NAME, &strdim)) != NC_NOERR) {
@@ -514,7 +514,7 @@ int ex_put_block_params(int exoid, size_t block_count, const struct ex_block *bl
           ex_err_fn(exoid, __func__, errmsg, status);
           goto error_ret; /* exit define mode and return */
         }
-        ex__compress_variable(exoid, connid, 1);
+        exi_compress_variable(exoid, connid, 1);
       }
     }
     /* store element type as attribute of connectivity variable */
@@ -562,7 +562,7 @@ int ex_put_block_params(int exoid, size_t block_count, const struct ex_block *bl
   free(blocks_to_define);
 
   /* leave define mode  */
-  if ((status = ex__leavedef(exoid, __func__)) != NC_NOERR) {
+  if ((status = exi_leavedef(exoid, __func__)) != NC_NOERR) {
     snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to exit define mode");
     ex_err_fn(exoid, __func__, errmsg, status);
     EX_FUNC_LEAVE(EX_FATAL);
@@ -603,6 +603,6 @@ int ex_put_block_params(int exoid, size_t block_count, const struct ex_block *bl
 error_ret:
   free(blocks_to_define);
 
-  ex__leavedef(exoid, __func__);
+  exi_leavedef(exoid, __func__);
   EX_FUNC_LEAVE(EX_FATAL);
 }

--- a/packages/seacas/libraries/exodus/src/ex_put_cmap_params.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_cmap_params.c
@@ -33,7 +33,7 @@
 /*****************************************************************************/
 
 #include <exodusII.h>     // for ex_err, etc
-#include <exodusII_int.h> // for EX_FATAL, ex__leavedef, etc
+#include <exodusII_int.h> // for EX_FATAL, exi_leavedef, etc
 
 int ex_put_cmap_params(int exoid, const void_int *node_cmap_ids,
                        const void_int *node_cmap_node_cnts, const void_int *elem_cmap_ids,
@@ -48,7 +48,7 @@ int ex_put_cmap_params(int exoid, const void_int *node_cmap_ids,
   EX_UNUSED(processor);
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -71,7 +71,7 @@ int ex_put_cmap_params(int exoid, const void_int *node_cmap_ids,
   ** be used for writing a parallel file
   */
   /* Get the file type */
-  if (ex__get_file_type(exoid, ftype) != EX_NOERR) {
+  if (exi_get_file_type(exoid, ftype) != EX_NOERR) {
     snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to get file type from file ID %d\n", exoid);
     ex_err_fn(exoid, __func__, errmsg, EX_MSG);
     EX_FUNC_LEAVE(EX_FATAL);
@@ -122,7 +122,7 @@ int ex_put_cmap_params(int exoid, const void_int *node_cmap_ids,
                VAR_N_COMM_DATA_IDX, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
@@ -145,7 +145,7 @@ int ex_put_cmap_params(int exoid, const void_int *node_cmap_ids,
                DIM_NCNT_CMAP, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
@@ -157,22 +157,22 @@ int ex_put_cmap_params(int exoid, const void_int *node_cmap_ids,
                VAR_N_COMM_NIDS, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
-    ex__compress_variable(exoid, varid, 1);
+    exi_compress_variable(exoid, varid, 1);
 
     if ((status = nc_def_var(exoid, VAR_N_COMM_PROC, NC_INT, 1, dimid, &varid)) != NC_NOERR) {
       snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to add variable \"%s\" in file ID %d",
                VAR_N_COMM_PROC, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
-    ex__compress_variable(exoid, varid, 1);
+    exi_compress_variable(exoid, varid, 1);
 
   } /* End "if (num_n_comm_maps > 0)" */
 
@@ -205,7 +205,7 @@ int ex_put_cmap_params(int exoid, const void_int *node_cmap_ids,
                VAR_E_COMM_DATA_IDX, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
@@ -227,7 +227,7 @@ int ex_put_cmap_params(int exoid, const void_int *node_cmap_ids,
                DIM_ECNT_CMAP, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
@@ -239,38 +239,38 @@ int ex_put_cmap_params(int exoid, const void_int *node_cmap_ids,
                VAR_E_COMM_EIDS, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
-    ex__compress_variable(exoid, varid, 1);
+    exi_compress_variable(exoid, varid, 1);
 
     if ((status = nc_def_var(exoid, VAR_E_COMM_PROC, NC_INT, 1, dimid, &varid)) != NC_NOERR) {
       snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to add variable \"%s\" in file ID %d",
                VAR_E_COMM_PROC, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
-    ex__compress_variable(exoid, varid, 1);
+    exi_compress_variable(exoid, varid, 1);
 
     if ((status = nc_def_var(exoid, VAR_E_COMM_SIDS, NC_INT, 1, dimid, &varid)) != NC_NOERR) {
       snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to add variable \"%s\" in file ID %d",
                VAR_E_COMM_SIDS, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
-    ex__compress_variable(exoid, varid, 1);
+    exi_compress_variable(exoid, varid, 1);
 
   } /* End "if (num_e_comm_maps > 0)" */
 
   /* Exit define mode */
-  ex__leavedef(exoid, __func__);
+  exi_leavedef(exoid, __func__);
 
   /* Set the status of the nodal communication maps */
   if (num_n_comm_maps > 0) {

--- a/packages/seacas/libraries/exodus/src/ex_put_cmap_params_cc.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_cmap_params_cc.c
@@ -33,7 +33,7 @@
 /*****************************************************************************/
 /*****************************************************************************/
 #include <exodusII.h>     // for ex_err, etc
-#include <exodusII_int.h> // for EX_FATAL, ex__leavedef, etc
+#include <exodusII_int.h> // for EX_FATAL, exi_leavedef, etc
 
 int ex_put_cmap_params_cc(int exoid, const void_int *node_cmap_ids,
                           const void_int *node_cmap_node_cnts, const void_int *node_proc_ptrs,
@@ -59,7 +59,7 @@ int ex_put_cmap_params_cc(int exoid, const void_int *node_cmap_ids,
   /*-----------------------------Execution begins-----------------------------*/
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -233,7 +233,7 @@ file ID %d",
                VAR_N_COMM_DATA_IDX, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
@@ -263,7 +263,7 @@ file ID %d",
                ncnt_cmap, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
@@ -274,22 +274,22 @@ file ID %d",
                VAR_N_COMM_NIDS, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
-    ex__compress_variable(exoid, varid, 1);
+    exi_compress_variable(exoid, varid, 1);
 
     if ((status = nc_def_var(exoid, VAR_N_COMM_PROC, NC_INT, 1, n_dimid, &varid)) != NC_NOERR) {
       snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to add variable \"%s\" in file ID %d",
                VAR_N_COMM_PROC, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
-    ex__compress_variable(exoid, varid, 1);
+    exi_compress_variable(exoid, varid, 1);
 
   } /* End "if (num_n_comm_maps > 0)" */
 
@@ -305,7 +305,7 @@ file ID %d",
                VAR_E_COMM_DATA_IDX, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
@@ -335,7 +335,7 @@ file ID %d",
                DIM_ECNT_CMAP, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
@@ -346,38 +346,38 @@ file ID %d",
                VAR_E_COMM_EIDS, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
-    ex__compress_variable(exoid, varid, 1);
+    exi_compress_variable(exoid, varid, 1);
 
     if ((status = nc_def_var(exoid, VAR_E_COMM_PROC, NC_INT, 1, e_dimid, &varid)) != NC_NOERR) {
       snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to add variable \"%s\" in file ID %d",
                VAR_E_COMM_PROC, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
-    ex__compress_variable(exoid, varid, 1);
+    exi_compress_variable(exoid, varid, 1);
 
     if ((status = nc_def_var(exoid, VAR_E_COMM_SIDS, bulk_type, 1, e_dimid, &varid)) != NC_NOERR) {
       snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to add variable \"%s\" in file ID %d",
                VAR_E_COMM_SIDS, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
-    ex__compress_variable(exoid, varid, 1);
+    exi_compress_variable(exoid, varid, 1);
 
   } /* End "if (num_e_comm_maps > 0)" */
 
   /* Exit define mode */
-  ex__leavedef(exoid, __func__);
+  exi_leavedef(exoid, __func__);
 
   /* Set the status of the nodal communication maps */
   if (num_n_comm_maps > 0) {

--- a/packages/seacas/libraries/exodus/src/ex_put_concat_all_blocks.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_concat_all_blocks.c
@@ -85,7 +85,7 @@ int ex_put_concat_all_blocks(int exoid, const ex_block_params *param)
     elem_id_int = param->elem_blk_id;
   }
 
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -235,7 +235,7 @@ int ex_put_concat_all_blocks(int exoid, const ex_block_params *param)
       ex_err_fn(exoid, __func__, errmsg, status);                                                  \
       goto error_ret; /* exit define mode and return */                                            \
     }                                                                                              \
-    ex__compress_variable(exoid, temp, 2);                                                         \
+    exi_compress_variable(exoid, temp, 2);                                                         \
                                                                                                    \
     /* Attribute names... */                                                                       \
     dims[0] = VADIM1;                                                                              \
@@ -274,7 +274,7 @@ int ex_put_concat_all_blocks(int exoid, const ex_block_params *param)
       ex_err_fn(exoid, __func__, errmsg, status);                                                  \
       goto error_ret; /* exit define mode and return */                                            \
     }                                                                                              \
-    ex__compress_variable(exoid, temp, 2);                                                         \
+    exi_compress_variable(exoid, temp, 2);                                                         \
                                                                                                    \
     /* Attribute names... */                                                                       \
     dims[0] = VADIM1;                                                                              \
@@ -307,7 +307,7 @@ int ex_put_concat_all_blocks(int exoid, const ex_block_params *param)
       ex_err_fn(exoid, __func__, errmsg, status);                                                  \
       goto error_ret; /* exit define mode and return */                                            \
     }                                                                                              \
-    ex__compress_variable(exoid, connid, 1);                                                       \
+    exi_compress_variable(exoid, connid, 1);                                                       \
   }
 
   /* Iterate over edge blocks ... */
@@ -320,7 +320,7 @@ int ex_put_concat_all_blocks(int exoid, const ex_block_params *param)
       eb_id = edge_id_int[iblk];
     }
 
-    cur_num_edge_blk = ex__get_file_item(exoid, ex__get_counter_list(EX_EDGE_BLOCK));
+    cur_num_edge_blk = exi_get_file_item(exoid, exi_get_counter_list(EX_EDGE_BLOCK));
     if (cur_num_edge_blk >= (int)num_edge_blk) {
       snprintf(errmsg, MAX_ERR_LENGTH,
                "ERROR: exceeded number of edge blocks (%ld) defined in file id %d",
@@ -329,9 +329,9 @@ int ex_put_concat_all_blocks(int exoid, const ex_block_params *param)
       goto error_ret;
     }
 
-    /* NOTE: ex__inc_file_item  is used to find the number of edge blocks
+    /* NOTE: exi_inc_file_item  is used to find the number of edge blocks
        for a specific file and returns that value incremented. */
-    cur_num_edge_blk = ex__inc_file_item(exoid, ex__get_counter_list(EX_EDGE_BLOCK));
+    cur_num_edge_blk = exi_inc_file_item(exoid, exi_get_counter_list(EX_EDGE_BLOCK));
 
     if (param->num_edge_this_blk[iblk] == 0) { /* Is this a NULL edge block? */
       continue;
@@ -388,7 +388,7 @@ int ex_put_concat_all_blocks(int exoid, const ex_block_params *param)
       fb_id = face_id_int[iblk];
     }
 
-    cur_num_face_blk = ex__get_file_item(exoid, ex__get_counter_list(EX_FACE_BLOCK));
+    cur_num_face_blk = exi_get_file_item(exoid, exi_get_counter_list(EX_FACE_BLOCK));
     if (cur_num_face_blk >= (int)num_face_blk) {
       snprintf(errmsg, MAX_ERR_LENGTH,
                "ERROR: exceeded number of face blocks (%ld) defined in file id %d",
@@ -397,9 +397,9 @@ int ex_put_concat_all_blocks(int exoid, const ex_block_params *param)
       goto error_ret;
     }
 
-    /* NOTE: ex__inc_file_item  is used to find the number of edge blocks
+    /* NOTE: exi_inc_file_item  is used to find the number of edge blocks
        for a specific file and returns that value incremented. */
-    cur_num_face_blk = ex__inc_file_item(exoid, ex__get_counter_list(EX_FACE_BLOCK));
+    cur_num_face_blk = exi_inc_file_item(exoid, exi_get_counter_list(EX_FACE_BLOCK));
 
     if (param->num_face_this_blk[iblk] == 0) { /* Is this a NULL face block? */
       continue;
@@ -456,7 +456,7 @@ int ex_put_concat_all_blocks(int exoid, const ex_block_params *param)
       eb_id = elem_id_int[iblk];
     }
 
-    cur_num_elem_blk = ex__get_file_item(exoid, ex__get_counter_list(EX_ELEM_BLOCK));
+    cur_num_elem_blk = exi_get_file_item(exoid, exi_get_counter_list(EX_ELEM_BLOCK));
     if (cur_num_elem_blk >= (int)num_elem_blk) {
       snprintf(errmsg, MAX_ERR_LENGTH,
                "ERROR: exceeded number of element blocks (%ld) defined "
@@ -466,9 +466,9 @@ int ex_put_concat_all_blocks(int exoid, const ex_block_params *param)
       goto error_ret;
     }
 
-    /* NOTE: ex__inc_file_item  is used to find the number of element blocks
+    /* NOTE: exi_inc_file_item  is used to find the number of element blocks
        for a specific file and returns that value incremented. */
-    cur_num_elem_blk = ex__inc_file_item(exoid, ex__get_counter_list(EX_ELEM_BLOCK));
+    cur_num_elem_blk = exi_inc_file_item(exoid, exi_get_counter_list(EX_ELEM_BLOCK));
 
     if (param->num_elem_this_blk[iblk] == 0) { /* Is this a NULL element block? */
       continue;
@@ -557,7 +557,7 @@ int ex_put_concat_all_blocks(int exoid, const ex_block_params *param)
         ex_err_fn(exoid, __func__, errmsg, status);
       }
       for (i = 1; i <= num_maps[map_type]; ++i) {
-        const char *mapname = ex__name_of_map(map_enums[map_type], i);
+        const char *mapname = exi_name_of_map(map_enums[map_type], i);
         if (nc_inq_varid(exoid, mapname, &temp) != NC_NOERR) {
           int map_int_type = NC_INT;
           if (ex_int64_status(exoid) & EX_MAPS_INT64_DB) {
@@ -576,14 +576,14 @@ int ex_put_concat_all_blocks(int exoid, const ex_block_params *param)
             ex_err_fn(exoid, __func__, errmsg, status);
             goto error_ret; /* exit define mode and return */
           }
-          ex__compress_variable(exoid, temp, 1);
+          exi_compress_variable(exoid, temp, 1);
         }
       }
     }
   }
 
   /* leave define mode  */
-  if ((status = ex__leavedef(exoid, __func__)) != NC_NOERR) {
+  if ((status = exi_leavedef(exoid, __func__)) != NC_NOERR) {
     snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to exit define mode");
     ex_err_fn(exoid, __func__, errmsg, status);
     EX_FUNC_LEAVE(EX_FATAL);
@@ -593,6 +593,6 @@ int ex_put_concat_all_blocks(int exoid, const ex_block_params *param)
 
 /* Fatal error: exit definition mode and return */
 error_ret:
-  ex__leavedef(exoid, __func__);
+  exi_leavedef(exoid, __func__);
   EX_FUNC_LEAVE(EX_FATAL);
 }

--- a/packages/seacas/libraries/exodus/src/ex_put_concat_elem_block.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_concat_elem_block.c
@@ -49,7 +49,7 @@ int ex_put_concat_elem_block(int exoid, const void_int *elem_blk_id, char *const
   char   errmsg[MAX_ERR_LENGTH];
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -180,7 +180,7 @@ int ex_put_concat_elem_block(int exoid, const void_int *elem_blk_id, char *const
       num_attr = ((int *)num_attr_this_blk)[iblk];
     }
 
-    cur_num_elem_blk = ex__get_file_item(exoid, ex__get_counter_list(EX_ELEM_BLOCK));
+    cur_num_elem_blk = exi_get_file_item(exoid, exi_get_counter_list(EX_ELEM_BLOCK));
     if (cur_num_elem_blk >= num_elem_blk) {
       snprintf(errmsg, MAX_ERR_LENGTH,
                "ERROR: exceeded number of element blocks (%d) defined in file id %d", num_elem_blk,
@@ -189,9 +189,9 @@ int ex_put_concat_elem_block(int exoid, const void_int *elem_blk_id, char *const
       goto error_ret;
     }
 
-    /* NOTE: ex__inc_file_item  is used to find the number of element blocks
+    /* NOTE: exi_inc_file_item  is used to find the number of element blocks
        for a specific file and returns that value incremented. */
-    cur_num_elem_blk = ex__inc_file_item(exoid, ex__get_counter_list(EX_ELEM_BLOCK));
+    cur_num_elem_blk = exi_inc_file_item(exoid, exi_get_counter_list(EX_ELEM_BLOCK));
 
     if (eb_array[iblk] == 0) { /* Is this a NULL element block? */
       continue;
@@ -236,7 +236,7 @@ int ex_put_concat_elem_block(int exoid, const void_int *elem_blk_id, char *const
       ex_err_fn(exoid, __func__, errmsg, status);
       goto error_ret; /* exit define mode and return */
     }
-    ex__compress_variable(exoid, connid, 1);
+    exi_compress_variable(exoid, connid, 1);
 
     /* store element type as attribute of connectivity variable */
     if ((status = nc_put_att_text(exoid, connid, ATT_NAME_ELB, strlen(elem_type[iblk]) + 1,
@@ -312,7 +312,7 @@ int ex_put_concat_elem_block(int exoid, const void_int *elem_blk_id, char *const
           ex_err_fn(exoid, __func__, errmsg, status);
           goto error_ret; /* exit define mode and return */
         }
-        ex__compress_variable(exoid, temp, 1);
+        exi_compress_variable(exoid, temp, 1);
       }
     }
 
@@ -336,13 +336,13 @@ int ex_put_concat_elem_block(int exoid, const void_int *elem_blk_id, char *const
           ex_err_fn(exoid, __func__, errmsg, status);
           goto error_ret; /* exit define mode and return */
         }
-        ex__compress_variable(exoid, temp, 1);
+        exi_compress_variable(exoid, temp, 1);
       }
     }
   }
 
   /* leave define mode  */
-  if ((status = ex__leavedef(exoid, __func__)) != NC_NOERR) {
+  if ((status = exi_leavedef(exoid, __func__)) != NC_NOERR) {
     snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to exit define mode");
     ex_err_fn(exoid, __func__, errmsg, status);
     free(eb_array);
@@ -383,6 +383,6 @@ int ex_put_concat_elem_block(int exoid, const void_int *elem_blk_id, char *const
 /* Fatal error: exit definition mode and return */
 error_ret:
   free(eb_array);
-  ex__leavedef(exoid, __func__);
+  exi_leavedef(exoid, __func__);
   EX_FUNC_LEAVE(EX_FATAL);
 }

--- a/packages/seacas/libraries/exodus/src/ex_put_concat_sets.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_concat_sets.c
@@ -23,7 +23,7 @@
  *****************************************************************************/
 
 #include "exodusII.h"     // for ex_err, etc
-#include "exodusII_int.h" // for EX_FATAL, ex__comp_ws, etc
+#include "exodusII_int.h" // for EX_FATAL, exi_comp_ws, etc
 
 /*!
  * writes the set ID's, set entry count array, set entry pointers array,
@@ -61,7 +61,7 @@ int ex_put_concat_sets(int exoid, ex_entity_type set_type, const struct ex_set_s
   ex_inquiry    ex_inq_val;
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -105,7 +105,7 @@ int ex_put_concat_sets(int exoid, ex_entity_type set_type, const struct ex_set_s
   }
 
   /* first check if any sets are specified */
-  if ((status = nc_inq_dimid(exoid, ex__dim_num_objects(set_type), &temp)) != NC_NOERR) {
+  if ((status = nc_inq_dimid(exoid, exi_dim_num_objects(set_type), &temp)) != NC_NOERR) {
     if (status == NC_EBADDIM) {
       snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: no %ss defined for file id %d",
                ex_name_of_object(set_type), exoid);
@@ -190,10 +190,10 @@ int ex_put_concat_sets(int exoid, ex_entity_type set_type, const struct ex_set_s
 
     /* Keep track of the total number of sets defined using a counter stored
        in a linked list keyed by exoid.
-       NOTE: ex__get_file_item  is used to find the number of sets of type
+       NOTE: exi_get_file_item  is used to find the number of sets of type
        for a specific file and returns that value.
     */
-    cur_num_sets = ex__get_file_item(exoid, ex__get_counter_list(set_type));
+    cur_num_sets = exi_get_file_item(exoid, exi_get_counter_list(set_type));
     if (cur_num_sets >= num_sets) {
       snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: exceeded number of %ss (%d) defined in file id %d",
                ex_name_of_object(set_type), num_sets, exoid);
@@ -201,10 +201,10 @@ int ex_put_concat_sets(int exoid, ex_entity_type set_type, const struct ex_set_s
       goto error_ret;
     }
 
-    /*   NOTE: ex__inc_file_item  is used to find the number of sets
+    /*   NOTE: exi_inc_file_item  is used to find the number of sets
          for a specific file and returns that value incremented. */
 
-    cur_num_sets = ex__inc_file_item(exoid, ex__get_counter_list(set_type));
+    cur_num_sets = exi_inc_file_item(exoid, exi_get_counter_list(set_type));
     set_id_ndx   = cur_num_sets + 1;
 
     /* setup more pointers based on set_type */
@@ -246,11 +246,11 @@ int ex_put_concat_sets(int exoid, ex_entity_type set_type, const struct ex_set_s
     }
 
     if (int_size == sizeof(int)) {
-      status = nc_def_dim(exoid, ex__dim_num_entries_in_object(set_type, set_id_ndx),
+      status = nc_def_dim(exoid, exi_dim_num_entries_in_object(set_type, set_id_ndx),
                           ((int *)num_entries_per_set)[i], &dimid);
     }
     else {
-      status = nc_def_dim(exoid, ex__dim_num_entries_in_object(set_type, set_id_ndx),
+      status = nc_def_dim(exoid, exi_dim_num_entries_in_object(set_type, set_id_ndx),
                           ((int64_t *)num_entries_per_set)[i], &dimid);
     }
 
@@ -292,7 +292,7 @@ int ex_put_concat_sets(int exoid, ex_entity_type set_type, const struct ex_set_s
       }
       goto error_ret; /* exit define mode and return */
     }
-    ex__compress_variable(exoid, temp, 1);
+    exi_compress_variable(exoid, temp, 1);
 
     /* create extra list variable for set  (only for edge, face and side sets)
      */
@@ -312,7 +312,7 @@ int ex_put_concat_sets(int exoid, ex_entity_type set_type, const struct ex_set_s
         }
         goto error_ret; /* exit define mode and return */
       }
-      ex__compress_variable(exoid, temp, 1);
+      exi_compress_variable(exoid, temp, 1);
     }
 
     /*  define dimension for number of dist factors per set */
@@ -375,12 +375,12 @@ int ex_put_concat_sets(int exoid, ex_entity_type set_type, const struct ex_set_s
         }
         goto error_ret; /* exit define mode and return */
       }
-      ex__compress_variable(exoid, temp, 2);
+      exi_compress_variable(exoid, temp, 2);
     } /* end define dist factors */
   }
 
   /* leave define mode  */
-  if ((status = ex__leavedef(exoid, __func__)) != NC_NOERR) {
+  if ((status = exi_leavedef(exoid, __func__)) != NC_NOERR) {
     snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to exit define mode");
     ex_err_fn(exoid, __func__, errmsg, status);
     free(set_stat);
@@ -475,7 +475,7 @@ int ex_put_concat_sets(int exoid, ex_entity_type set_type, const struct ex_set_s
       df_ndx = ((int64_t *)sets_dist_index)[i];
     }
 
-    if (ex__comp_ws(exoid) == sizeof(float)) {
+    if (exi_comp_ws(exoid) == sizeof(float)) {
       flt_dist_fact = sets_dist_fact;
       if (num_df > 0) { /* store dist factors if required */
         if (ex_put_set_dist_fact(exoid, set_type, set_id, &(flt_dist_fact[df_ndx])) == -1) {
@@ -489,7 +489,7 @@ int ex_put_concat_sets(int exoid, ex_entity_type set_type, const struct ex_set_s
         }
       }
     }
-    else if (ex__comp_ws(exoid) == sizeof(double)) {
+    else if (exi_comp_ws(exoid) == sizeof(double)) {
       dbl_dist_fact = sets_dist_fact;
       if (num_df) { /* only store if they exist */
         if (ex_put_set_dist_fact(exoid, set_type, set_id, &(dbl_dist_fact[df_ndx])) == -1) {
@@ -506,7 +506,7 @@ int ex_put_concat_sets(int exoid, ex_entity_type set_type, const struct ex_set_s
     else {
       /* unknown floating point word size */
       snprintf(errmsg, MAX_ERR_LENGTH,
-               "ERROR: unsupported floating point word size %d for file id %d", ex__comp_ws(exoid),
+               "ERROR: unsupported floating point word size %d for file id %d", exi_comp_ws(exoid),
                exoid);
       ex_err_fn(exoid, __func__, errmsg, EX_BADPARAM);
       free(set_stat);
@@ -520,6 +520,6 @@ int ex_put_concat_sets(int exoid, ex_entity_type set_type, const struct ex_set_s
 error_ret:
   free(set_stat);
 
-  ex__leavedef(exoid, __func__);
+  exi_leavedef(exoid, __func__);
   EX_FUNC_LEAVE(EX_FATAL);
 }

--- a/packages/seacas/libraries/exodus/src/ex_put_conn.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_conn.c
@@ -7,7 +7,7 @@
  */
 
 #include "exodusII.h"     // for ex_err, etc
-#include "exodusII_int.h" // for EX_FATAL, ex__id_lkup, etc
+#include "exodusII_int.h" // for EX_FATAL, exi_id_lkup, etc
 
 /*! write out the connectivity array */
 int ex_int_write_conn(int exoid, ex_entity_id blk_id, const char *type, int var_id,
@@ -49,11 +49,11 @@ int ex_put_conn(int exoid, ex_entity_type blk_type, ex_entity_id blk_id, const v
   char errmsg[MAX_ERR_LENGTH];
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
-  int blk_id_ndx = ex__id_lkup(exoid, blk_type, blk_id);
+  int blk_id_ndx = exi_id_lkup(exoid, blk_type, blk_id);
   if (blk_id_ndx <= 0) {
     ex_get_err(NULL, NULL, &status);
 

--- a/packages/seacas/libraries/exodus/src/ex_put_coord.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_coord.c
@@ -95,7 +95,7 @@ int ex_put_coord(int exoid, const void *x_coor, const void *y_coor, const void *
   char   errmsg[MAX_ERR_LENGTH];
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -181,7 +181,7 @@ int ex_put_coord(int exoid, const void *x_coor, const void *y_coor, const void *
     }
 
     if (coor != NULL && coordid != -1) {
-      if (ex__comp_ws(exoid) == 4) {
+      if (exi_comp_ws(exoid) == 4) {
         status = nc_put_var_float(exoid, coordid, coor);
       }
       else {

--- a/packages/seacas/libraries/exodus/src/ex_put_coord_names.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_coord_names.c
@@ -51,7 +51,7 @@ int ex_put_coord_names(int exoid, char *const coord_names[])
   char   errmsg[MAX_ERR_LENGTH];
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -77,7 +77,7 @@ int ex_put_coord_names(int exoid, char *const coord_names[])
   }
 
   /* write out coordinate names */
-  status = ex__put_names(exoid, varid, num_dim, coord_names, EX_COORDINATE, "", __func__);
+  status = exi_put_names(exoid, varid, num_dim, coord_names, EX_COORDINATE, "", __func__);
 
   EX_FUNC_LEAVE(status);
 }

--- a/packages/seacas/libraries/exodus/src/ex_put_coordinate_frames.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_coordinate_frames.c
@@ -50,7 +50,7 @@ int ex_put_coordinate_frames(int exoid, int nframes, const void_int *cf_ids,
   assert(pt_coordinates != NULL);
   assert(tags != NULL);
 
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -91,7 +91,7 @@ int ex_put_coordinate_frames(int exoid, int nframes, const void_int *cf_ids,
   }
 
   /* leave define mode */
-  if ((status = ex__leavedef(exoid, __func__)) != NC_NOERR) {
+  if ((status = exi_leavedef(exoid, __func__)) != NC_NOERR) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -125,7 +125,7 @@ int ex_put_coordinate_frames(int exoid, int nframes, const void_int *cf_ids,
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
-  if (ex__comp_ws(exoid) == 4) {
+  if (exi_comp_ws(exoid) == 4) {
     status = nc_put_var_float(exoid, varcoords, pt_coordinates);
   }
   else {
@@ -140,6 +140,6 @@ int ex_put_coordinate_frames(int exoid, int nframes, const void_int *cf_ids,
   EX_FUNC_LEAVE(EX_NOERR);
 
 error_ret:
-  ex__leavedef(exoid, __func__);
+  exi_leavedef(exoid, __func__);
   EX_FUNC_LEAVE(EX_FATAL);
 }

--- a/packages/seacas/libraries/exodus/src/ex_put_eb_info_global.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_eb_info_global.c
@@ -32,7 +32,7 @@ int ex_put_eb_info_global(int exoid, const void_int *el_blk_ids, const void_int 
   char errmsg[MAX_ERR_LENGTH];
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 

--- a/packages/seacas/libraries/exodus/src/ex_put_elem_cmap.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_elem_cmap.c
@@ -42,7 +42,7 @@ int ex_put_elem_cmap(int exoid, ex_entity_id map_id, const void_int *elem_ids,
   /*-----------------------------Execution begins-----------------------------*/
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 

--- a/packages/seacas/libraries/exodus/src/ex_put_elem_cmap.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_elem_cmap.c
@@ -56,7 +56,7 @@ int ex_put_elem_cmap(int exoid, ex_entity_id map_id, const void_int *elem_ids,
   }
 
   /* Get the index for this map_id */
-  if ((map_idx = ne__id_lkup(exoid, VAR_E_COMM_IDS, varidx, map_id)) == -1) {
+  if ((map_idx = nei_id_lkup(exoid, VAR_E_COMM_IDS, varidx, map_id)) == -1) {
     snprintf(errmsg, MAX_ERR_LENGTH,
              "ERROR: failed to find index for variable \"%s\" in file ID %d", VAR_E_COMM_IDS,
              exoid);

--- a/packages/seacas/libraries/exodus/src/ex_put_entity_count_per_polyhedra.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_entity_count_per_polyhedra.c
@@ -12,7 +12,7 @@
  *****************************************************************************/
 
 #include "exodusII.h"     // for ex_err, etc
-#include "exodusII_int.h" // for EX_FATAL, ex__id_lkup, etc
+#include "exodusII_int.h" // for EX_FATAL, exi_id_lkup, etc
 
 /*!
  * writes out the number of entities (nodes/faces) per polyhedra
@@ -30,11 +30,11 @@ int ex_put_entity_count_per_polyhedra(int exoid, ex_entity_type blk_type, ex_ent
   char errmsg[MAX_ERR_LENGTH];
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
-  blk_id_ndx = ex__id_lkup(exoid, blk_type, blk_id);
+  blk_id_ndx = exi_id_lkup(exoid, blk_type, blk_id);
   if (blk_id_ndx <= 0) {
     ex_get_err(NULL, NULL, &status);
 

--- a/packages/seacas/libraries/exodus/src/ex_put_id_map.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_id_map.c
@@ -44,7 +44,7 @@ int ex_put_id_map(int exoid, ex_entity_type map_type, const void_int *map)
   const char *vmap;
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -111,10 +111,10 @@ int ex_put_id_map(int exoid, ex_entity_type map_type, const void_int *map)
       }
       goto error_ret; /* exit define mode and return */
     }
-    ex__compress_variable(exoid, mapid, 1);
+    exi_compress_variable(exoid, mapid, 1);
 
     /* leave define mode  */
-    if ((status = ex__leavedef(exoid, __func__)) != NC_NOERR) {
+    if ((status = exi_leavedef(exoid, __func__)) != NC_NOERR) {
       snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to exit define mode");
       ex_err_fn(exoid, __func__, errmsg, status);
       EX_FUNC_LEAVE(EX_FATAL);
@@ -140,6 +140,6 @@ int ex_put_id_map(int exoid, ex_entity_type map_type, const void_int *map)
 
 /* Fatal error: exit definition mode and return */
 error_ret:
-  ex__leavedef(exoid, __func__);
+  exi_leavedef(exoid, __func__);
   EX_FUNC_LEAVE(EX_FATAL);
 }

--- a/packages/seacas/libraries/exodus/src/ex_put_info.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_info.c
@@ -80,7 +80,7 @@ int ex_put_info(int exoid, int num_info, char *const info[])
   int rootid = exoid & EX_FILE_ID_MASK;
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -141,13 +141,13 @@ int ex_put_info(int exoid, int num_info, char *const info[])
        * compilers/mpi so are doing it this way...
        */
 #if defined(PARALLEL_AWARE_EXODUS)
-      if (ex__is_parallel(rootid)) {
+      if (exi_is_parallel(rootid)) {
         nc_var_par_access(rootid, varid, NC_INDEPENDENT);
       }
 #endif
 
       /*   leave define mode  */
-      if ((status = ex__leavedef(rootid, __func__)) != NC_NOERR) {
+      if ((status = exi_leavedef(rootid, __func__)) != NC_NOERR) {
         snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to exit define mode");
         ex_err_fn(exoid, __func__, errmsg, status);
         EX_FUNC_LEAVE(EX_FATAL);
@@ -182,7 +182,7 @@ int ex_put_info(int exoid, int num_info, char *const info[])
     }
     /* PnetCDF applies setting to entire file, so put back to collective... */
 #if defined(PARALLEL_AWARE_EXODUS)
-    if (ex__is_parallel(rootid)) {
+    if (exi_is_parallel(rootid)) {
       nc_var_par_access(rootid, varid, NC_COLLECTIVE);
     }
 #endif
@@ -191,6 +191,6 @@ int ex_put_info(int exoid, int num_info, char *const info[])
 
 /* Fatal error: exit definition mode and return */
 error_ret:
-  ex__leavedef(rootid, __func__);
+  exi_leavedef(rootid, __func__);
   EX_FUNC_LEAVE(EX_FATAL);
 }

--- a/packages/seacas/libraries/exodus/src/ex_put_init_ext.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_init_ext.c
@@ -30,7 +30,7 @@ static void write_dummy_names(int exoid, ex_entity_type obj_type, int num)
   if (num > 0) {
     int    varid;
     size_t num_entity;
-    ex__get_dimension(exoid, ex__dim_num_objects(obj_type), ex_name_of_object(obj_type),
+    exi_get_dimension(exoid, exi_dim_num_objects(obj_type), ex_name_of_object(obj_type),
                       &num_entity, &varid, __func__);
 
     char *text = "";
@@ -57,7 +57,7 @@ static int ex_write_object_names(int exoid, const char *type, const char *dimens
       ex_err_fn(exoid, __func__, errmsg, status);
       return (status); /* exit define mode and return */
     }
-    ex__set_compact_storage(exoid, varid);
+    exi_set_compact_storage(exoid, varid);
 #if defined(EX_CAN_USE_NC_DEF_VAR_FILL)
     int fill = NC_FILL_CHAR;
     nc_def_var_fill(exoid, varid, 0, &fill);
@@ -96,7 +96,7 @@ static int ex_write_object_params(int exoid, const char *type, const char *dimen
 
     int sixty_four_kb = 64 * 1024; // Compact storage can only be used for < 64KiByte data sizes
     if (4 * count < sixty_four_kb) {
-      ex__set_compact_storage(exoid, varid);
+      exi_set_compact_storage(exoid, varid);
     }
 
     /* type id array */
@@ -115,7 +115,7 @@ static int ex_write_object_params(int exoid, const char *type, const char *dimen
       return (status); /* exit define mode and return */
     }
     if (int_size * count < sixty_four_kb) {
-      ex__set_compact_storage(exoid, varid);
+      exi_set_compact_storage(exoid, varid);
     }
 
     /*   store property name as attribute of property array variable */
@@ -234,7 +234,7 @@ int ex_put_init_ext(int exoid, const ex_init_params *model)
   int header_size, fixed_var_size, iows;
 #endif
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
   int rootid = exoid & EX_FILE_ID_MASK;
@@ -294,10 +294,10 @@ int ex_put_init_ext(int exoid, const ex_init_params *model)
     goto error_ret;
   }
   {
-    struct ex__file_item *file = ex__find_file_item(exoid);
+    struct exi_file_item *file = exi_find_file_item(exoid);
     file->time_varid           = temp;
   }
-  ex__compress_variable(exoid, temp, -2); /* Don't compress, but do set collective io */
+  exi_compress_variable(exoid, temp, -2); /* Don't compress, but do set collective io */
 
   if (model->num_dim > 0) {
     if ((status = nc_def_dim(exoid, DIM_NUM_DIM, model->num_dim, &numdimdim)) != NC_NOERR) {
@@ -449,7 +449,7 @@ int ex_put_init_ext(int exoid, const ex_init_params *model)
         ex_err_fn(exoid, __func__, errmsg, status);
         goto error_ret; /* exit define mode and return */
       }
-      ex__compress_variable(exoid, temp, 2);
+      exi_compress_variable(exoid, temp, 2);
     }
 
     if (model->num_dim > 1) {
@@ -461,7 +461,7 @@ int ex_put_init_ext(int exoid, const ex_init_params *model)
         ex_err_fn(exoid, __func__, errmsg, status);
         goto error_ret; /* exit define mode and return */
       }
-      ex__compress_variable(exoid, temp, 2);
+      exi_compress_variable(exoid, temp, 2);
     }
 
     if (model->num_dim > 2) {
@@ -473,7 +473,7 @@ int ex_put_init_ext(int exoid, const ex_init_params *model)
         ex_err_fn(exoid, __func__, errmsg, status);
         goto error_ret; /* exit define mode and return */
       }
-      ex__compress_variable(exoid, temp, 2);
+      exi_compress_variable(exoid, temp, 2);
     }
   }
 
@@ -533,7 +533,7 @@ int ex_put_init_ext(int exoid, const ex_init_params *model)
   }
 
   /* leave define mode */
-  if ((status = ex__leavedef(exoid, __func__)) != NC_NOERR) {
+  if ((status = exi_leavedef(exoid, __func__)) != NC_NOERR) {
     char errmsg[MAX_ERR_LENGTH];
     snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to exit define mode");
     ex_err_fn(exoid, __func__, errmsg, status);
@@ -624,6 +624,6 @@ int ex_put_init_ext(int exoid, const ex_init_params *model)
 
 /* Fatal error: exit definition mode and return */
 error_ret:
-  ex__leavedef(exoid, __func__);
+  exi_leavedef(exoid, __func__);
   EX_FUNC_LEAVE(EX_FATAL);
 }

--- a/packages/seacas/libraries/exodus/src/ex_put_init_global.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_init_global.c
@@ -32,7 +32,7 @@
 /*****************************************************************************/
 
 #include <exodusII.h>     // for ex_err, etc
-#include <exodusII_int.h> // for ex__leavedef, EX_FATAL, etc
+#include <exodusII_int.h> // for exi_leavedef, EX_FATAL, etc
 
 /*!
  * \ingroup ModelDescription
@@ -49,7 +49,7 @@ int ex_put_init_global(int exoid, int64_t num_nodes_g, int64_t num_elems_g, int6
 
   /*-----------------------------Execution begins-----------------------------*/
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -67,7 +67,7 @@ int ex_put_init_global(int exoid, int64_t num_nodes_g, int64_t num_elems_g, int6
   }
 
   /* Output the file version */
-  if ((status = ex__put_nemesis_version(exoid)) < 0) {
+  if ((status = exi_put_nemesis_version(exoid)) < 0) {
     EX_FUNC_LEAVE(status);
   }
 
@@ -77,7 +77,7 @@ int ex_put_init_global(int exoid, int64_t num_nodes_g, int64_t num_elems_g, int6
              DIM_NUM_NODES_GLOBAL, exoid);
     ex_err_fn(exoid, __func__, errmsg, status);
     /* Leave define mode before returning */
-    ex__leavedef(exoid, __func__);
+    exi_leavedef(exoid, __func__);
 
     EX_FUNC_LEAVE(EX_FATAL);
   }
@@ -88,7 +88,7 @@ int ex_put_init_global(int exoid, int64_t num_nodes_g, int64_t num_elems_g, int6
              DIM_NUM_ELEMS_GLOBAL, exoid);
     ex_err_fn(exoid, __func__, errmsg, status);
     /* Leave define mode before returning */
-    ex__leavedef(exoid, __func__);
+    exi_leavedef(exoid, __func__);
 
     EX_FUNC_LEAVE(EX_FATAL);
   }
@@ -103,7 +103,7 @@ int ex_put_init_global(int exoid, int64_t num_nodes_g, int64_t num_elems_g, int6
              DIM_NUM_ELBLK_GLOBAL, exoid);
     ex_err_fn(exoid, __func__, errmsg, status);
     /* Leave define mode before returning */
-    ex__leavedef(exoid, __func__);
+    exi_leavedef(exoid, __func__);
 
     EX_FUNC_LEAVE(EX_FATAL);
   }
@@ -115,7 +115,7 @@ int ex_put_init_global(int exoid, int64_t num_nodes_g, int64_t num_elems_g, int6
              VAR_ELBLK_IDS_GLOBAL, exoid);
     ex_err_fn(exoid, __func__, errmsg, status);
     /* Leave define mode before returning */
-    ex__leavedef(exoid, __func__);
+    exi_leavedef(exoid, __func__);
 
     EX_FUNC_LEAVE(EX_FATAL);
   }
@@ -127,7 +127,7 @@ int ex_put_init_global(int exoid, int64_t num_nodes_g, int64_t num_elems_g, int6
              VAR_ELBLK_CNT_GLOBAL, exoid);
     ex_err_fn(exoid, __func__, errmsg, status);
     /* Leave define mode before returning */
-    ex__leavedef(exoid, __func__);
+    exi_leavedef(exoid, __func__);
 
     EX_FUNC_LEAVE(EX_FATAL);
   }
@@ -143,7 +143,7 @@ int ex_put_init_global(int exoid, int64_t num_nodes_g, int64_t num_elems_g, int6
                DIM_NUM_NS_GLOBAL, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
@@ -156,7 +156,7 @@ int ex_put_init_global(int exoid, int64_t num_nodes_g, int64_t num_elems_g, int6
       ex_err_fn(exoid, __func__, errmsg, status);
 
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
@@ -169,7 +169,7 @@ int ex_put_init_global(int exoid, int64_t num_nodes_g, int64_t num_elems_g, int6
                VAR_NS_NODE_CNT_GLOBAL, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
@@ -185,7 +185,7 @@ int ex_put_init_global(int exoid, int64_t num_nodes_g, int64_t num_elems_g, int6
                VAR_NS_DF_CNT_GLOBAL, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
@@ -203,7 +203,7 @@ int ex_put_init_global(int exoid, int64_t num_nodes_g, int64_t num_elems_g, int6
                DIM_NUM_SS_GLOBAL, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
@@ -216,7 +216,7 @@ int ex_put_init_global(int exoid, int64_t num_nodes_g, int64_t num_elems_g, int6
       ex_err_fn(exoid, __func__, errmsg, status);
 
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
@@ -233,7 +233,7 @@ int ex_put_init_global(int exoid, int64_t num_nodes_g, int64_t num_elems_g, int6
       ex_err_fn(exoid, __func__, errmsg, status);
 
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
@@ -250,7 +250,7 @@ int ex_put_init_global(int exoid, int64_t num_nodes_g, int64_t num_elems_g, int6
       ex_err_fn(exoid, __func__, errmsg, status);
 
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
@@ -258,7 +258,7 @@ int ex_put_init_global(int exoid, int64_t num_nodes_g, int64_t num_elems_g, int6
   } /* End "if (num_side_sets_g > 0)" */
 
   /* End define mode */
-  if (ex__leavedef(exoid, __func__) != EX_NOERR) {
+  if (exi_leavedef(exoid, __func__) != EX_NOERR) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 

--- a/packages/seacas/libraries/exodus/src/ex_put_init_info.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_init_info.c
@@ -41,7 +41,7 @@ int ex_put_init_info(int exoid, int num_proc, int num_proc_in_f, const char *fty
   /*-----------------------------Execution begins-----------------------------*/
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -82,7 +82,7 @@ int ex_put_init_info(int exoid, int num_proc, int num_proc_in_f, const char *fty
                DIM_NUM_PROCS, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
@@ -97,7 +97,7 @@ int ex_put_init_info(int exoid, int num_proc, int num_proc_in_f, const char *fty
       ex_err_fn(exoid, __func__, errmsg, status);
 
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
@@ -110,12 +110,12 @@ int ex_put_init_info(int exoid, int num_proc, int num_proc_in_f, const char *fty
       ex_err_fn(exoid, __func__, errmsg, status);
 
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
 
-    if (ex__leavedef(exoid, __func__) != EX_NOERR) {
+    if (exi_leavedef(exoid, __func__) != EX_NOERR) {
       EX_FUNC_LEAVE(EX_FATAL);
     }
 
@@ -128,7 +128,7 @@ int ex_put_init_info(int exoid, int num_proc, int num_proc_in_f, const char *fty
     }
   }
   else {
-    if (ex__leavedef(exoid, __func__) != EX_NOERR) {
+    if (exi_leavedef(exoid, __func__) != EX_NOERR) {
       EX_FUNC_LEAVE(EX_FATAL);
     }
   }

--- a/packages/seacas/libraries/exodus/src/ex_put_loadbal_param.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_loadbal_param.c
@@ -29,7 +29,7 @@
 /*****************************************************************************/
 
 #include <exodusII.h>     // for ex_err, etc
-#include <exodusII_int.h> // for ex__leavedef, EX_FATAL, etc
+#include <exodusII_int.h> // for exi_leavedef, EX_FATAL, etc
 
 /*!
  * \ingroup ModelDescription
@@ -60,12 +60,12 @@ int ex_put_loadbal_param(int exoid, int64_t num_int_nodes, int64_t num_bor_nodes
   /*-----------------------------Execution begins-----------------------------*/
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
   /* Get the file type */
-  if (ex__get_file_type(exoid, ftype) != EX_NOERR) {
+  if (exi_get_file_type(exoid, ftype) != EX_NOERR) {
     snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to get file type from file ID %d\n", exoid);
     ex_err_fn(exoid, __func__, errmsg, EX_BADPARAM);
     EX_FUNC_LEAVE(EX_FATAL);
@@ -98,8 +98,8 @@ int ex_put_loadbal_param(int exoid, int64_t num_int_nodes, int64_t num_bor_nodes
   }
 
   /* Output the file version */
-  if ((status = ex__put_nemesis_version(exoid)) < 0) {
-    ex__leavedef(exoid, __func__);
+  if ((status = exi_put_nemesis_version(exoid)) < 0) {
+    exi_leavedef(exoid, __func__);
     EX_FUNC_LEAVE(status);
   }
 
@@ -110,7 +110,7 @@ int ex_put_loadbal_param(int exoid, int64_t num_int_nodes, int64_t num_bor_nodes
                VAR_INT_N_STAT, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
@@ -123,7 +123,7 @@ int ex_put_loadbal_param(int exoid, int64_t num_int_nodes, int64_t num_bor_nodes
                VAR_BOR_N_STAT, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
@@ -135,7 +135,7 @@ int ex_put_loadbal_param(int exoid, int64_t num_int_nodes, int64_t num_bor_nodes
                VAR_EXT_N_STAT, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
@@ -148,7 +148,7 @@ int ex_put_loadbal_param(int exoid, int64_t num_int_nodes, int64_t num_bor_nodes
                VAR_INT_E_STAT, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
@@ -160,7 +160,7 @@ int ex_put_loadbal_param(int exoid, int64_t num_int_nodes, int64_t num_bor_nodes
                VAR_BOR_E_STAT, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
@@ -172,7 +172,7 @@ int ex_put_loadbal_param(int exoid, int64_t num_int_nodes, int64_t num_bor_nodes
              VAR_INT_N_STAT, exoid);
     ex_err_fn(exoid, __func__, errmsg, status);
     /* Leave define mode before returning */
-    ex__leavedef(exoid, __func__);
+    exi_leavedef(exoid, __func__);
 
     EX_FUNC_LEAVE(EX_FATAL);
   }
@@ -182,7 +182,7 @@ int ex_put_loadbal_param(int exoid, int64_t num_int_nodes, int64_t num_bor_nodes
              VAR_BOR_N_STAT, exoid);
     ex_err_fn(exoid, __func__, errmsg, status);
     /* Leave define mode before returning */
-    ex__leavedef(exoid, __func__);
+    exi_leavedef(exoid, __func__);
 
     EX_FUNC_LEAVE(EX_FATAL);
   }
@@ -192,7 +192,7 @@ int ex_put_loadbal_param(int exoid, int64_t num_int_nodes, int64_t num_bor_nodes
              VAR_EXT_N_STAT, exoid);
     ex_err_fn(exoid, __func__, errmsg, status);
     /* Leave define mode before returning */
-    ex__leavedef(exoid, __func__);
+    exi_leavedef(exoid, __func__);
 
     EX_FUNC_LEAVE(EX_FATAL);
   }
@@ -205,7 +205,7 @@ int ex_put_loadbal_param(int exoid, int64_t num_int_nodes, int64_t num_bor_nodes
                DIM_NUM_INT_ELEMS, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
@@ -215,11 +215,11 @@ int ex_put_loadbal_param(int exoid, int64_t num_int_nodes, int64_t num_bor_nodes
                VAR_ELEM_MAP_INT, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
-    ex__compress_variable(exoid, varid, 1);
+    exi_compress_variable(exoid, varid, 1);
 
   } /* End "if (num_int_elems > 0)" */
 
@@ -229,7 +229,7 @@ int ex_put_loadbal_param(int exoid, int64_t num_int_nodes, int64_t num_bor_nodes
              VAR_INT_E_STAT, exoid);
     ex_err_fn(exoid, __func__, errmsg, status);
     /* Leave define mode before returning */
-    ex__leavedef(exoid, __func__);
+    exi_leavedef(exoid, __func__);
 
     EX_FUNC_LEAVE(EX_FATAL);
   }
@@ -239,7 +239,7 @@ int ex_put_loadbal_param(int exoid, int64_t num_int_nodes, int64_t num_bor_nodes
              VAR_BOR_E_STAT, exoid);
     ex_err_fn(exoid, __func__, errmsg, status);
     /* Leave define mode before returning */
-    ex__leavedef(exoid, __func__);
+    exi_leavedef(exoid, __func__);
 
     EX_FUNC_LEAVE(EX_FATAL);
   }
@@ -252,7 +252,7 @@ int ex_put_loadbal_param(int exoid, int64_t num_int_nodes, int64_t num_bor_nodes
                DIM_NUM_BOR_ELEMS, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
@@ -262,11 +262,11 @@ int ex_put_loadbal_param(int exoid, int64_t num_int_nodes, int64_t num_bor_nodes
                VAR_ELEM_MAP_BOR, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
-    ex__compress_variable(exoid, varid, 1);
+    exi_compress_variable(exoid, varid, 1);
 
   } /* End "if (num_bor_elems > 0)" */
 
@@ -278,7 +278,7 @@ int ex_put_loadbal_param(int exoid, int64_t num_int_nodes, int64_t num_bor_nodes
                DIM_NUM_INT_NODES, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
@@ -289,11 +289,11 @@ int ex_put_loadbal_param(int exoid, int64_t num_int_nodes, int64_t num_bor_nodes
                VAR_NODE_MAP_INT, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
-    ex__compress_variable(exoid, varid, 1);
+    exi_compress_variable(exoid, varid, 1);
 
   } /* End "if (num_int_nodes > 0)" */
 
@@ -305,7 +305,7 @@ int ex_put_loadbal_param(int exoid, int64_t num_int_nodes, int64_t num_bor_nodes
                DIM_NUM_BOR_NODES, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
@@ -316,11 +316,11 @@ int ex_put_loadbal_param(int exoid, int64_t num_int_nodes, int64_t num_bor_nodes
                VAR_NODE_MAP_BOR, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
-    ex__compress_variable(exoid, varid, 1);
+    exi_compress_variable(exoid, varid, 1);
 
   } /* End "if (num_bor_nodes > 0)" */
 
@@ -332,7 +332,7 @@ int ex_put_loadbal_param(int exoid, int64_t num_int_nodes, int64_t num_bor_nodes
                DIM_NUM_EXT_NODES, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
@@ -343,11 +343,11 @@ int ex_put_loadbal_param(int exoid, int64_t num_int_nodes, int64_t num_bor_nodes
                VAR_NODE_MAP_EXT, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
-    ex__compress_variable(exoid, varid, 1);
+    exi_compress_variable(exoid, varid, 1);
 
   } /* End "if (num_ext_nodes > 0)" */
 
@@ -359,7 +359,7 @@ int ex_put_loadbal_param(int exoid, int64_t num_int_nodes, int64_t num_bor_nodes
                DIM_NUM_N_CMAPS, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
@@ -370,11 +370,11 @@ int ex_put_loadbal_param(int exoid, int64_t num_int_nodes, int64_t num_bor_nodes
                VAR_N_COMM_IDS, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
-    ex__compress_variable(exoid, varid, 1);
+    exi_compress_variable(exoid, varid, 1);
 
     /* Add the status vector */
     if ((status = nc_def_var(exoid, VAR_N_COMM_STAT, NC_INT, 1, dimid, &varid)) != NC_NOERR) {
@@ -382,7 +382,7 @@ int ex_put_loadbal_param(int exoid, int64_t num_int_nodes, int64_t num_bor_nodes
                VAR_N_COMM_STAT, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
@@ -397,7 +397,7 @@ int ex_put_loadbal_param(int exoid, int64_t num_int_nodes, int64_t num_bor_nodes
                DIM_NUM_E_CMAPS, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
@@ -408,18 +408,18 @@ int ex_put_loadbal_param(int exoid, int64_t num_int_nodes, int64_t num_bor_nodes
                VAR_E_COMM_IDS, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
-    ex__compress_variable(exoid, varid, 1);
+    exi_compress_variable(exoid, varid, 1);
 
     if ((status = nc_def_var(exoid, VAR_E_COMM_STAT, NC_INT, 1, dimid, &varid)) != NC_NOERR) {
       snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to define variable \"%s\" in file ID %d",
                VAR_E_COMM_STAT, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
@@ -427,7 +427,7 @@ int ex_put_loadbal_param(int exoid, int64_t num_int_nodes, int64_t num_bor_nodes
   } /* End "if (num_elem_cmaps > 0)" */
 
   /* Leave define mode */
-  if (ex__leavedef(exoid, __func__) != EX_NOERR) {
+  if (exi_leavedef(exoid, __func__) != EX_NOERR) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 

--- a/packages/seacas/libraries/exodus/src/ex_put_loadbal_param_cc.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_loadbal_param_cc.c
@@ -36,7 +36,7 @@
 /*****************************************************************************/
 
 #include <exodusII.h>     // for ex_err, etc
-#include <exodusII_int.h> // for ex__leavedef, EX_FATAL, etc
+#include <exodusII_int.h> // for exi_leavedef, EX_FATAL, etc
 
 #ifndef NC_INT64
 #define NC_INT64 NC_INT
@@ -82,7 +82,7 @@ int ex_put_loadbal_param_cc(int exoid, const void_int *num_int_nodes, const void
 
   /*-----------------------------Execution begins-----------------------------*/
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -134,7 +134,7 @@ int ex_put_loadbal_param_cc(int exoid, const void_int *num_int_nodes, const void
   }
 
   /* Output the file version */
-  if ((status = ex__put_nemesis_version(exoid)) < 0) {
+  if ((status = exi_put_nemesis_version(exoid)) < 0) {
     EX_FUNC_LEAVE(status);
   }
 
@@ -145,7 +145,7 @@ int ex_put_loadbal_param_cc(int exoid, const void_int *num_int_nodes, const void
       ex_err_fn(exoid, __func__, errmsg, status);
 
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
@@ -158,7 +158,7 @@ int ex_put_loadbal_param_cc(int exoid, const void_int *num_int_nodes, const void
                VAR_INT_N_STAT, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
@@ -171,7 +171,7 @@ int ex_put_loadbal_param_cc(int exoid, const void_int *num_int_nodes, const void
                VAR_BOR_N_STAT, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
@@ -183,7 +183,7 @@ int ex_put_loadbal_param_cc(int exoid, const void_int *num_int_nodes, const void
                VAR_EXT_N_STAT, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
@@ -196,7 +196,7 @@ int ex_put_loadbal_param_cc(int exoid, const void_int *num_int_nodes, const void
                VAR_INT_E_STAT, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
@@ -208,7 +208,7 @@ int ex_put_loadbal_param_cc(int exoid, const void_int *num_int_nodes, const void
                VAR_BOR_E_STAT, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
@@ -220,7 +220,7 @@ int ex_put_loadbal_param_cc(int exoid, const void_int *num_int_nodes, const void
              VAR_INT_N_STAT, exoid);
     ex_err_fn(exoid, __func__, errmsg, status);
     /* Leave define mode before returning */
-    ex__leavedef(exoid, __func__);
+    exi_leavedef(exoid, __func__);
 
     EX_FUNC_LEAVE(EX_FATAL);
   }
@@ -230,7 +230,7 @@ int ex_put_loadbal_param_cc(int exoid, const void_int *num_int_nodes, const void
              VAR_BOR_N_STAT, exoid);
     ex_err_fn(exoid, __func__, errmsg, status);
     /* Leave define mode before returning */
-    ex__leavedef(exoid, __func__);
+    exi_leavedef(exoid, __func__);
 
     EX_FUNC_LEAVE(EX_FATAL);
   }
@@ -240,7 +240,7 @@ int ex_put_loadbal_param_cc(int exoid, const void_int *num_int_nodes, const void
              VAR_EXT_N_STAT, exoid);
     ex_err_fn(exoid, __func__, errmsg, status);
     /* Leave define mode before returning */
-    ex__leavedef(exoid, __func__);
+    exi_leavedef(exoid, __func__);
 
     EX_FUNC_LEAVE(EX_FATAL);
   }
@@ -251,7 +251,7 @@ int ex_put_loadbal_param_cc(int exoid, const void_int *num_int_nodes, const void
              VAR_INT_E_STAT, exoid);
     ex_err_fn(exoid, __func__, errmsg, status);
     /* Leave define mode before returning */
-    ex__leavedef(exoid, __func__);
+    exi_leavedef(exoid, __func__);
 
     EX_FUNC_LEAVE(EX_FATAL);
   }
@@ -261,7 +261,7 @@ int ex_put_loadbal_param_cc(int exoid, const void_int *num_int_nodes, const void
              VAR_BOR_E_STAT, exoid);
     ex_err_fn(exoid, __func__, errmsg, status);
     /* Leave define mode before returning */
-    ex__leavedef(exoid, __func__);
+    exi_leavedef(exoid, __func__);
 
     EX_FUNC_LEAVE(EX_FATAL);
   }
@@ -301,7 +301,7 @@ int ex_put_loadbal_param_cc(int exoid, const void_int *num_int_nodes, const void
                DIM_NUM_INT_ELEMS, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
@@ -311,11 +311,11 @@ int ex_put_loadbal_param_cc(int exoid, const void_int *num_int_nodes, const void
                VAR_ELEM_MAP_INT, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
-    ex__compress_variable(exoid, varid, 1);
+    exi_compress_variable(exoid, varid, 1);
 
     /* and the index variable */
     if ((status = nc_def_var(exoid, VAR_ELEM_MAP_INT_IDX, index_type, 1, &dimid_npf,
@@ -324,7 +324,7 @@ int ex_put_loadbal_param_cc(int exoid, const void_int *num_int_nodes, const void
                VAR_ELEM_MAP_INT_IDX, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
@@ -337,7 +337,7 @@ int ex_put_loadbal_param_cc(int exoid, const void_int *num_int_nodes, const void
                DIM_NUM_BOR_ELEMS, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
@@ -347,11 +347,11 @@ int ex_put_loadbal_param_cc(int exoid, const void_int *num_int_nodes, const void
                VAR_ELEM_MAP_BOR, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
-    ex__compress_variable(exoid, varid, 1);
+    exi_compress_variable(exoid, varid, 1);
 
     /* and the index variable */
     if ((status = nc_def_var(exoid, VAR_ELEM_MAP_BOR_IDX, index_type, 1, &dimid_npf,
@@ -360,7 +360,7 @@ int ex_put_loadbal_param_cc(int exoid, const void_int *num_int_nodes, const void
                VAR_ELEM_MAP_BOR_IDX, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
@@ -374,7 +374,7 @@ int ex_put_loadbal_param_cc(int exoid, const void_int *num_int_nodes, const void
                DIM_NUM_INT_NODES, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
@@ -385,11 +385,11 @@ int ex_put_loadbal_param_cc(int exoid, const void_int *num_int_nodes, const void
                VAR_NODE_MAP_INT, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
-    ex__compress_variable(exoid, varid, 1);
+    exi_compress_variable(exoid, varid, 1);
 
     /* and the index variable */
     if ((status = nc_def_var(exoid, VAR_NODE_MAP_INT_IDX, index_type, 1, &dimid_npf,
@@ -398,7 +398,7 @@ int ex_put_loadbal_param_cc(int exoid, const void_int *num_int_nodes, const void
                VAR_NODE_MAP_INT_IDX, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
@@ -412,7 +412,7 @@ int ex_put_loadbal_param_cc(int exoid, const void_int *num_int_nodes, const void
                DIM_NUM_BOR_NODES, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
@@ -423,11 +423,11 @@ int ex_put_loadbal_param_cc(int exoid, const void_int *num_int_nodes, const void
                VAR_NODE_MAP_BOR, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
-    ex__compress_variable(exoid, varid, 1);
+    exi_compress_variable(exoid, varid, 1);
 
     /* and the index variable */
     if ((status = nc_def_var(exoid, VAR_NODE_MAP_BOR_IDX, index_type, 1, &dimid_npf,
@@ -436,7 +436,7 @@ int ex_put_loadbal_param_cc(int exoid, const void_int *num_int_nodes, const void
                VAR_NODE_MAP_BOR_IDX, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
@@ -450,7 +450,7 @@ int ex_put_loadbal_param_cc(int exoid, const void_int *num_int_nodes, const void
                DIM_NUM_EXT_NODES, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
@@ -461,11 +461,11 @@ int ex_put_loadbal_param_cc(int exoid, const void_int *num_int_nodes, const void
                VAR_NODE_MAP_EXT, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
-    ex__compress_variable(exoid, varid, 1);
+    exi_compress_variable(exoid, varid, 1);
 
     /* and the index variable */
     if ((status = nc_def_var(exoid, VAR_NODE_MAP_EXT_IDX, index_type, 1, &dimid_npf,
@@ -474,7 +474,7 @@ int ex_put_loadbal_param_cc(int exoid, const void_int *num_int_nodes, const void
                VAR_NODE_MAP_EXT_IDX, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
@@ -488,7 +488,7 @@ int ex_put_loadbal_param_cc(int exoid, const void_int *num_int_nodes, const void
                DIM_NUM_N_CMAPS, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
@@ -499,7 +499,7 @@ int ex_put_loadbal_param_cc(int exoid, const void_int *num_int_nodes, const void
                VAR_N_COMM_IDS, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
@@ -509,7 +509,7 @@ int ex_put_loadbal_param_cc(int exoid, const void_int *num_int_nodes, const void
                VAR_N_COMM_STAT, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
@@ -521,7 +521,7 @@ int ex_put_loadbal_param_cc(int exoid, const void_int *num_int_nodes, const void
                VAR_N_COMM_INFO_IDX, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
@@ -534,7 +534,7 @@ int ex_put_loadbal_param_cc(int exoid, const void_int *num_int_nodes, const void
                DIM_NUM_E_CMAPS, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
@@ -545,7 +545,7 @@ int ex_put_loadbal_param_cc(int exoid, const void_int *num_int_nodes, const void
                VAR_E_COMM_IDS, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
@@ -555,7 +555,7 @@ int ex_put_loadbal_param_cc(int exoid, const void_int *num_int_nodes, const void
                VAR_E_COMM_STAT, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
@@ -567,7 +567,7 @@ int ex_put_loadbal_param_cc(int exoid, const void_int *num_int_nodes, const void
                VAR_E_COMM_INFO_IDX, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       /* Leave define mode before returning */
-      ex__leavedef(exoid, __func__);
+      exi_leavedef(exoid, __func__);
 
       EX_FUNC_LEAVE(EX_FATAL);
     }
@@ -575,7 +575,7 @@ int ex_put_loadbal_param_cc(int exoid, const void_int *num_int_nodes, const void
   } /* End "if (num_e_cmaps > 0)" */
 
   /* Leave define mode */
-  if (ex__leavedef(exoid, __func__) != EX_NOERR) {
+  if (exi_leavedef(exoid, __func__) != EX_NOERR) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 

--- a/packages/seacas/libraries/exodus/src/ex_put_map.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_map.c
@@ -63,7 +63,7 @@ int ex_put_map(int exoid, const void_int *elem_map)
   char errmsg[MAX_ERR_LENGTH];
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -101,10 +101,10 @@ int ex_put_map(int exoid, const void_int *elem_map)
     }
     goto error_ret; /* exit define mode and return */
   }
-  ex__compress_variable(exoid, mapid, 1);
+  exi_compress_variable(exoid, mapid, 1);
 
   /* leave define mode  */
-  if ((status = ex__leavedef(exoid, __func__)) != NC_NOERR) {
+  if ((status = exi_leavedef(exoid, __func__)) != NC_NOERR) {
     snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to exit define mode");
     ex_err_fn(exoid, __func__, errmsg, status);
     EX_FUNC_LEAVE(EX_FATAL);
@@ -128,6 +128,6 @@ int ex_put_map(int exoid, const void_int *elem_map)
 
 /* Fatal error: exit definition mode and return */
 error_ret:
-  ex__leavedef(exoid, __func__);
+  exi_leavedef(exoid, __func__);
   EX_FUNC_LEAVE(EX_FATAL);
 }

--- a/packages/seacas/libraries/exodus/src/ex_put_map_param.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_map_param.c
@@ -44,7 +44,7 @@ int ex_put_map_param(int exoid, int num_node_maps, int num_elem_maps)
   int  int_type = NC_INT;
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -147,7 +147,7 @@ int ex_put_map_param(int exoid, int num_node_maps, int num_elem_maps)
           }
           goto error_ret; /* exit define mode and return */
         }
-        ex__compress_variable(exoid, varid, 1);
+        exi_compress_variable(exoid, varid, 1);
       }
     }
 
@@ -216,12 +216,12 @@ int ex_put_map_param(int exoid, int num_node_maps, int num_elem_maps)
           }
           goto error_ret; /* exit define mode and return */
         }
-        ex__compress_variable(exoid, varid, 1);
+        exi_compress_variable(exoid, varid, 1);
       }
     }
 
     /* leave define mode */
-    if ((status = ex__leavedef(exoid, __func__)) != NC_NOERR) {
+    if ((status = exi_leavedef(exoid, __func__)) != NC_NOERR) {
       snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to exit define mode");
       ex_err_fn(exoid, __func__, errmsg, status);
       EX_FUNC_LEAVE(EX_FATAL);
@@ -268,6 +268,6 @@ int ex_put_map_param(int exoid, int num_node_maps, int num_elem_maps)
 
 /* Fatal error: exit definition mode and return */
 error_ret:
-  ex__leavedef(exoid, __func__);
+  exi_leavedef(exoid, __func__);
   EX_FUNC_LEAVE(EX_FATAL);
 }

--- a/packages/seacas/libraries/exodus/src/ex_put_name.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_name.c
@@ -26,9 +26,9 @@
  *****************************************************************************/
 
 #include "exodusII.h"     // for ex_err, etc
-#include "exodusII_int.h" // for EX_FATAL, ex__id_lkup, etc
+#include "exodusII_int.h" // for EX_FATAL, exi_id_lkup, etc
 
-int ex__put_assembly_name(int exoid, ex_entity_type obj_type, ex_entity_id entity_id,
+int exi_put_assembly_name(int exoid, ex_entity_type obj_type, ex_entity_id entity_id,
                           const char *name)
 {
   /* Internal function to handle renaming of an existing assembly.
@@ -49,15 +49,15 @@ int ex__put_assembly_name(int exoid, ex_entity_type obj_type, ex_entity_id entit
       snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to store assembly name %s in file id %d",
                name, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
-      if ((status = ex__leavedef(exoid, __func__)) != NC_NOERR) {
+      if ((status = exi_leavedef(exoid, __func__)) != NC_NOERR) {
         snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to exit define mode in file id %d", exoid);
         ex_err_fn(exoid, __func__, errmsg, status);
       }
       EX_FUNC_LEAVE(EX_FATAL);
     }
     /* Update the maximum_name_length attribute on the file. */
-    ex__update_max_name_length(exoid, length - 1);
-    if ((status = ex__leavedef(exoid, __func__)) != NC_NOERR) {
+    exi_update_max_name_length(exoid, length - 1);
+    if ((status = exi_leavedef(exoid, __func__)) != NC_NOERR) {
       snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to exit define mode in file id %d", exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       EX_FUNC_LEAVE(EX_FATAL);
@@ -90,12 +90,12 @@ int ex_put_name(int exoid, ex_entity_type obj_type, ex_entity_id entity_id, cons
   const char *vobj;
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
   switch (obj_type) {
-  case EX_ASSEMBLY: return ex__put_assembly_name(exoid, obj_type, entity_id, name);
+  case EX_ASSEMBLY: return exi_put_assembly_name(exoid, obj_type, entity_id, name);
   case EX_EDGE_BLOCK: vobj = VAR_NAME_ED_BLK; break;
   case EX_FACE_BLOCK: vobj = VAR_NAME_FA_BLK; break;
   case EX_ELEM_BLOCK: vobj = VAR_NAME_EL_BLK; break;
@@ -121,7 +121,7 @@ int ex_put_name(int exoid, ex_entity_type obj_type, ex_entity_id entity_id, cons
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
-  ent_ndx = ex__id_lkup(exoid, obj_type, entity_id);
+  ent_ndx = exi_id_lkup(exoid, obj_type, entity_id);
   if (ent_ndx == -EX_LOOKUPFAIL) { /* could not find the entity with `entity_id` */
     if (obj_type == EX_NODE_MAP || obj_type == EX_ELEM_MAP || obj_type == EX_FACE_MAP ||
         obj_type == EX_EDGE_MAP) {
@@ -143,7 +143,7 @@ int ex_put_name(int exoid, ex_entity_type obj_type, ex_entity_id entity_id, cons
   }
 
   /* write EXODUS entityname */
-  status = ex__put_name(exoid, varid, ent_ndx - 1, name, obj_type, "", __func__);
+  status = exi_put_name(exoid, varid, ent_ndx - 1, name, obj_type, "", __func__);
 
   EX_FUNC_LEAVE(status);
 }

--- a/packages/seacas/libraries/exodus/src/ex_put_names.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_names.c
@@ -44,7 +44,7 @@ int ex_put_names(int exoid, ex_entity_type obj_type, char *const names[])
   const char *vname = NULL;
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -82,7 +82,7 @@ int ex_put_names(int exoid, ex_entity_type obj_type, char *const names[])
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
-  ex__get_dimension(exoid, ex__dim_num_objects(obj_type), ex_name_of_object(obj_type), &num_entity,
+  exi_get_dimension(exoid, exi_dim_num_objects(obj_type), ex_name_of_object(obj_type), &num_entity,
                     &varid, __func__);
 
   if ((status = nc_inq_varid(exoid, vname, &varid)) != NC_NOERR) {
@@ -93,7 +93,7 @@ int ex_put_names(int exoid, ex_entity_type obj_type, char *const names[])
   }
 
   /* write EXODUS entitynames */
-  status = ex__put_names(exoid, varid, num_entity, names, obj_type, "", __func__);
+  status = exi_put_names(exoid, varid, num_entity, names, obj_type, "", __func__);
 
   EX_FUNC_LEAVE(status);
 }

--- a/packages/seacas/libraries/exodus/src/ex_put_nodal_var.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_nodal_var.c
@@ -7,7 +7,7 @@
  */
 
 #include "exodusII.h"     // for ex_err, etc
-#include "exodusII_int.h" // for EX_WARN, ex__comp_ws, etc
+#include "exodusII_int.h" // for EX_WARN, exi_comp_ws, etc
 
 /*!
 \deprecated Use ex_put_var()(exoid, time_step, EX_NODAL, nodal_var_index, 1, num_nodes,

--- a/packages/seacas/libraries/exodus/src/ex_put_node_cmap.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_node_cmap.c
@@ -56,7 +56,7 @@ int ex_put_node_cmap(int exoid, ex_entity_id map_id, const void_int *node_ids,
   }
 
   /* Get the index for this map_id */
-  if ((map_idx = ne__id_lkup(exoid, VAR_N_COMM_IDS, varidx, map_id)) == -1) {
+  if ((map_idx = nei_id_lkup(exoid, VAR_N_COMM_IDS, varidx, map_id)) == -1) {
     snprintf(errmsg, MAX_ERR_LENGTH,
              "ERROR: failed to find index for variable \"%s\" in file ID %d", VAR_N_COMM_IDS,
              exoid);

--- a/packages/seacas/libraries/exodus/src/ex_put_node_cmap.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_node_cmap.c
@@ -42,7 +42,7 @@ int ex_put_node_cmap(int exoid, ex_entity_id map_id, const void_int *node_ids,
   /*-----------------------------Execution begins-----------------------------*/
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 

--- a/packages/seacas/libraries/exodus/src/ex_put_ns_param_global.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_ns_param_global.c
@@ -38,7 +38,7 @@ int ex_put_ns_param_global(int exoid, const void_int *global_ids, const void_int
   /*-----------------------------Execution begins-----------------------------*/
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 

--- a/packages/seacas/libraries/exodus/src/ex_put_num_map.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_num_map.c
@@ -42,7 +42,7 @@ int ex_put_num_map(int exoid, ex_entity_type map_type, ex_entity_id map_id, cons
   int    status;
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -100,7 +100,7 @@ int ex_put_num_map(int exoid, ex_entity_type map_type, ex_entity_id map_id, cons
   }
 
   /* Check for duplicate map id entry */
-  status = ex__id_lkup(exoid, map_type, map_id);
+  status = exi_id_lkup(exoid, map_type, map_id);
   if (status != -EX_LOOKUPFAIL) { /* found the map id */
     snprintf(errmsg, MAX_ERR_LENGTH, "Warning: %s %" PRId64 " already defined in file id %d",
              ex_name_of_object(map_type), map_id, exoid);
@@ -120,10 +120,10 @@ int ex_put_num_map(int exoid, ex_entity_type map_type, ex_entity_id map_id, cons
 
   /* Keep track of the total number of maps defined using a counter stored
      in a linked list keyed by exoid.
-     NOTE: ex__get_file_item  is used to find the number of maps
+     NOTE: exi_get_file_item  is used to find the number of maps
      for a specific file and returns that value.
   */
-  int cur_num_maps = ex__get_file_item(exoid, ex__get_counter_list(map_type));
+  int cur_num_maps = exi_get_file_item(exoid, exi_get_counter_list(map_type));
   if (!overwrite_map) {
     int num_maps = num_entries;
     if (cur_num_maps >= num_maps) {
@@ -133,9 +133,9 @@ int ex_put_num_map(int exoid, ex_entity_type map_type, ex_entity_id map_id, cons
       EX_FUNC_LEAVE(EX_FATAL);
     }
 
-    /*   NOTE: ex__inc_file_item  is used to find the number of maps
+    /*   NOTE: exi_inc_file_item  is used to find the number of maps
          for a specific file and returns that value incremented. */
-    cur_num_maps = ex__inc_file_item(exoid, ex__get_counter_list(map_type));
+    cur_num_maps = exi_inc_file_item(exoid, exi_get_counter_list(map_type));
   }
 
   if (id_is_index) {
@@ -207,9 +207,9 @@ int ex_put_num_map(int exoid, ex_entity_type map_type, ex_entity_id map_id, cons
       snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to define map %s in file id %d", vmap, exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
     }
-    ex__compress_variable(exoid, varid, 1);
+    exi_compress_variable(exoid, varid, 1);
 
-    if ((status = ex__leavedef(exoid, __func__)) != NC_NOERR) { /* exit define mode */
+    if ((status = exi_leavedef(exoid, __func__)) != NC_NOERR) { /* exit define mode */
       snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to exit define mode");
       ex_err_fn(exoid, __func__, errmsg, status);
       varid = -1; /* force early exit */

--- a/packages/seacas/libraries/exodus/src/ex_put_one_attr.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_one_attr.c
@@ -23,7 +23,7 @@
  *****************************************************************************/
 
 #include "exodusII.h"     // for ex_err, etc
-#include "exodusII_int.h" // for EX_FATAL, ex__get_dimension, etc
+#include "exodusII_int.h" // for EX_FATAL, exi_get_dimension, etc
 
 /*!
  * writes the specified attribute for a block
@@ -48,13 +48,13 @@ int ex_put_one_attr(int exoid, ex_entity_type obj_type, ex_entity_id obj_id, int
   const char *vattrbname;
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
   /* Determine index of obj_id in id array */
   if (obj_type != EX_NODAL) {
-    obj_id_ndx = ex__id_lkup(exoid, obj_type, obj_id);
+    obj_id_ndx = exi_id_lkup(exoid, obj_type, obj_id);
     if (obj_id_ndx <= 0) {
       ex_get_err(NULL, NULL, &status);
       if (status != 0) {
@@ -128,12 +128,12 @@ int ex_put_one_attr(int exoid, ex_entity_type obj_type, ex_entity_id obj_id, int
   }
 
   /* inquire id's of previously defined dimensions  */
-  if (ex__get_dimension(exoid, dnumobjent, "entries", &num_entries_this_obj, &temp, __func__) !=
+  if (exi_get_dimension(exoid, dnumobjent, "entries", &num_entries_this_obj, &temp, __func__) !=
       NC_NOERR) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
-  if (ex__get_dimension(exoid, dnumobjatt, "attributes", &num_attr, &temp, __func__) != NC_NOERR) {
+  if (exi_get_dimension(exoid, dnumobjatt, "attributes", &num_attr, &temp, __func__) != NC_NOERR) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -165,7 +165,7 @@ int ex_put_one_attr(int exoid, ex_entity_type obj_type, ex_entity_id obj_id, int
   stride[0] = 1;
   stride[1] = num_attr;
 
-  if (ex__comp_ws(exoid) == 4) {
+  if (exi_comp_ws(exoid) == 4) {
     status = nc_put_vars_float(exoid, attrid, start, count, stride, attrib);
   }
   else {

--- a/packages/seacas/libraries/exodus/src/ex_put_partial_attr.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_partial_attr.c
@@ -24,7 +24,7 @@
  *****************************************************************************/
 
 #include "exodusII.h"     // for ex_err, ex_name_of_object, etc
-#include "exodusII_int.h" // for ex__check_valid_file_id, etc
+#include "exodusII_int.h" // for exi_check_valid_file_id, etc
 
 /*!
  * writes the attributes for an edge/face/element block
@@ -48,13 +48,13 @@ int ex_put_partial_attr(int exoid, ex_entity_type blk_type, ex_entity_id blk_id,
   char   errmsg[MAX_ERR_LENGTH];
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
   if (blk_type != EX_NODAL) {
     /* Determine index of blk_id in VAR_ID_EL_BLK array */
-    blk_id_ndx = ex__id_lkup(exoid, blk_type, blk_id);
+    blk_id_ndx = exi_id_lkup(exoid, blk_type, blk_id);
     if (blk_id_ndx <= 0) {
       ex_get_err(NULL, NULL, &status);
 
@@ -151,7 +151,7 @@ int ex_put_partial_attr(int exoid, ex_entity_type blk_type, ex_entity_id blk_id,
     start[0] = 0;
   }
 
-  if (ex__comp_ws(exoid) == 4) {
+  if (exi_comp_ws(exoid) == 4) {
     status = nc_put_vara_float(exoid, attrid, start, count, attrib);
   }
   else {

--- a/packages/seacas/libraries/exodus/src/ex_put_partial_conn.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_partial_conn.c
@@ -28,7 +28,7 @@
  *
  */
 #include "exodusII.h"     // for ex_err, ex_name_of_object, etc
-#include "exodusII_int.h" // for ex__check_valid_file_id, etc
+#include "exodusII_int.h" // for exi_check_valid_file_id, etc
 
 /*
  * reads the connectivity array for an element block
@@ -75,13 +75,13 @@ int ex_put_partial_conn(int exoid, ex_entity_type blk_type, ex_entity_id blk_id,
     ex_err_fn(exoid, __func__, errmsg, EX_BADPARAM);
   }
 
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
   /* Locate index of element block id in VAR_ID_EL_BLK array */
 
-  blk_id_ndx = ex__id_lkup(exoid, blk_type, blk_id);
+  blk_id_ndx = exi_id_lkup(exoid, blk_type, blk_id);
   if (blk_id_ndx <= 0) {
     ex_get_err(NULL, NULL, &status);
 

--- a/packages/seacas/libraries/exodus/src/ex_put_partial_coord.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_partial_coord.c
@@ -28,7 +28,7 @@
  *****************************************************************************/
 
 #include "exodusII.h"     // for ex_err, etc
-#include "exodusII_int.h" // for EX_FATAL, ex__comp_ws, etc
+#include "exodusII_int.h" // for EX_FATAL, exi_comp_ws, etc
 
 /*!
  * writes the coordinates of some of the nodes in the model
@@ -55,7 +55,7 @@ int ex_put_partial_coord(int exoid, int64_t start_node_num, int64_t num_nodes, c
   char    errmsg[MAX_ERR_LENGTH];
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -165,7 +165,7 @@ int ex_put_partial_coord(int exoid, int64_t start_node_num, int64_t num_nodes, c
     }
 
     if (coor != NULL && coordid != -1) {
-      if (ex__comp_ws(exoid) == 4) {
+      if (exi_comp_ws(exoid) == 4) {
         status = nc_put_vara_float(exoid, coordid, start, count, coor);
       }
       else {

--- a/packages/seacas/libraries/exodus/src/ex_put_partial_coord_component.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_partial_coord_component.c
@@ -7,7 +7,7 @@
  */
 
 #include "exodusII.h"     // for ex_err, etc
-#include "exodusII_int.h" // for EX_FATAL, ex__comp_ws, etc
+#include "exodusII_int.h" // for EX_FATAL, exi_comp_ws, etc
 
 /*!
  * writes the coordinates of some of the nodes in the model for the specified component
@@ -23,7 +23,7 @@ int ex_put_partial_coord_component(int exoid, int64_t start_node_num, int64_t nu
                                    int component, const void *coor)
 {
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -122,7 +122,7 @@ int ex_put_partial_coord_component(int exoid, int64_t start_node_num, int64_t nu
       EX_FUNC_LEAVE(EX_FATAL);
     }
 
-    if (ex__comp_ws(exoid) == 4) {
+    if (exi_comp_ws(exoid) == 4) {
       status = nc_put_vara_float(exoid, coordid, start, count, coor);
     }
     else {

--- a/packages/seacas/libraries/exodus/src/ex_put_partial_id_map.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_partial_id_map.c
@@ -48,11 +48,11 @@ int ex_put_partial_id_map(int exoid, ex_entity_type map_type, int64_t start_enti
   const char *vmap        = NULL;
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
-  if (num_entities == 0 && !ex__is_parallel(exoid)) {
+  if (num_entities == 0 && !exi_is_parallel(exoid)) {
     EX_FUNC_LEAVE(EX_NOERR);
   }
 
@@ -135,10 +135,10 @@ int ex_put_partial_id_map(int exoid, ex_entity_type map_type, int64_t start_enti
       }
       goto error_ret; /* exit define mode and return */
     }
-    ex__compress_variable(exoid, mapid, 1);
+    exi_compress_variable(exoid, mapid, 1);
 
     /* leave define mode  */
-    if ((status = ex__leavedef(exoid, __func__)) != NC_NOERR) {
+    if ((status = exi_leavedef(exoid, __func__)) != NC_NOERR) {
       snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to exit define mode");
       ex_err_fn(exoid, __func__, errmsg, status);
       EX_FUNC_LEAVE(EX_FATAL);
@@ -171,6 +171,6 @@ int ex_put_partial_id_map(int exoid, ex_entity_type map_type, int64_t start_enti
 
 /* Fatal error: exit definition mode and return */
 error_ret:
-  ex__leavedef(exoid, __func__);
+  exi_leavedef(exoid, __func__);
   EX_FUNC_LEAVE(EX_FATAL);
 }

--- a/packages/seacas/libraries/exodus/src/ex_put_partial_nodal_var_int.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_partial_nodal_var_int.c
@@ -26,7 +26,7 @@
  *****************************************************************************/
 
 #include "exodusII.h"     // for ex_err, etc
-#include "exodusII_int.h" // for EX_WARN, ex__comp_ws, etc
+#include "exodusII_int.h" // for EX_WARN, exi_comp_ws, etc
 
 /*!
   \internal
@@ -45,7 +45,7 @@
  * \param nodal_var_vals   array of nodal variable values
  */
 
-int ex__put_partial_nodal_var(int exoid, int time_step, int nodal_var_index, int64_t start_node,
+int exi_put_partial_nodal_var(int exoid, int time_step, int nodal_var_index, int64_t start_node,
                               int64_t num_nodes, const void *nodal_var_vals)
 
 {
@@ -55,7 +55,7 @@ int ex__put_partial_nodal_var(int exoid, int time_step, int nodal_var_index, int
   char   errmsg[MAX_ERR_LENGTH];
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -75,7 +75,7 @@ int ex__put_partial_nodal_var(int exoid, int time_step, int nodal_var_index, int
     start[1] = 0;
   }
 
-  if (ex__comp_ws(exoid) == 4) {
+  if (exi_comp_ws(exoid) == 4) {
     status = nc_put_vara_float(exoid, varid, start, count, nodal_var_vals);
   }
   else {

--- a/packages/seacas/libraries/exodus/src/ex_put_partial_node_cmap.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_partial_node_cmap.c
@@ -66,7 +66,7 @@ int ex_put_partial_node_cmap(int exoid, ex_entity_id map_id, int64_t start_entit
   }
 
   /* Get the index for this map_id */
-  if ((map_idx = ne__id_lkup(exoid, VAR_N_COMM_IDS, varidx, map_id)) == -1) {
+  if ((map_idx = nei_id_lkup(exoid, VAR_N_COMM_IDS, varidx, map_id)) == -1) {
     snprintf(errmsg, MAX_ERR_LENGTH,
              "ERROR: failed to find index for variable \"%s\" in file ID %d", VAR_N_COMM_IDS,
              exoid);

--- a/packages/seacas/libraries/exodus/src/ex_put_partial_node_cmap.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_partial_node_cmap.c
@@ -52,7 +52,7 @@ int ex_put_partial_node_cmap(int exoid, ex_entity_id map_id, int64_t start_entit
   /*-----------------------------Execution begins-----------------------------*/
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 

--- a/packages/seacas/libraries/exodus/src/ex_put_partial_num_map.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_partial_num_map.c
@@ -46,7 +46,7 @@ int ex_put_partial_num_map(int exoid, ex_entity_type map_type, ex_entity_id map_
   const char *vmap;
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -98,7 +98,7 @@ int ex_put_partial_num_map(int exoid, ex_entity_type map_type, ex_entity_id map_
   }
 
   /* Check for duplicate map id entry */
-  status = ex__id_lkup(exoid, map_type, map_id);
+  status = exi_id_lkup(exoid, map_type, map_id);
   if (status == -EX_LOOKUPFAIL) { /* did not find the map id */
     map_exists = 0;               /* Map is being defined */
   }
@@ -118,10 +118,10 @@ int ex_put_partial_num_map(int exoid, ex_entity_type map_type, ex_entity_id map_
 
     /* Keep track of the total number of maps defined using a
        counter stored in a linked list keyed by exoid.  NOTE:
-       ex__get_file_item is used to find the number of element maps for a
+       exi_get_file_item is used to find the number of element maps for a
        specific file and returns that value.
     */
-    cur_num_maps = ex__get_file_item(exoid, ex__get_counter_list(map_type));
+    cur_num_maps = exi_get_file_item(exoid, exi_get_counter_list(map_type));
     if (cur_num_maps >= (int)num_maps) {
       snprintf(errmsg, MAX_ERR_LENGTH,
                "ERROR: exceeded number of %ss (%zu) specified in file id %d",
@@ -130,16 +130,16 @@ int ex_put_partial_num_map(int exoid, ex_entity_type map_type, ex_entity_id map_
       EX_FUNC_LEAVE(EX_FATAL);
     }
 
-    /*   NOTE: ex__inc_file_item  is used to find the number of element maps
+    /*   NOTE: exi_inc_file_item  is used to find the number of element maps
          for a specific file and returns that value incremented. */
-    cur_num_maps = ex__inc_file_item(exoid, ex__get_counter_list(map_type));
+    cur_num_maps = exi_inc_file_item(exoid, exi_get_counter_list(map_type));
 
     if (id_is_index) {
       cur_num_maps = map_id - 1;
     }
   }
   else {
-    int map_ndx  = ex__id_lkup(exoid, map_type, map_id);
+    int map_ndx  = exi_id_lkup(exoid, map_type, map_id);
     cur_num_maps = map_ndx - 1;
   }
 

--- a/packages/seacas/libraries/exodus/src/ex_put_partial_one_attr.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_partial_one_attr.c
@@ -23,7 +23,7 @@
  *****************************************************************************/
 
 #include "exodusII.h"     // for ex_err, etc
-#include "exodusII_int.h" // for EX_FATAL, ex__get_dimension, etc
+#include "exodusII_int.h" // for EX_FATAL, exi_get_dimension, etc
 
 /*!
  * writes the specified attribute for a block
@@ -51,13 +51,13 @@ int ex_put_partial_one_attr(int exoid, ex_entity_type obj_type, ex_entity_id obj
   const char *vattrbname;
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
   /* Determine index of obj_id in id array */
   if (obj_type != EX_NODAL) {
-    obj_id_ndx = ex__id_lkup(exoid, obj_type, obj_id);
+    obj_id_ndx = exi_id_lkup(exoid, obj_type, obj_id);
     if (obj_id_ndx <= 0) {
       ex_get_err(NULL, NULL, &status);
 
@@ -132,7 +132,7 @@ int ex_put_partial_one_attr(int exoid, ex_entity_type obj_type, ex_entity_id obj
   }
 
   /* inquire id's of previously defined dimensions  */
-  if (ex__get_dimension(exoid, dnumobjent, "entries", &num_entries_this_obj, &temp, __func__) !=
+  if (exi_get_dimension(exoid, dnumobjent, "entries", &num_entries_this_obj, &temp, __func__) !=
       NC_NOERR) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
@@ -146,7 +146,7 @@ int ex_put_partial_one_attr(int exoid, ex_entity_type obj_type, ex_entity_id obj
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
-  if (ex__get_dimension(exoid, dnumobjatt, "attributes", &num_attr, &temp, __func__) != NC_NOERR) {
+  if (exi_get_dimension(exoid, dnumobjatt, "attributes", &num_attr, &temp, __func__) != NC_NOERR) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -182,7 +182,7 @@ int ex_put_partial_one_attr(int exoid, ex_entity_type obj_type, ex_entity_id obj
     start[0] = 0;
   }
 
-  if (ex__comp_ws(exoid) == 4) {
+  if (exi_comp_ws(exoid) == 4) {
     status = nc_put_vars_float(exoid, attrid, start, count, stride, attrib);
   }
   else {

--- a/packages/seacas/libraries/exodus/src/ex_put_partial_set.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_partial_set.c
@@ -25,7 +25,7 @@
 *****************************************************************************/
 
 #include "exodusII.h"     // for ex_err, ex_name_of_object, etc
-#include "exodusII_int.h" // for ex__is_parallel, etc
+#include "exodusII_int.h" // for exi_is_parallel, etc
 
 /*!
  * writes the set entry list and set extra list for a single set
@@ -53,12 +53,12 @@ int ex_put_partial_set(int exoid, ex_entity_type set_type, ex_entity_id set_id, 
 
   EX_FUNC_ENTER();
 
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
   /* first check if any sets are specified */
-  if ((status = nc_inq_dimid(exoid, ex__dim_num_objects(set_type), &dimid)) != NC_NOERR) {
+  if ((status = nc_inq_dimid(exoid, exi_dim_num_objects(set_type), &dimid)) != NC_NOERR) {
     snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: no %ss defined in file id %d",
              ex_name_of_object(set_type), exoid);
     ex_err_fn(exoid, __func__, errmsg, status);
@@ -66,7 +66,7 @@ int ex_put_partial_set(int exoid, ex_entity_type set_type, ex_entity_id set_id, 
   }
 
   /* Lookup index of set id in VAR_*S_IDS array */
-  set_id_ndx = ex__id_lkup(exoid, set_type, set_id);
+  set_id_ndx = exi_id_lkup(exoid, set_type, set_id);
   if (set_id_ndx <= 0) {
     ex_get_err(NULL, NULL, &status);
 
@@ -116,7 +116,7 @@ int ex_put_partial_set(int exoid, ex_entity_type set_type, ex_entity_id set_id, 
   }
 
   /* write out the entry list and extra list arrays */
-  if (set_entry_list != NULL || ex__is_parallel(exoid)) {
+  if (set_entry_list != NULL || exi_is_parallel(exoid)) {
     start[0] = offset - 1;
     count[0] = num_to_put;
     if (count[0] == 0) {
@@ -140,7 +140,7 @@ int ex_put_partial_set(int exoid, ex_entity_type set_type, ex_entity_id set_id, 
   }
 
   /* only do for edge, face and side sets */
-  if (extraptr && (set_extra_list != NULL || ex__is_parallel(exoid))) {
+  if (extraptr && (set_extra_list != NULL || exi_is_parallel(exoid))) {
     if ((status = nc_inq_varid(exoid, extraptr, &extra_list_id)) != NC_NOERR) {
       snprintf(errmsg, MAX_ERR_LENGTH,
                "ERROR: failed to locate extra list for %s %" PRId64 " in file id %d",

--- a/packages/seacas/libraries/exodus/src/ex_put_partial_set_dist_fact.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_partial_set_dist_fact.c
@@ -27,7 +27,7 @@ write
 *****************************************************************************/
 
 #include "exodusII.h"     // for ex_err, ex_name_of_object, etc
-#include "exodusII_int.h" // for ex__check_valid_file_id, etc
+#include "exodusII_int.h" // for exi_check_valid_file_id, etc
 
 /*!
  * writes the partial distribution factors for a single set
@@ -51,12 +51,12 @@ int ex_put_partial_set_dist_fact(int exoid, ex_entity_type set_type, ex_entity_i
 
   EX_FUNC_ENTER();
 
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
   /* first check if any sets are specified */
-  if ((status = nc_inq_dimid(exoid, ex__dim_num_objects(set_type), &dimid)) != NC_NOERR) {
+  if ((status = nc_inq_dimid(exoid, exi_dim_num_objects(set_type), &dimid)) != NC_NOERR) {
     snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: no %ss specified in file id %d",
              ex_name_of_object(set_type), exoid);
     ex_err_fn(exoid, __func__, errmsg, status);
@@ -64,7 +64,7 @@ int ex_put_partial_set_dist_fact(int exoid, ex_entity_type set_type, ex_entity_i
   }
 
   /* Lookup index of set id in VAR_*S_IDS array */
-  set_id_ndx = ex__id_lkup(exoid, set_type, set_id);
+  set_id_ndx = exi_id_lkup(exoid, set_type, set_id);
   if (set_id_ndx <= 0) {
     ex_get_err(NULL, NULL, &status);
 
@@ -129,7 +129,7 @@ int ex_put_partial_set_dist_fact(int exoid, ex_entity_type set_type, ex_entity_i
   }
 
   /* write out the distribution factors array */
-  if (ex__comp_ws(exoid) == 4) {
+  if (exi_comp_ws(exoid) == 4) {
     status = nc_put_vara_float(exoid, dist_id, start, count, set_dist_fact);
   }
   else {

--- a/packages/seacas/libraries/exodus/src/ex_put_partial_var.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_partial_var.c
@@ -7,9 +7,9 @@
  */
 
 #include "exodusII.h"     // for ex_err, etc
-#include "exodusII_int.h" // for EX_FATAL, ex__get_dimension, etc
+#include "exodusII_int.h" // for EX_FATAL, exi_get_dimension, etc
 
-static int ex__look_up_var(int exoid, ex_entity_type var_type, int var_index, ex_entity_id obj_id,
+static int exi_look_up_var(int exoid, ex_entity_type var_type, int var_index, ex_entity_id obj_id,
                            const char *VOBJID, const char *VOBJTAB, const char *DNUMOBJ,
                            const char *DNUMOBJVAR, int *varid)
 {
@@ -48,7 +48,7 @@ static int ex__look_up_var(int exoid, ex_entity_type var_type, int var_index, ex
   }
   else {
     /* Determine index of obj_id in VOBJID array */
-    obj_id_ndx = ex__id_lkup(exoid, var_type, obj_id);
+    obj_id_ndx = exi_id_lkup(exoid, var_type, obj_id);
     if (obj_id_ndx <= 0) {
       ex_get_err(NULL, NULL, &status);
 
@@ -70,19 +70,19 @@ static int ex__look_up_var(int exoid, ex_entity_type var_type, int var_index, ex
     }
   }
 
-  if ((status = nc_inq_varid(exoid, ex__name_var_of_object(var_type, var_index, obj_id_ndx),
+  if ((status = nc_inq_varid(exoid, exi_name_var_of_object(var_type, var_index, obj_id_ndx),
                              varid)) != NC_NOERR) {
     if (status == NC_ENOTVAR) { /* variable doesn't exist, create it! */
       /* check for the existence of an TNAME variable truth table */
       if (nc_inq_varid(exoid, VOBJTAB, varid) == NC_NOERR) {
         /* find out number of TNAMEs and TNAME variables */
-        status = ex__get_dimension(exoid, DNUMOBJ, ex_name_of_object(var_type), &num_obj, &dimid,
+        status = exi_get_dimension(exoid, DNUMOBJ, ex_name_of_object(var_type), &num_obj, &dimid,
                                    __func__);
         if (status != NC_NOERR) {
           return (status);
         }
 
-        status = ex__get_dimension(exoid, DNUMOBJVAR, ex_name_of_object(var_type), &num_obj_var,
+        status = exi_get_dimension(exoid, DNUMOBJVAR, ex_name_of_object(var_type), &num_obj_var,
                                    &dimid, __func__);
         if (status != NC_NOERR) {
           return (status);
@@ -123,7 +123,7 @@ static int ex__look_up_var(int exoid, ex_entity_type var_type, int var_index, ex
         goto error_ret; /* exit define mode and return */
       }
 
-      ex__get_dimension(exoid, ex__dim_num_entries_in_object(var_type, obj_id_ndx),
+      exi_get_dimension(exoid, exi_dim_num_entries_in_object(var_type, obj_id_ndx),
                         ex_name_of_object(var_type), &num_entity, &numobjdim, __func__);
 
       /*    variable doesn't exist so put file into define mode  */
@@ -136,23 +136,23 @@ static int ex__look_up_var(int exoid, ex_entity_type var_type, int var_index, ex
       /* define netCDF variable to store TNAME variable values */
       dims[0] = time_dim;
       dims[1] = numobjdim;
-      if ((status = nc_def_var(exoid, ex__name_var_of_object(var_type, var_index, obj_id_ndx),
+      if ((status = nc_def_var(exoid, exi_name_var_of_object(var_type, var_index, obj_id_ndx),
                                nc_flt_code(exoid), 2, dims, varid)) != NC_NOERR) {
         snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to define %s variable %d in file id %d",
                  ex_name_of_object(var_type), var_index, exoid);
         ex_err_fn(exoid, __func__, errmsg, status);
         goto error_ret;
       }
-      ex__compress_variable(exoid, *varid, 2);
+      exi_compress_variable(exoid, *varid, 2);
 
       /*    leave define mode  */
-      if ((status = ex__leavedef(exoid, __func__)) != NC_NOERR) {
+      if ((status = exi_leavedef(exoid, __func__)) != NC_NOERR) {
         return (EX_FATAL);
       }
     }
     else {
       snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to locate %s variable %s in file id %d",
-               ex_name_of_object(var_type), ex__name_var_of_object(var_type, var_index, obj_id_ndx),
+               ex_name_of_object(var_type), exi_name_var_of_object(var_type, var_index, obj_id_ndx),
                exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       return (EX_FATAL);
@@ -162,7 +162,7 @@ static int ex__look_up_var(int exoid, ex_entity_type var_type, int var_index, ex
 
 /* Fatal error: exit definition mode and return */
 error_ret:
-  ex__leavedef(exoid, __func__);
+  exi_leavedef(exoid, __func__);
   return (EX_FATAL);
 }
 
@@ -192,7 +192,7 @@ int ex_put_partial_var(int exoid, int time_step, ex_entity_type var_type, int va
 
   EX_FUNC_ENTER();
 
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -222,47 +222,47 @@ int ex_put_partial_var(int exoid, int time_step, ex_entity_type var_type, int va
     break;
   case EX_NODAL:
     status =
-        ex__put_partial_nodal_var(exoid, time_step, var_index, start_index, num_entities, var_vals);
+        exi_put_partial_nodal_var(exoid, time_step, var_index, start_index, num_entities, var_vals);
     EX_FUNC_LEAVE(status);
     break;
   case EX_ASSEMBLY:
-    status = ex__look_up_var(exoid, var_type, var_index, obj_id, "", VAR_ASSEMBLY_TAB,
+    status = exi_look_up_var(exoid, var_type, var_index, obj_id, "", VAR_ASSEMBLY_TAB,
                              DIM_NUM_ASSEMBLY, DIM_NUM_ASSEMBLY_VAR, &varid);
     break;
   case EX_BLOB:
-    status = ex__look_up_var(exoid, var_type, var_index, obj_id, "", VAR_BLOB_TAB, DIM_NUM_BLOB,
+    status = exi_look_up_var(exoid, var_type, var_index, obj_id, "", VAR_BLOB_TAB, DIM_NUM_BLOB,
                              DIM_NUM_BLOB_VAR, &varid);
     break;
   case EX_EDGE_BLOCK:
-    status = ex__look_up_var(exoid, var_type, var_index, obj_id, VAR_ID_ED_BLK, VAR_EBLK_TAB,
+    status = exi_look_up_var(exoid, var_type, var_index, obj_id, VAR_ID_ED_BLK, VAR_EBLK_TAB,
                              DIM_NUM_ED_BLK, DIM_NUM_EDG_VAR, &varid);
     break;
   case EX_FACE_BLOCK:
-    status = ex__look_up_var(exoid, var_type, var_index, obj_id, VAR_ID_FA_BLK, VAR_FBLK_TAB,
+    status = exi_look_up_var(exoid, var_type, var_index, obj_id, VAR_ID_FA_BLK, VAR_FBLK_TAB,
                              DIM_NUM_FA_BLK, DIM_NUM_FAC_VAR, &varid);
     break;
   case EX_ELEM_BLOCK:
-    status = ex__look_up_var(exoid, var_type, var_index, obj_id, VAR_ID_EL_BLK, VAR_ELEM_TAB,
+    status = exi_look_up_var(exoid, var_type, var_index, obj_id, VAR_ID_EL_BLK, VAR_ELEM_TAB,
                              DIM_NUM_EL_BLK, DIM_NUM_ELE_VAR, &varid);
     break;
   case EX_NODE_SET:
-    status = ex__look_up_var(exoid, var_type, var_index, obj_id, VAR_NS_IDS, VAR_NSET_TAB,
+    status = exi_look_up_var(exoid, var_type, var_index, obj_id, VAR_NS_IDS, VAR_NSET_TAB,
                              DIM_NUM_NS, DIM_NUM_NSET_VAR, &varid);
     break;
   case EX_EDGE_SET:
-    status = ex__look_up_var(exoid, var_type, var_index, obj_id, VAR_ES_IDS, VAR_ESET_TAB,
+    status = exi_look_up_var(exoid, var_type, var_index, obj_id, VAR_ES_IDS, VAR_ESET_TAB,
                              DIM_NUM_ES, DIM_NUM_ESET_VAR, &varid);
     break;
   case EX_FACE_SET:
-    status = ex__look_up_var(exoid, var_type, var_index, obj_id, VAR_FS_IDS, VAR_FSET_TAB,
+    status = exi_look_up_var(exoid, var_type, var_index, obj_id, VAR_FS_IDS, VAR_FSET_TAB,
                              DIM_NUM_FS, DIM_NUM_FSET_VAR, &varid);
     break;
   case EX_SIDE_SET:
-    status = ex__look_up_var(exoid, var_type, var_index, obj_id, VAR_SS_IDS, VAR_SSET_TAB,
+    status = exi_look_up_var(exoid, var_type, var_index, obj_id, VAR_SS_IDS, VAR_SSET_TAB,
                              DIM_NUM_SS, DIM_NUM_SSET_VAR, &varid);
     break;
   case EX_ELEM_SET:
-    status = ex__look_up_var(exoid, var_type, var_index, obj_id, VAR_ELS_IDS, VAR_ELSET_TAB,
+    status = exi_look_up_var(exoid, var_type, var_index, obj_id, VAR_ELS_IDS, VAR_ELSET_TAB,
                              DIM_NUM_ELS, DIM_NUM_ELSET_VAR, &varid);
     break;
   default:
@@ -296,7 +296,7 @@ int ex_put_partial_var(int exoid, int time_step, ex_entity_type var_type, int va
     start[1] = 0;
   }
 
-  if (ex__comp_ws(exoid) == 4) {
+  if (exi_comp_ws(exoid) == 4) {
     status = nc_put_vara_float(exoid, varid, start, count, var_vals);
   }
   else {

--- a/packages/seacas/libraries/exodus/src/ex_put_processor_elem_maps.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_processor_elem_maps.c
@@ -39,12 +39,12 @@ int ex_put_processor_elem_maps(int exoid, const void_int *elem_mapi, const void_
   /*-----------------------------Execution begins-----------------------------*/
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
   /* Get the file type */
-  if (ex__get_file_type(exoid, ftype) != EX_NOERR) {
+  if (exi_get_file_type(exoid, ftype) != EX_NOERR) {
     snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: unable to find file type for file ID %d", exoid);
     ex_err_fn(exoid, __func__, errmsg, EX_BADPARAM);
 

--- a/packages/seacas/libraries/exodus/src/ex_put_processor_node_maps.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_processor_node_maps.c
@@ -39,12 +39,12 @@ int ex_put_processor_node_maps(int exoid, const void_int *node_mapi, const void_
   /*-----------------------------Execution begins-----------------------------*/
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
   /* Get the file type */
-  if (ex__get_file_type(exoid, ftype) != EX_NOERR) {
+  if (exi_get_file_type(exoid, ftype) != EX_NOERR) {
     snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: unable to find file type for file ID %d", exoid);
     ex_err_fn(exoid, __func__, errmsg, EX_BADPARAM);
 

--- a/packages/seacas/libraries/exodus/src/ex_put_prop.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_prop.c
@@ -7,7 +7,7 @@
  */
 
 #include "exodusII.h"     // for ex_err, etc
-#include "exodusII_int.h" // for EX_FATAL, ex__id_lkup, etc
+#include "exodusII_int.h" // for EX_FATAL, exi_id_lkup, etc
 #include <stdbool.h>
 
 /*!
@@ -93,7 +93,7 @@ int ex_put_prop(int exoid, ex_entity_type obj_type, ex_entity_id obj_id, const c
   char errmsg[MAX_ERR_LENGTH];
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -269,10 +269,10 @@ int ex_put_prop(int exoid, ex_entity_type obj_type, ex_entity_id obj_id, const c
       goto error_ret; /* Exit define mode and return */
     }
 
-    ex__update_max_name_length(exoid, prop_name_len - 1);
+    exi_update_max_name_length(exoid, prop_name_len - 1);
 
     /* leave define mode  */
-    if ((status = ex__leavedef(exoid, __func__)) != NC_NOERR) {
+    if ((status = exi_leavedef(exoid, __func__)) != NC_NOERR) {
       EX_FUNC_LEAVE(EX_FATAL);
     }
 
@@ -280,12 +280,12 @@ int ex_put_prop(int exoid, ex_entity_type obj_type, ex_entity_id obj_id, const c
   }
 
   /* find index into property array using obj_id; put value in property */
-  /* array at proper index; ex__id_lkup returns an index that is 1-based,*/
+  /* array at proper index; exi_id_lkup returns an index that is 1-based,*/
   /* but netcdf expects 0-based arrays so subtract 1                    */
 
   /* special case: property name ID - check for duplicate ID assignment */
   if (strcmp("ID", prop_name) == 0) {
-    int indx = ex__id_lkup(exoid, obj_type, value);
+    int indx = exi_id_lkup(exoid, obj_type, value);
     if (indx != -EX_LOOKUPFAIL) { /* found the id */
       snprintf(errmsg, MAX_ERR_LENGTH,
                "Warning: attempt to assign duplicate %s ID %" PRId64 " in file id %d",
@@ -295,7 +295,7 @@ int ex_put_prop(int exoid, ex_entity_type obj_type, ex_entity_id obj_id, const c
     }
   }
 
-  status = ex__id_lkup(exoid, obj_type, obj_id);
+  status = exi_id_lkup(exoid, obj_type, obj_id);
   if (status > 0) {
     start[0] = status - 1;
   }
@@ -334,6 +334,6 @@ int ex_put_prop(int exoid, ex_entity_type obj_type, ex_entity_id obj_id, const c
 error_ret:
   nc_set_fill(exoid, oldfill, &temp); /* default: nofill */
 
-  ex__leavedef(exoid, __func__);
+  exi_leavedef(exoid, __func__);
   EX_FUNC_LEAVE(EX_FATAL);
 }

--- a/packages/seacas/libraries/exodus/src/ex_put_prop_array.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_prop_array.c
@@ -83,7 +83,7 @@ int ex_put_prop_array(int exoid, ex_entity_type obj_type, const char *prop_name,
   char errmsg[MAX_ERR_LENGTH];
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -92,7 +92,7 @@ int ex_put_prop_array(int exoid, ex_entity_type obj_type, const char *prop_name,
   num_props = ex_get_num_props(exoid, obj_type);
 
   /* inquire id of previously defined dimension (number of objects) */
-  status = ex__get_dimension(exoid, ex__dim_num_objects(obj_type), ex_name_of_object(obj_type),
+  status = exi_get_dimension(exoid, exi_dim_num_objects(obj_type), ex_name_of_object(obj_type),
                              &num_obj, &dimid, __func__);
   if (status != NC_NOERR) {
     EX_FUNC_LEAVE(status);
@@ -199,7 +199,7 @@ int ex_put_prop_array(int exoid, ex_entity_type obj_type, const char *prop_name,
 
     /* leave define mode  */
 
-    if ((status = ex__leavedef(exoid, __func__)) != NC_NOERR) {
+    if ((status = exi_leavedef(exoid, __func__)) != NC_NOERR) {
       snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to exit define mode");
       ex_err_fn(exoid, __func__, errmsg, status);
       EX_FUNC_LEAVE(EX_FATAL);
@@ -225,6 +225,6 @@ int ex_put_prop_array(int exoid, ex_entity_type obj_type, const char *prop_name,
 /* Fatal error: exit definition mode and return */
 error_ret:
   nc_set_fill(exoid, oldfill, &temp); /* default: nofill */
-  ex__leavedef(exoid, __func__);
+  exi_leavedef(exoid, __func__);
   EX_FUNC_LEAVE(EX_FATAL);
 }

--- a/packages/seacas/libraries/exodus/src/ex_put_prop_names.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_prop_names.c
@@ -108,7 +108,7 @@ int ex_put_prop_names(int exoid, ex_entity_type obj_type, int num_props, char **
   char errmsg[MAX_ERR_LENGTH];
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -120,7 +120,7 @@ int ex_put_prop_names(int exoid, ex_entity_type obj_type, int num_props, char **
   name_length = ex_inquire_int(exoid, EX_INQ_DB_MAX_ALLOWED_NAME_LENGTH) + 1;
 
   /* inquire id of previously defined dimension (number of objects) */
-  if ((status = nc_inq_dimid(exoid, ex__dim_num_objects(obj_type), &dimid)) != NC_NOERR) {
+  if ((status = nc_inq_dimid(exoid, exi_dim_num_objects(obj_type), &dimid)) != NC_NOERR) {
     snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to locate number of %s in file id %d",
              ex_name_of_object(obj_type), exoid);
     ex_err_fn(exoid, __func__, errmsg, status);
@@ -204,20 +204,20 @@ int ex_put_prop_names(int exoid, ex_entity_type obj_type, int num_props, char **
   }
 
   /* leave define mode  */
-  if ((status = ex__leavedef(exoid, __func__)) != NC_NOERR) {
+  if ((status = exi_leavedef(exoid, __func__)) != NC_NOERR) {
     snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to exit define mode");
     ex_err_fn(exoid, __func__, errmsg, status);
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
   /* Update the maximum_name_length attribute on the file. */
-  ex__update_max_name_length(exoid, max_name_len - 1);
+  exi_update_max_name_length(exoid, max_name_len - 1);
 
   nc_set_fill(exoid, oldfill, &temp); /* default: turn off fill */
   EX_FUNC_LEAVE(EX_NOERR);
 
 /* Fatal error: exit definition mode and return */
 error_ret:
-  ex__leavedef(exoid, __func__);
+  exi_leavedef(exoid, __func__);
   EX_FUNC_LEAVE(EX_FATAL);
 }

--- a/packages/seacas/libraries/exodus/src/ex_put_qa.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_qa.c
@@ -71,7 +71,7 @@ int ex_put_qa(int exoid, int num_qa_records, char *qa_record[][4])
   EX_FUNC_ENTER();
   int rootid = exoid & EX_FILE_ID_MASK;
 
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -146,13 +146,13 @@ int ex_put_qa(int exoid, int num_qa_records, char *qa_record[][4])
        * compilers/mpi so are doing it this way...
        */
 #if defined(PARALLEL_AWARE_EXODUS)
-      if (ex__is_parallel(rootid)) {
+      if (exi_is_parallel(rootid)) {
         nc_var_par_access(rootid, varid, NC_INDEPENDENT);
       }
 #endif
 
       /*   leave define mode  */
-      if ((status = ex__leavedef(rootid, __func__)) != NC_NOERR) {
+      if ((status = exi_leavedef(rootid, __func__)) != NC_NOERR) {
         snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to exit define mode");
         ex_err_fn(exoid, __func__, errmsg, status);
         EX_FUNC_LEAVE(EX_FATAL);
@@ -192,7 +192,7 @@ int ex_put_qa(int exoid, int num_qa_records, char *qa_record[][4])
     }
     /* PnetCDF applies setting to entire file, so put back to collective... */
 #if defined(PARALLEL_AWARE_EXODUS)
-    if (ex__is_parallel(rootid)) {
+    if (exi_is_parallel(rootid)) {
       nc_var_par_access(rootid, varid, NC_COLLECTIVE);
     }
 #endif
@@ -201,6 +201,6 @@ int ex_put_qa(int exoid, int num_qa_records, char *qa_record[][4])
 
 /* Fatal error: exit definition mode and return */
 error_ret:
-  ex__leavedef(rootid, __func__);
+  exi_leavedef(rootid, __func__);
   EX_FUNC_LEAVE(EX_FATAL);
 }

--- a/packages/seacas/libraries/exodus/src/ex_put_reduction_variable_name.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_reduction_variable_name.c
@@ -46,7 +46,7 @@ int ex_put_reduction_variable_name(int exoid, ex_entity_type obj_type, int var_n
 
   EX_FUNC_ENTER();
 
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -76,7 +76,7 @@ int ex_put_reduction_variable_name(int exoid, ex_entity_type obj_type, int var_n
   }
 
   /* write EXODUS variable name */
-  status = ex__put_name(exoid, varid, var_num - 1, var_name, obj_type, "variable", __func__);
+  status = exi_put_name(exoid, varid, var_num - 1, var_name, obj_type, "variable", __func__);
 
   EX_FUNC_LEAVE(status);
 }

--- a/packages/seacas/libraries/exodus/src/ex_put_reduction_variable_names.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_reduction_variable_names.c
@@ -125,7 +125,7 @@ int ex_put_reduction_variable_names(int exoid, ex_entity_type obj_type, int num_
   int varid;
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -184,6 +184,6 @@ int ex_put_reduction_variable_names(int exoid, ex_entity_type obj_type, int num_
   }
 
   /* write EXODUS variable names */
-  int status = ex__put_names(exoid, varid, num_vars, var_names, obj_type, "variable", __func__);
+  int status = exi_put_names(exoid, varid, num_vars, var_names, obj_type, "variable", __func__);
   EX_FUNC_LEAVE(status);
 }

--- a/packages/seacas/libraries/exodus/src/ex_put_reduction_variable_param.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_reduction_variable_param.c
@@ -7,10 +7,10 @@
  */
 
 #include "exodusII.h"     // for ex_err, etc
-#include "exodusII_int.h" // for ex__compress_variable, etc
+#include "exodusII_int.h" // for exi_compress_variable, etc
 
 /*! \cond INTERNAL */
-static int ex__prepare_result_var(int exoid, int num_vars, char *type_name, char *dim_name,
+static int exi_prepare_result_var(int exoid, int num_vars, char *type_name, char *dim_name,
                                   char *variable_name)
 {
   int status;
@@ -127,7 +127,7 @@ int ex_put_reduction_variable_param(int exoid, ex_entity_type obj_type, int num_
   int  status;
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -173,7 +173,7 @@ int ex_put_reduction_variable_param(int exoid, ex_entity_type obj_type, int num_
 
   /* define dimensions and variables */
   if (obj_type == EX_GLOBAL) {
-    if (ex__prepare_result_var(exoid, num_vars, "global", DIM_NUM_GLO_VAR, VAR_NAME_GLO_VAR) !=
+    if (exi_prepare_result_var(exoid, num_vars, "global", DIM_NUM_GLO_VAR, VAR_NAME_GLO_VAR) !=
         EX_NOERR) {
       goto error_ret;
     }
@@ -193,7 +193,7 @@ int ex_put_reduction_variable_param(int exoid, ex_entity_type obj_type, int num_
       ex_err_fn(exoid, __func__, errmsg, status);
       goto error_ret; /* exit define mode and return */
     }
-    ex__compress_variable(exoid, varid, 2);
+    exi_compress_variable(exoid, varid, 2);
   }
 
   /* netCDF variables in which to store the EXODUS obj_type variable values will
@@ -202,68 +202,68 @@ int ex_put_reduction_variable_param(int exoid, ex_entity_type obj_type, int num_
    * (the info that is stored in the obj_type variable truth table)
    */
   else if (obj_type == EX_ELEM_BLOCK) {
-    if (ex__prepare_result_var(exoid, num_vars, "element", DIM_NUM_ELE_RED_VAR,
+    if (exi_prepare_result_var(exoid, num_vars, "element", DIM_NUM_ELE_RED_VAR,
                                VAR_NAME_ELE_RED_VAR) != EX_NOERR) {
       goto error_ret;
     }
   }
   else if (obj_type == EX_NODE_SET) {
-    if (ex__prepare_result_var(exoid, num_vars, "nodeset", DIM_NUM_NSET_RED_VAR,
+    if (exi_prepare_result_var(exoid, num_vars, "nodeset", DIM_NUM_NSET_RED_VAR,
                                VAR_NAME_NSET_RED_VAR) != EX_NOERR) {
       goto error_ret;
     }
   }
   else if (obj_type == EX_SIDE_SET) {
-    if (ex__prepare_result_var(exoid, num_vars, "sideset", DIM_NUM_SSET_RED_VAR,
+    if (exi_prepare_result_var(exoid, num_vars, "sideset", DIM_NUM_SSET_RED_VAR,
                                VAR_NAME_SSET_RED_VAR) != EX_NOERR) {
       goto error_ret;
     }
   }
   else if (obj_type == EX_ASSEMBLY) {
-    if (ex__prepare_result_var(exoid, num_vars, "assembly", DIM_NUM_ASSEMBLY_RED_VAR,
+    if (exi_prepare_result_var(exoid, num_vars, "assembly", DIM_NUM_ASSEMBLY_RED_VAR,
                                VAR_NAME_ASSEMBLY_RED_VAR) != EX_NOERR) {
       goto error_ret;
     }
   }
   else if (obj_type == EX_BLOB) {
-    if (ex__prepare_result_var(exoid, num_vars, "blob", DIM_NUM_BLOB_RED_VAR,
+    if (exi_prepare_result_var(exoid, num_vars, "blob", DIM_NUM_BLOB_RED_VAR,
                                VAR_NAME_BLOB_RED_VAR) != EX_NOERR) {
       goto error_ret;
     }
   }
   else if (obj_type == EX_EDGE_BLOCK) {
-    if (ex__prepare_result_var(exoid, num_vars, "edge", DIM_NUM_EDG_RED_VAR,
+    if (exi_prepare_result_var(exoid, num_vars, "edge", DIM_NUM_EDG_RED_VAR,
                                VAR_NAME_EDG_RED_VAR) != EX_NOERR) {
       goto error_ret;
     }
   }
   else if (obj_type == EX_FACE_BLOCK) {
-    if (ex__prepare_result_var(exoid, num_vars, "face", DIM_NUM_FAC_RED_VAR,
+    if (exi_prepare_result_var(exoid, num_vars, "face", DIM_NUM_FAC_RED_VAR,
                                VAR_NAME_FAC_RED_VAR) != EX_NOERR) {
       goto error_ret;
     }
   }
   else if (obj_type == EX_EDGE_SET) {
-    if (ex__prepare_result_var(exoid, num_vars, "edgeset", DIM_NUM_ESET_RED_VAR,
+    if (exi_prepare_result_var(exoid, num_vars, "edgeset", DIM_NUM_ESET_RED_VAR,
                                VAR_NAME_ESET_RED_VAR) != EX_NOERR) {
       goto error_ret;
     }
   }
   else if (obj_type == EX_FACE_SET) {
-    if (ex__prepare_result_var(exoid, num_vars, "faceset", DIM_NUM_FSET_RED_VAR,
+    if (exi_prepare_result_var(exoid, num_vars, "faceset", DIM_NUM_FSET_RED_VAR,
                                VAR_NAME_FSET_RED_VAR) != EX_NOERR) {
       goto error_ret;
     }
   }
   else if (obj_type == EX_ELEM_SET) {
-    if (ex__prepare_result_var(exoid, num_vars, "elementset", DIM_NUM_ELSET_RED_VAR,
+    if (exi_prepare_result_var(exoid, num_vars, "elementset", DIM_NUM_ELSET_RED_VAR,
                                VAR_NAME_ELSET_RED_VAR) != EX_NOERR) {
       goto error_ret;
     }
   }
 
   /* leave define mode  */
-  if ((status = ex__leavedef(exoid, __func__)) != NC_NOERR) {
+  if ((status = exi_leavedef(exoid, __func__)) != NC_NOERR) {
     snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to exit define mode");
     ex_err_fn(exoid, __func__, errmsg, status);
     EX_FUNC_LEAVE(EX_FATAL);
@@ -273,6 +273,6 @@ int ex_put_reduction_variable_param(int exoid, ex_entity_type obj_type, int num_
 
 /* Fatal error: exit definition mode and return */
 error_ret:
-  ex__leavedef(exoid, __func__);
+  exi_leavedef(exoid, __func__);
   EX_FUNC_LEAVE(EX_FATAL);
 }

--- a/packages/seacas/libraries/exodus/src/ex_put_reduction_vars.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_reduction_vars.c
@@ -9,7 +9,7 @@
 #include "exodusII.h"
 #include "exodusII_int.h"
 
-static int ex__look_up_var(int exoid, ex_entity_type var_type, ex_entity_id obj_id,
+static int exi_look_up_var(int exoid, ex_entity_type var_type, ex_entity_id obj_id,
                            const char *var_obj_id, const char *dim_num_obj_var, int *varid)
 {
   int  status;
@@ -40,7 +40,7 @@ static int ex__look_up_var(int exoid, ex_entity_type var_type, ex_entity_id obj_
   }
   else {
     /* Determine index of obj_id in var_obj_id array */
-    obj_id_ndx = ex__id_lkup(exoid, var_type, obj_id);
+    obj_id_ndx = exi_id_lkup(exoid, var_type, obj_id);
     if (obj_id_ndx <= 0) {
       ex_get_err(NULL, NULL, &status);
 
@@ -61,7 +61,7 @@ static int ex__look_up_var(int exoid, ex_entity_type var_type, ex_entity_id obj_
       }
     }
   }
-  if ((status = nc_inq_varid(exoid, ex__name_red_var_of_object(var_type, obj_id_ndx), varid)) !=
+  if ((status = nc_inq_varid(exoid, exi_name_red_var_of_object(var_type, obj_id_ndx), varid)) !=
       NC_NOERR) {
     if (status == NC_ENOTVAR) { /* variable doesn't exist, create it! */
       int time_dim;
@@ -74,7 +74,7 @@ static int ex__look_up_var(int exoid, ex_entity_type var_type, ex_entity_id obj_
 
       size_t num_obj_var;
       int    numvardim;
-      if ((status = ex__get_dimension(exoid, dim_num_obj_var, ex_name_of_object(var_type),
+      if ((status = exi_get_dimension(exoid, dim_num_obj_var, ex_name_of_object(var_type),
                                       &num_obj_var, &numvardim, __func__)) != EX_NOERR) {
         snprintf(errmsg, MAX_ERR_LENGTH,
                  "ERROR: failed to inquire number of %s reduction variables in file id %d",
@@ -92,24 +92,24 @@ static int ex__look_up_var(int exoid, ex_entity_type var_type, ex_entity_id obj_
 
       /* define NetCDF variable to store reduction variable values */
       int dims[] = {time_dim, numvardim};
-      if ((status = nc_def_var(exoid, ex__name_red_var_of_object(var_type, obj_id_ndx),
+      if ((status = nc_def_var(exoid, exi_name_red_var_of_object(var_type, obj_id_ndx),
                                nc_flt_code(exoid), 2, dims, varid)) != NC_NOERR) {
         snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to define %s in file id %d",
                  ex_name_of_object(var_type), exoid);
         ex_err_fn(exoid, __func__, errmsg, status);
-        ex__leavedef(exoid, __func__);
+        exi_leavedef(exoid, __func__);
         return (EX_FATAL);
       }
-      ex__compress_variable(exoid, *varid, 2);
+      exi_compress_variable(exoid, *varid, 2);
 
       /*    leave define mode  */
-      if ((status = ex__leavedef(exoid, __func__)) != NC_NOERR) {
+      if ((status = exi_leavedef(exoid, __func__)) != NC_NOERR) {
         return (EX_FATAL);
       }
     }
     else {
       snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to locate %s %s in file id %d",
-               ex_name_of_object(var_type), ex__name_red_var_of_object(var_type, obj_id_ndx),
+               ex_name_of_object(var_type), exi_name_red_var_of_object(var_type, obj_id_ndx),
                exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       return (EX_FATAL);
@@ -189,7 +189,7 @@ int ex_put_reduction_vars(int exoid, int time_step, ex_entity_type var_type, ex_
 
   EX_FUNC_ENTER();
 
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -200,34 +200,34 @@ int ex_put_reduction_vars(int exoid, int time_step, ex_entity_type var_type, ex_
     return ex_put_var(exoid, time_step, var_type, 1, 1, num_variables, var_vals);
     break;
   case EX_ASSEMBLY:
-    status = ex__look_up_var(exoid, var_type, obj_id, "assembly", DIM_NUM_ASSEMBLY_RED_VAR, &varid);
+    status = exi_look_up_var(exoid, var_type, obj_id, "assembly", DIM_NUM_ASSEMBLY_RED_VAR, &varid);
     break;
   case EX_BLOB:
-    status = ex__look_up_var(exoid, var_type, obj_id, "blob", DIM_NUM_BLOB_RED_VAR, &varid);
+    status = exi_look_up_var(exoid, var_type, obj_id, "blob", DIM_NUM_BLOB_RED_VAR, &varid);
     break;
   case EX_EDGE_BLOCK:
-    status = ex__look_up_var(exoid, var_type, obj_id, VAR_ID_ED_BLK, DIM_NUM_EDG_RED_VAR, &varid);
+    status = exi_look_up_var(exoid, var_type, obj_id, VAR_ID_ED_BLK, DIM_NUM_EDG_RED_VAR, &varid);
     break;
   case EX_FACE_BLOCK:
-    status = ex__look_up_var(exoid, var_type, obj_id, VAR_ID_FA_BLK, DIM_NUM_FAC_RED_VAR, &varid);
+    status = exi_look_up_var(exoid, var_type, obj_id, VAR_ID_FA_BLK, DIM_NUM_FAC_RED_VAR, &varid);
     break;
   case EX_ELEM_BLOCK:
-    status = ex__look_up_var(exoid, var_type, obj_id, VAR_ID_EL_BLK, DIM_NUM_ELE_RED_VAR, &varid);
+    status = exi_look_up_var(exoid, var_type, obj_id, VAR_ID_EL_BLK, DIM_NUM_ELE_RED_VAR, &varid);
     break;
   case EX_NODE_SET:
-    status = ex__look_up_var(exoid, var_type, obj_id, VAR_NS_IDS, DIM_NUM_NSET_RED_VAR, &varid);
+    status = exi_look_up_var(exoid, var_type, obj_id, VAR_NS_IDS, DIM_NUM_NSET_RED_VAR, &varid);
     break;
   case EX_EDGE_SET:
-    status = ex__look_up_var(exoid, var_type, obj_id, VAR_ES_IDS, DIM_NUM_ESET_RED_VAR, &varid);
+    status = exi_look_up_var(exoid, var_type, obj_id, VAR_ES_IDS, DIM_NUM_ESET_RED_VAR, &varid);
     break;
   case EX_FACE_SET:
-    status = ex__look_up_var(exoid, var_type, obj_id, VAR_FS_IDS, DIM_NUM_FSET_RED_VAR, &varid);
+    status = exi_look_up_var(exoid, var_type, obj_id, VAR_FS_IDS, DIM_NUM_FSET_RED_VAR, &varid);
     break;
   case EX_SIDE_SET:
-    status = ex__look_up_var(exoid, var_type, obj_id, VAR_SS_IDS, DIM_NUM_SSET_RED_VAR, &varid);
+    status = exi_look_up_var(exoid, var_type, obj_id, VAR_SS_IDS, DIM_NUM_SSET_RED_VAR, &varid);
     break;
   case EX_ELEM_SET:
-    status = ex__look_up_var(exoid, var_type, obj_id, VAR_ELS_IDS, DIM_NUM_ELSET_RED_VAR, &varid);
+    status = exi_look_up_var(exoid, var_type, obj_id, VAR_ELS_IDS, DIM_NUM_ELSET_RED_VAR, &varid);
     break;
   default:
     snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: invalid variable type (%d) specified for file id %d",
@@ -247,7 +247,7 @@ int ex_put_reduction_vars(int exoid, int time_step, ex_entity_type var_type, ex_
   start[1] = 0;
   count[1] = num_variables;
 
-  if (ex__comp_ws(exoid) == 4) {
+  if (exi_comp_ws(exoid) == 4) {
     status = nc_put_vara_float(exoid, varid, start, count, var_vals);
   }
   else {

--- a/packages/seacas/libraries/exodus/src/ex_put_set.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_set.c
@@ -25,7 +25,7 @@
 *****************************************************************************/
 
 #include "exodusII.h"     // for ex_err, ex_name_of_object, etc
-#include "exodusII_int.h" // for ex__check_valid_file_id, etc
+#include "exodusII_int.h" // for exi_check_valid_file_id, etc
 
 /*!
  * writes the set entry list and set extra list for a single set
@@ -49,12 +49,12 @@ int ex_put_set(int exoid, ex_entity_type set_type, ex_entity_id set_id,
 
   EX_FUNC_ENTER();
 
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
   /* first check if any sets are specified */
-  if ((status = nc_inq_dimid(exoid, ex__dim_num_objects(set_type), &dimid)) != NC_NOERR) {
+  if ((status = nc_inq_dimid(exoid, exi_dim_num_objects(set_type), &dimid)) != NC_NOERR) {
     snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: no %ss defined in file id %d",
              ex_name_of_object(set_type), exoid);
     ex_err_fn(exoid, __func__, errmsg, status);
@@ -62,7 +62,7 @@ int ex_put_set(int exoid, ex_entity_type set_type, ex_entity_id set_id,
   }
 
   /* Lookup index of set id in VAR_*S_IDS array */
-  set_id_ndx = ex__id_lkup(exoid, set_type, set_id);
+  set_id_ndx = exi_id_lkup(exoid, set_type, set_id);
   if (set_id_ndx <= 0) {
     ex_get_err(NULL, NULL, &status);
 

--- a/packages/seacas/libraries/exodus/src/ex_put_set_dist_fact.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_set_dist_fact.c
@@ -45,12 +45,12 @@ int ex_put_set_dist_fact(int exoid, ex_entity_type set_type, ex_entity_id set_id
 
   EX_FUNC_ENTER();
 
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
   /* first check if any sets are specified */
-  if ((status = nc_inq_dimid(exoid, ex__dim_num_objects(set_type), &dimid)) != NC_NOERR) {
+  if ((status = nc_inq_dimid(exoid, exi_dim_num_objects(set_type), &dimid)) != NC_NOERR) {
     snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: no %ss specified in file id %d",
              ex_name_of_object(set_type), exoid);
     ex_err_fn(exoid, __func__, errmsg, status);
@@ -58,7 +58,7 @@ int ex_put_set_dist_fact(int exoid, ex_entity_type set_type, ex_entity_id set_id
   }
 
   /* Lookup index of set id in VAR_*S_IDS array */
-  set_id_ndx = ex__id_lkup(exoid, set_type, set_id);
+  set_id_ndx = exi_id_lkup(exoid, set_type, set_id);
   if (set_id_ndx <= 0) {
     ex_get_err(NULL, NULL, &status);
 
@@ -117,7 +117,7 @@ int ex_put_set_dist_fact(int exoid, ex_entity_type set_type, ex_entity_id set_id
   }
 
   /* write out the distribution factors array */
-  if (ex__comp_ws(exoid) == 4) {
+  if (exi_comp_ws(exoid) == 4) {
     status = nc_put_var_float(exoid, dist_id, set_dist_fact);
   }
   else {

--- a/packages/seacas/libraries/exodus/src/ex_put_sets.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_sets.c
@@ -39,7 +39,7 @@ int ex_put_sets(int exoid, size_t set_count, const struct ex_set *sets)
 
   EX_FUNC_ENTER();
 
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -59,7 +59,7 @@ int ex_put_sets(int exoid, size_t set_count, const struct ex_set *sets)
   */
   for (i = 0; i < set_count; i++) {
     /* first check if any sets are specified */
-    if ((status = nc_inq_dimid(exoid, ex__dim_num_objects(sets[i].type), &dimid)) != NC_NOERR) {
+    if ((status = nc_inq_dimid(exoid, exi_dim_num_objects(sets[i].type), &dimid)) != NC_NOERR) {
       if (status == NC_EBADDIM) {
         snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: no %ss defined for file id %d",
                  ex_name_of_object(sets[i].type), exoid);
@@ -83,7 +83,7 @@ int ex_put_sets(int exoid, size_t set_count, const struct ex_set *sets)
       sets_to_define[i] = -1;
     }
     else {
-      status = ex__id_lkup(exoid, sets[i].type, sets[i].id);
+      status = exi_id_lkup(exoid, sets[i].type, sets[i].id);
       if (status != -EX_LOOKUPFAIL) { /* found the side set id, so set is already defined... */
         sets_to_define[i] = 0;
       }
@@ -109,14 +109,14 @@ int ex_put_sets(int exoid, size_t set_count, const struct ex_set *sets)
       }
 
       if (sets_to_define[i] > 0) {
-        /*   NOTE: ex__inc_file_item finds the current number of sets defined
+        /*   NOTE: exi_inc_file_item finds the current number of sets defined
              for a specific file and returns that value incremented. */
-        cur_num_sets      = ex__inc_file_item(exoid, ex__get_counter_list(sets[i].type));
+        cur_num_sets      = exi_inc_file_item(exoid, exi_get_counter_list(sets[i].type));
         set_id_ndx        = cur_num_sets + 1;
         sets_to_define[i] = set_id_ndx;
       }
       else {
-        cur_num_sets      = ex__get_file_item(exoid, ex__get_counter_list(sets[i].type));
+        cur_num_sets      = exi_get_file_item(exoid, exi_get_counter_list(sets[i].type));
         set_id_ndx        = cur_num_sets - set_count + i + 1;
         sets_to_define[i] = set_id_ndx;
       }
@@ -202,7 +202,7 @@ int ex_put_sets(int exoid, size_t set_count, const struct ex_set *sets)
         }
         goto error_ret; /* exit define mode and return */
       }
-      ex__compress_variable(exoid, varid, 1);
+      exi_compress_variable(exoid, varid, 1);
 
       if (extraptr) {
         if ((status = nc_def_var(exoid, extraptr, int_type, 1, dims, &varid)) != NC_NOERR) {
@@ -220,7 +220,7 @@ int ex_put_sets(int exoid, size_t set_count, const struct ex_set *sets)
           }
           goto error_ret; /* exit define mode and return */
         }
-        ex__compress_variable(exoid, varid, 1);
+        exi_compress_variable(exoid, varid, 1);
       }
 
       /* Create distribution factors variable if required */
@@ -268,12 +268,12 @@ int ex_put_sets(int exoid, size_t set_count, const struct ex_set *sets)
           }
           goto error_ret; /* exit define mode and return */
         }
-        ex__compress_variable(exoid, varid, 2);
+        exi_compress_variable(exoid, varid, 2);
       }
     }
 
     /* leave define mode  */
-    if ((status = ex__leavedef(exoid, __func__)) != NC_NOERR) {
+    if ((status = exi_leavedef(exoid, __func__)) != NC_NOERR) {
       snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to exit define mode");
       ex_err_fn(exoid, __func__, errmsg, status);
       free(sets_to_define);
@@ -381,6 +381,6 @@ int ex_put_sets(int exoid, size_t set_count, const struct ex_set *sets)
 error_ret:
   free(sets_to_define);
 
-  ex__leavedef(exoid, __func__);
+  exi_leavedef(exoid, __func__);
   EX_FUNC_LEAVE(EX_FATAL);
 }

--- a/packages/seacas/libraries/exodus/src/ex_put_ss_param_global.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_ss_param_global.c
@@ -39,7 +39,7 @@ int ex_put_ss_param_global(int exoid, const void_int *global_ids, const void_int
   /*-----------------------------Execution begins-----------------------------*/
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 

--- a/packages/seacas/libraries/exodus/src/ex_put_time.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_time.c
@@ -7,7 +7,7 @@
  */
 
 #include "exodusII.h"     // for ex_err, etc
-#include "exodusII_int.h" // for EX_FATAL, ex__comp_ws, etc
+#include "exodusII_int.h" // for EX_FATAL, exi_comp_ws, etc
 
 /*!
 \ingroup ResultsData
@@ -54,11 +54,11 @@ int ex_put_time(int exoid, int time_step, const void *time_value)
   int                   varid;
   size_t                start[1];
   char                  errmsg[MAX_ERR_LENGTH];
-  struct ex__file_item *file = NULL;
+  struct exi_file_item *file = NULL;
 
   EX_FUNC_ENTER();
 
-  file = ex__find_file_item(exoid);
+  file = exi_find_file_item(exoid);
   if (!file) {
     snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: unknown file id %d.", exoid);
     ex_err_fn(exoid, __func__, errmsg, EX_BADFILEID);
@@ -80,7 +80,7 @@ int ex_put_time(int exoid, int time_step, const void *time_value)
   /* store time value */
   start[0] = --time_step;
 
-  if (ex__comp_ws(exoid) == 4) {
+  if (exi_comp_ws(exoid) == 4) {
     status = nc_put_var1_float(exoid, varid, start, time_value);
   }
   else {

--- a/packages/seacas/libraries/exodus/src/ex_put_truth_table.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_truth_table.c
@@ -25,7 +25,7 @@
  *****************************************************************************/
 
 #include "exodusII.h"     // for ex_err, etc
-#include "exodusII_int.h" // for ex__get_dimension, EX_FATAL, etc
+#include "exodusII_int.h" // for exi_get_dimension, EX_FATAL, etc
 
 /*!
 \ingroup ResultsData
@@ -88,15 +88,15 @@ int ex_put_truth_table(int exoid, ex_entity_type obj_type, int num_blk, int num_
 
   EX_FUNC_ENTER();
 
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
-  ex__get_dimension(exoid, ex__dim_num_objects(obj_type), ex_name_of_object(obj_type), &num_entity,
+  exi_get_dimension(exoid, exi_dim_num_objects(obj_type), ex_name_of_object(obj_type), &num_entity,
                     &numelblkdim, __func__);
 
   if (obj_type == EX_ELEM_BLOCK) {
-    ex__get_dimension(exoid, DIM_NUM_ELE_VAR, "element variables", &num_var_db, &numelvardim,
+    exi_get_dimension(exoid, DIM_NUM_ELE_VAR, "element variables", &num_var_db, &numelvardim,
                       __func__);
     var_name = "vals_elem_var";
     ent_type = "eb";
@@ -105,7 +105,7 @@ int ex_put_truth_table(int exoid, ex_entity_type obj_type, int num_blk, int num_
     tab_type = VAR_ELEM_TAB;
   }
   else if (obj_type == EX_EDGE_BLOCK) {
-    ex__get_dimension(exoid, DIM_NUM_EDG_VAR, "edge block variables", &num_var_db, &numelvardim,
+    exi_get_dimension(exoid, DIM_NUM_EDG_VAR, "edge block variables", &num_var_db, &numelvardim,
                       __func__);
     var_name = "vals_edge_var";
     ent_type = "eb";
@@ -114,7 +114,7 @@ int ex_put_truth_table(int exoid, ex_entity_type obj_type, int num_blk, int num_
     tab_type = VAR_EBLK_TAB;
   }
   else if (obj_type == EX_FACE_BLOCK) {
-    ex__get_dimension(exoid, DIM_NUM_FAC_VAR, "face block variables", &num_var_db, &numelvardim,
+    exi_get_dimension(exoid, DIM_NUM_FAC_VAR, "face block variables", &num_var_db, &numelvardim,
                       __func__);
     var_name = "vals_face_var";
     ent_type = "fb";
@@ -123,7 +123,7 @@ int ex_put_truth_table(int exoid, ex_entity_type obj_type, int num_blk, int num_
     tab_type = VAR_FBLK_TAB;
   }
   else if (obj_type == EX_SIDE_SET) {
-    ex__get_dimension(exoid, DIM_NUM_SSET_VAR, "sideset variables", &num_var_db, &numelvardim,
+    exi_get_dimension(exoid, DIM_NUM_SSET_VAR, "sideset variables", &num_var_db, &numelvardim,
                       __func__);
     var_name = "vals_sset_var";
     ent_type = "ss";
@@ -132,7 +132,7 @@ int ex_put_truth_table(int exoid, ex_entity_type obj_type, int num_blk, int num_
     tab_type = VAR_SSET_TAB;
   }
   else if (obj_type == EX_NODE_SET) {
-    ex__get_dimension(exoid, DIM_NUM_NSET_VAR, "nodeset variables", &num_var_db, &numelvardim,
+    exi_get_dimension(exoid, DIM_NUM_NSET_VAR, "nodeset variables", &num_var_db, &numelvardim,
                       __func__);
     var_name = "vals_nset_var";
     ent_type = "ns";
@@ -141,7 +141,7 @@ int ex_put_truth_table(int exoid, ex_entity_type obj_type, int num_blk, int num_
     tab_type = VAR_NSET_TAB;
   }
   else if (obj_type == EX_EDGE_SET) {
-    ex__get_dimension(exoid, DIM_NUM_ESET_VAR, "edge set variables", &num_var_db, &numelvardim,
+    exi_get_dimension(exoid, DIM_NUM_ESET_VAR, "edge set variables", &num_var_db, &numelvardim,
                       __func__);
     var_name = "vals_eset_var";
     ent_type = "es";
@@ -150,7 +150,7 @@ int ex_put_truth_table(int exoid, ex_entity_type obj_type, int num_blk, int num_
     tab_type = VAR_ESET_TAB;
   }
   else if (obj_type == EX_FACE_SET) {
-    ex__get_dimension(exoid, DIM_NUM_FSET_VAR, "face set variables", &num_var_db, &numelvardim,
+    exi_get_dimension(exoid, DIM_NUM_FSET_VAR, "face set variables", &num_var_db, &numelvardim,
                       __func__);
     var_name = "vals_fset_var";
     ent_type = "fs";
@@ -159,7 +159,7 @@ int ex_put_truth_table(int exoid, ex_entity_type obj_type, int num_blk, int num_
     tab_type = VAR_FSET_TAB;
   }
   else if (obj_type == EX_ELEM_SET) {
-    ex__get_dimension(exoid, DIM_NUM_ELSET_VAR, "element set variables", &num_var_db, &numelvardim,
+    exi_get_dimension(exoid, DIM_NUM_ELSET_VAR, "element set variables", &num_var_db, &numelvardim,
                       __func__);
     var_name = "vals_elset_var";
     ent_type = "es";
@@ -168,7 +168,7 @@ int ex_put_truth_table(int exoid, ex_entity_type obj_type, int num_blk, int num_
     tab_type = VAR_ELSET_TAB;
   }
   else if (obj_type == EX_BLOB) {
-    ex__get_dimension(exoid, DIM_NUM_BLOB_VAR, "blob variables", &num_var_db, &numelvardim,
+    exi_get_dimension(exoid, DIM_NUM_BLOB_VAR, "blob variables", &num_var_db, &numelvardim,
                       __func__);
     var_name = "vals_blob_var";
     ent_type = "blob";
@@ -271,7 +271,7 @@ int ex_put_truth_table(int exoid, ex_entity_type obj_type, int num_blk, int num_
           dims[0] = timedim;
 
           /* Determine number of entities in block */
-          if ((status = nc_inq_dimid(exoid, ex__catstr(ent_size, (i + 1)), &dims[1])) != NC_NOERR) {
+          if ((status = nc_inq_dimid(exoid, exi_catstr(ent_size, (i + 1)), &dims[1])) != NC_NOERR) {
             free(stat_vals);
             snprintf(errmsg, MAX_ERR_LENGTH,
                      "ERROR: failed to locate number of entities in "
@@ -288,7 +288,7 @@ int ex_put_truth_table(int exoid, ex_entity_type obj_type, int num_blk, int num_
            * instead of 0
            */
 
-          if ((status = nc_def_var(exoid, ex__catstr2(var_name, j, ent_type, i + 1),
+          if ((status = nc_def_var(exoid, exi_catstr2(var_name, j, ent_type, i + 1),
                                    nc_flt_code(exoid), 2, dims, &varid)) != NC_NOERR) {
             if (status != NC_ENAMEINUSE) {
               free(stat_vals);
@@ -298,7 +298,7 @@ int ex_put_truth_table(int exoid, ex_entity_type obj_type, int num_blk, int num_
               ex_err_fn(exoid, __func__, errmsg, status);
               goto error_ret; /* exit define mode and return */
             }
-            ex__compress_variable(exoid, varid, 2);
+            exi_compress_variable(exoid, varid, 2);
           }
         }
       }    /* if */
@@ -324,7 +324,7 @@ int ex_put_truth_table(int exoid, ex_entity_type obj_type, int num_blk, int num_
   }
 
   /* leave define mode  */
-  if ((status = ex__leavedef(exoid, __func__)) != NC_NOERR) {
+  if ((status = exi_leavedef(exoid, __func__)) != NC_NOERR) {
     snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to exit define mode");
     ex_err_fn(exoid, __func__, errmsg, status);
     EX_FUNC_LEAVE(EX_FATAL);
@@ -344,6 +344,6 @@ int ex_put_truth_table(int exoid, ex_entity_type obj_type, int num_blk, int num_
 
 /* Fatal error: exit definition mode and return */
 error_ret:
-  ex__leavedef(exoid, __func__);
+  exi_leavedef(exoid, __func__);
   EX_FUNC_LEAVE(EX_FATAL);
 }

--- a/packages/seacas/libraries/exodus/src/ex_put_var_multi_time.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_var_multi_time.c
@@ -9,7 +9,7 @@
 #include "exodusII.h"     // for ex_err, etc
 #include "exodusII_int.h" // for EX_FATAL, etc
 
-static int ex__look_up_var(int exoid, ex_entity_type var_type, int var_index, ex_entity_id obj_id,
+static int exi_look_up_var(int exoid, ex_entity_type var_type, int var_index, ex_entity_id obj_id,
                            const char *VOBJID, const char *VOBJTAB, const char *DNUMOBJ,
                            const char *DNUMOBJVAR, int *varid)
 {
@@ -48,7 +48,7 @@ static int ex__look_up_var(int exoid, ex_entity_type var_type, int var_index, ex
   }
   else {
     /* Determine index of obj_id in VOBJID array */
-    obj_id_ndx = ex__id_lkup(exoid, var_type, obj_id);
+    obj_id_ndx = exi_id_lkup(exoid, var_type, obj_id);
     if (obj_id_ndx <= 0) {
       ex_get_err(NULL, NULL, &status);
 
@@ -70,19 +70,19 @@ static int ex__look_up_var(int exoid, ex_entity_type var_type, int var_index, ex
     }
   }
 
-  if ((status = nc_inq_varid(exoid, ex__name_var_of_object(var_type, var_index, obj_id_ndx),
+  if ((status = nc_inq_varid(exoid, exi_name_var_of_object(var_type, var_index, obj_id_ndx),
                              varid)) != NC_NOERR) {
     if (status == NC_ENOTVAR) { /* variable doesn't exist, create it! */
       /* check for the existence of an TNAME variable truth table */
       if (nc_inq_varid(exoid, VOBJTAB, varid) == NC_NOERR) {
         /* find out number of TNAMEs and TNAME variables */
-        status = ex__get_dimension(exoid, DNUMOBJ, ex_name_of_object(var_type), &num_obj, &dimid,
+        status = exi_get_dimension(exoid, DNUMOBJ, ex_name_of_object(var_type), &num_obj, &dimid,
                                    __func__);
         if (status != NC_NOERR) {
           return (status);
         }
 
-        status = ex__get_dimension(exoid, DNUMOBJVAR, ex_name_of_object(var_type), &num_obj_var,
+        status = exi_get_dimension(exoid, DNUMOBJVAR, ex_name_of_object(var_type), &num_obj_var,
                                    &dimid, __func__);
         if (status != NC_NOERR) {
           return (status);
@@ -123,7 +123,7 @@ static int ex__look_up_var(int exoid, ex_entity_type var_type, int var_index, ex
         goto error_ret; /* exit define mode and return */
       }
 
-      ex__get_dimension(exoid, ex__dim_num_entries_in_object(var_type, obj_id_ndx),
+      exi_get_dimension(exoid, exi_dim_num_entries_in_object(var_type, obj_id_ndx),
                         ex_name_of_object(var_type), &num_entity, &numobjdim, __func__);
 
       /*    variable doesn't exist so put file into define mode  */
@@ -136,23 +136,23 @@ static int ex__look_up_var(int exoid, ex_entity_type var_type, int var_index, ex
       /* define netCDF variable to store TNAME variable values */
       dims[0] = time_dim;
       dims[1] = numobjdim;
-      if ((status = nc_def_var(exoid, ex__name_var_of_object(var_type, var_index, obj_id_ndx),
+      if ((status = nc_def_var(exoid, exi_name_var_of_object(var_type, var_index, obj_id_ndx),
                                nc_flt_code(exoid), 2, dims, varid)) != NC_NOERR) {
         snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to define %s variable %d in file id %d",
                  ex_name_of_object(var_type), var_index, exoid);
         ex_err_fn(exoid, __func__, errmsg, status);
         goto error_ret;
       }
-      ex__compress_variable(exoid, *varid, 2);
+      exi_compress_variable(exoid, *varid, 2);
 
       /*    leave define mode  */
-      if ((status = ex__leavedef(exoid, __func__)) != NC_NOERR) {
+      if ((status = exi_leavedef(exoid, __func__)) != NC_NOERR) {
         return (EX_FATAL);
       }
     }
     else {
       snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to locate %s variable %s in file id %d",
-               ex_name_of_object(var_type), ex__name_var_of_object(var_type, var_index, obj_id_ndx),
+               ex_name_of_object(var_type), exi_name_var_of_object(var_type, var_index, obj_id_ndx),
                exoid);
       ex_err_fn(exoid, __func__, errmsg, status);
       return (EX_FATAL);
@@ -162,7 +162,7 @@ static int ex__look_up_var(int exoid, ex_entity_type var_type, int var_index, ex
 
 /* Fatal error: exit definition mode and return */
 error_ret:
-  ex__leavedef(exoid, __func__);
+  exi_leavedef(exoid, __func__);
   return (EX_FATAL);
 }
 
@@ -247,7 +247,7 @@ int ex_put_var_multi_time(int exoid, ex_entity_type var_type, int var_index, ex_
 
   EX_FUNC_ENTER();
 
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -276,47 +276,47 @@ int ex_put_var_multi_time(int exoid, ex_entity_type var_type, int var_index, ex_
     }
     break;
   case EX_NODAL:
-    status = ex__put_nodal_var_time(exoid, var_index, num_entries_this_obj, beg_time_step,
+    status = exi_put_nodal_var_time(exoid, var_index, num_entries_this_obj, beg_time_step,
                                     end_time_step, var_vals);
     EX_FUNC_LEAVE(status);
   case EX_ASSEMBLY:
-    status = ex__look_up_var(exoid, var_type, var_index, obj_id, "", VAR_ASSEMBLY_TAB,
+    status = exi_look_up_var(exoid, var_type, var_index, obj_id, "", VAR_ASSEMBLY_TAB,
                              DIM_NUM_ASSEMBLY, DIM_NUM_ASSEMBLY_VAR, &varid);
     break;
   case EX_BLOB:
-    status = ex__look_up_var(exoid, var_type, var_index, obj_id, "", VAR_BLOB_TAB, DIM_NUM_BLOB,
+    status = exi_look_up_var(exoid, var_type, var_index, obj_id, "", VAR_BLOB_TAB, DIM_NUM_BLOB,
                              DIM_NUM_BLOB_VAR, &varid);
     break;
   case EX_EDGE_BLOCK:
-    status = ex__look_up_var(exoid, var_type, var_index, obj_id, VAR_ID_ED_BLK, VAR_EBLK_TAB,
+    status = exi_look_up_var(exoid, var_type, var_index, obj_id, VAR_ID_ED_BLK, VAR_EBLK_TAB,
                              DIM_NUM_ED_BLK, DIM_NUM_EDG_VAR, &varid);
     break;
   case EX_FACE_BLOCK:
-    status = ex__look_up_var(exoid, var_type, var_index, obj_id, VAR_ID_FA_BLK, VAR_FBLK_TAB,
+    status = exi_look_up_var(exoid, var_type, var_index, obj_id, VAR_ID_FA_BLK, VAR_FBLK_TAB,
                              DIM_NUM_FA_BLK, DIM_NUM_FAC_VAR, &varid);
     break;
   case EX_ELEM_BLOCK:
-    status = ex__look_up_var(exoid, var_type, var_index, obj_id, VAR_ID_EL_BLK, VAR_ELEM_TAB,
+    status = exi_look_up_var(exoid, var_type, var_index, obj_id, VAR_ID_EL_BLK, VAR_ELEM_TAB,
                              DIM_NUM_EL_BLK, DIM_NUM_ELE_VAR, &varid);
     break;
   case EX_NODE_SET:
-    status = ex__look_up_var(exoid, var_type, var_index, obj_id, VAR_NS_IDS, VAR_NSET_TAB,
+    status = exi_look_up_var(exoid, var_type, var_index, obj_id, VAR_NS_IDS, VAR_NSET_TAB,
                              DIM_NUM_NS, DIM_NUM_NSET_VAR, &varid);
     break;
   case EX_EDGE_SET:
-    status = ex__look_up_var(exoid, var_type, var_index, obj_id, VAR_ES_IDS, VAR_ESET_TAB,
+    status = exi_look_up_var(exoid, var_type, var_index, obj_id, VAR_ES_IDS, VAR_ESET_TAB,
                              DIM_NUM_ES, DIM_NUM_ESET_VAR, &varid);
     break;
   case EX_FACE_SET:
-    status = ex__look_up_var(exoid, var_type, var_index, obj_id, VAR_FS_IDS, VAR_FSET_TAB,
+    status = exi_look_up_var(exoid, var_type, var_index, obj_id, VAR_FS_IDS, VAR_FSET_TAB,
                              DIM_NUM_FS, DIM_NUM_FSET_VAR, &varid);
     break;
   case EX_SIDE_SET:
-    status = ex__look_up_var(exoid, var_type, var_index, obj_id, VAR_SS_IDS, VAR_SSET_TAB,
+    status = exi_look_up_var(exoid, var_type, var_index, obj_id, VAR_SS_IDS, VAR_SSET_TAB,
                              DIM_NUM_SS, DIM_NUM_SSET_VAR, &varid);
     break;
   case EX_ELEM_SET:
-    status = ex__look_up_var(exoid, var_type, var_index, obj_id, VAR_ELS_IDS, VAR_ELSET_TAB,
+    status = exi_look_up_var(exoid, var_type, var_index, obj_id, VAR_ELS_IDS, VAR_ELSET_TAB,
                              DIM_NUM_ELS, DIM_NUM_ELSET_VAR, &varid);
     break;
   default:
@@ -346,7 +346,7 @@ int ex_put_var_multi_time(int exoid, ex_entity_type var_type, int var_index, ex_
   count[0] = end_time_step - beg_time_step + 1;
   count[1] = num_entries_this_obj;
 
-  if (ex__comp_ws(exoid) == 4) {
+  if (exi_comp_ws(exoid) == 4) {
     status = nc_put_vara_float(exoid, varid, start, count, var_vals);
   }
   else {

--- a/packages/seacas/libraries/exodus/src/ex_put_variable_name.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_variable_name.c
@@ -45,7 +45,7 @@ int ex_put_variable_name(int exoid, ex_entity_type obj_type, int var_num, const 
 
   EX_FUNC_ENTER();
 
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -78,7 +78,7 @@ int ex_put_variable_name(int exoid, ex_entity_type obj_type, int var_num, const 
   }
 
   /* write EXODUS variable name */
-  status = ex__put_name(exoid, varid, var_num - 1, var_name, obj_type, "variable", __func__);
+  status = exi_put_name(exoid, varid, var_num - 1, var_name, obj_type, "variable", __func__);
 
   EX_FUNC_LEAVE(status);
 }

--- a/packages/seacas/libraries/exodus/src/ex_put_variable_names.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_variable_names.c
@@ -129,7 +129,7 @@ int ex_put_variable_names(int exoid, ex_entity_type obj_type, int num_vars, char
   char errmsg[MAX_ERR_LENGTH];
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -178,7 +178,7 @@ int ex_put_variable_names(int exoid, ex_entity_type obj_type, int num_vars, char
   }
 
   /* write EXODUS variable names */
-  status = ex__put_names(exoid, varid, num_vars, var_names, obj_type, "variable", __func__);
+  status = exi_put_names(exoid, varid, num_vars, var_names, obj_type, "variable", __func__);
 
   EX_FUNC_LEAVE(status);
 }

--- a/packages/seacas/libraries/exodus/src/ex_put_variable_param.c
+++ b/packages/seacas/libraries/exodus/src/ex_put_variable_param.c
@@ -7,7 +7,7 @@
  */
 
 #include "exodusII.h"     // for ex_err, etc
-#include "exodusII_int.h" // for ex__compress_variable, etc
+#include "exodusII_int.h" // for exi_compress_variable, etc
 
 /*! \cond INTERNAL */
 static int ex_prepare_result_var(int exoid, int num_vars, char *type_name, char *dim_name,
@@ -59,7 +59,7 @@ static int ex_prepare_result_var(int exoid, int num_vars, char *type_name, char 
     }
     return (EX_FATAL); /* exit define mode and return */
   }
-  ex__set_compact_storage(exoid, varid);
+  exi_set_compact_storage(exoid, varid);
 #if defined(EX_CAN_USE_NC_DEF_VAR_FILL)
   int fill = NC_FILL_CHAR;
   nc_def_var_fill(exoid, varid, 0, &fill);
@@ -129,7 +129,7 @@ int ex_put_variable_param(int exoid, ex_entity_type obj_type, int num_vars)
   int  status;
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -202,9 +202,9 @@ int ex_put_variable_param(int exoid, ex_entity_type obj_type, int num_vars)
       ex_err_fn(exoid, __func__, errmsg, status);
       goto error_ret; /* exit define mode and return */
     }
-    ex__compress_variable(exoid, varid, 2);
+    exi_compress_variable(exoid, varid, 2);
     if (num_vars * 8 < 64 * 1024) {
-      ex__set_compact_storage(exoid, varid);
+      exi_set_compact_storage(exoid, varid);
     }
   }
   else if (obj_type == EX_NODAL) {
@@ -224,7 +224,7 @@ int ex_put_variable_param(int exoid, ex_entity_type obj_type, int num_vars)
         ex_err_fn(exoid, __func__, errmsg, status);
         goto error_ret; /* exit define mode and return */
       }
-      ex__compress_variable(exoid, varid, 2);
+      exi_compress_variable(exoid, varid, 2);
     }
   }
 
@@ -295,7 +295,7 @@ int ex_put_variable_param(int exoid, ex_entity_type obj_type, int num_vars)
   }
 
   /* leave define mode  */
-  if ((status = ex__leavedef(exoid, __func__)) != NC_NOERR) {
+  if ((status = exi_leavedef(exoid, __func__)) != NC_NOERR) {
     snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to exit define mode");
     ex_err_fn(exoid, __func__, errmsg, status);
     EX_FUNC_LEAVE(EX_FATAL);
@@ -305,6 +305,6 @@ int ex_put_variable_param(int exoid, ex_entity_type obj_type, int num_vars)
 
 /* Fatal error: exit definition mode and return */
 error_ret:
-  ex__leavedef(exoid, __func__);
+  exi_leavedef(exoid, __func__);
   EX_FUNC_LEAVE(EX_FATAL);
 }

--- a/packages/seacas/libraries/exodus/src/ex_threadsafe.c
+++ b/packages/seacas/libraries/exodus/src/ex_threadsafe.c
@@ -36,7 +36,7 @@ static void ex_key_destructor(void *key_val)
     abort();                                                                                       \
   } while (0)
 
-void ex__pthread_first_thread_init(void)
+void exi_pthread_first_thread_init(void)
 {
   int err = pthread_mutexattr_init(&EX_g.attribute);
   if (err != 0) {
@@ -60,7 +60,7 @@ void ex__pthread_first_thread_init(void)
   }
 }
 
-int ex__mutex_lock(EX_mutex_t *mutex)
+int exi_mutex_lock(EX_mutex_t *mutex)
 {
   int ret_value = pthread_mutex_lock(&mutex->atomic_lock);
   if (ret_value != 0) {
@@ -69,7 +69,7 @@ int ex__mutex_lock(EX_mutex_t *mutex)
   return ret_value;
 }
 
-int ex__mutex_unlock(EX_mutex_t *mutex, const char *func, int line)
+int exi_mutex_unlock(EX_mutex_t *mutex, const char *func, int line)
 {
   int ret_value = pthread_mutex_unlock(&mutex->atomic_lock);
   if (ret_value != 0) {

--- a/packages/seacas/libraries/exodus/src/ex_update.c
+++ b/packages/seacas/libraries/exodus/src/ex_update.c
@@ -31,7 +31,7 @@ int ex_update(int exoid)
 {
   EX_FUNC_ENTER();
 
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 

--- a/packages/seacas/libraries/exodus/src/ex_utils.c
+++ b/packages/seacas/libraries/exodus/src/ex_utils.c
@@ -20,25 +20,25 @@
 #include "exodusII.h"
 #include "exodusII_int.h"
 
-struct ex__obj_stats *exoII_eb  = NULL;
-struct ex__obj_stats *exoII_ed  = NULL;
-struct ex__obj_stats *exoII_fa  = NULL;
-struct ex__obj_stats *exoII_ns  = NULL;
-struct ex__obj_stats *exoII_es  = NULL;
-struct ex__obj_stats *exoII_fs  = NULL;
-struct ex__obj_stats *exoII_ss  = NULL;
-struct ex__obj_stats *exoII_els = NULL;
-struct ex__obj_stats *exoII_em  = NULL;
-struct ex__obj_stats *exoII_edm = NULL;
-struct ex__obj_stats *exoII_fam = NULL;
-struct ex__obj_stats *exoII_nm  = NULL;
-struct ex__obj_stats *exoII_ass = NULL;
+struct exi_obj_stats *exoII_eb  = NULL;
+struct exi_obj_stats *exoII_ed  = NULL;
+struct exi_obj_stats *exoII_fa  = NULL;
+struct exi_obj_stats *exoII_ns  = NULL;
+struct exi_obj_stats *exoII_es  = NULL;
+struct exi_obj_stats *exoII_fs  = NULL;
+struct exi_obj_stats *exoII_ss  = NULL;
+struct exi_obj_stats *exoII_els = NULL;
+struct exi_obj_stats *exoII_em  = NULL;
+struct exi_obj_stats *exoII_edm = NULL;
+struct exi_obj_stats *exoII_fam = NULL;
+struct exi_obj_stats *exoII_nm  = NULL;
+struct exi_obj_stats *exoII_ass = NULL;
 
 /*****************************************************************************
  *
  * utility routines for string conversions
- * ex__catstr  - concatenate  string/number (where number is converted to ASCII)
- * ex__catstr2 - concatenate  string1/number1/string2/number2   "
+ * exi_catstr  - concatenate  string/number (where number is converted to ASCII)
+ * exi_catstr2 - concatenate  string1/number1/string2/number2   "
  *
  * NOTE: these routines reuse the same storage over and over to build
  *        concatenated strings, because the strings are just passed to netCDF
@@ -170,7 +170,7 @@ void ex_print_config(void) { fprintf(stderr, "%s\n", ex_config()); }
   \ingroup Utilities
   \undoc
 */
-int ex__check_file_type(const char *path, int *type)
+int exi_check_file_type(const char *path, int *type)
 {
   /* Based on (stolen from?) NC_check_file_type from netcdf sources.
 
@@ -246,7 +246,7 @@ int ex_set_max_name_length(int exoid, int length)
   char errmsg[MAX_ERR_LENGTH];
 
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
   if (length <= 0) {
@@ -270,10 +270,10 @@ int ex_set_max_name_length(int exoid, int length)
   \ingroup Utilities
   \undoc
 */
-void ex__update_max_name_length(int exoid, int length)
+void exi_update_max_name_length(int exoid, int length)
 {
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_VOID();
   }
 
@@ -308,11 +308,11 @@ void ex__update_max_name_length(int exoid, int length)
   \internal
   \undoc
 */
-int ex__put_names(int exoid, int varid, size_t num_names, char *const *names,
+int exi_put_names(int exoid, int varid, size_t num_names, char *const *names,
                   ex_entity_type obj_type, const char *subtype, const char *routine)
 {
   EX_FUNC_ENTER();
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
   /* inquire previously defined dimensions  */
@@ -366,7 +366,7 @@ int ex__put_names(int exoid, int varid, size_t num_names, char *const *names,
   if (found_name) {
 
     /* Update the maximum_name_length attribute on the file. */
-    ex__update_max_name_length(exoid, max_name_len - 1);
+    exi_update_max_name_length(exoid, max_name_len - 1);
   }
   free(int_names);
 
@@ -377,10 +377,10 @@ int ex__put_names(int exoid, int varid, size_t num_names, char *const *names,
   \internal
   \undoc
 */
-int ex__put_name(int exoid, int varid, size_t index, const char *name, ex_entity_type obj_type,
+int exi_put_name(int exoid, int varid, size_t index, const char *name, ex_entity_type obj_type,
                  const char *subtype, const char *routine)
 {
-  if (ex__check_valid_file_id(exoid, __func__) == EX_FATAL) {
+  if (exi_check_valid_file_id(exoid, __func__) == EX_FATAL) {
     EX_FUNC_LEAVE(EX_FATAL);
   }
 
@@ -422,7 +422,7 @@ int ex__put_name(int exoid, int varid, size_t index, const char *name, ex_entity
     }
 
     /* Update the maximum_name_length attribute on the file. */
-    ex__update_max_name_length(exoid, count[1] - 1);
+    exi_update_max_name_length(exoid, count[1] - 1);
   }
   return (EX_NOERR);
 }
@@ -431,7 +431,7 @@ int ex__put_name(int exoid, int varid, size_t index, const char *name, ex_entity
   \internal
   \undoc
 */
-int ex__get_names(int exoid, int varid, size_t num_names, char **names, ex_entity_type obj_type,
+int exi_get_names(int exoid, int varid, size_t num_names, char **names, ex_entity_type obj_type,
                   const char *routine)
 {
   /* Query size of names on file
@@ -442,7 +442,7 @@ int ex__get_names(int exoid, int varid, size_t num_names, char **names, ex_entit
   int name_size     = db_name_size < api_name_size ? db_name_size : api_name_size;
 
   for (size_t i = 0; i < num_names; i++) {
-    int status = ex__get_name(exoid, varid, i, names[i], name_size, obj_type, routine);
+    int status = exi_get_name(exoid, varid, i, names[i], name_size, obj_type, routine);
     if (status != NC_NOERR) {
       return (status);
     }
@@ -454,7 +454,7 @@ int ex__get_names(int exoid, int varid, size_t num_names, char **names, ex_entit
   \internal
   \undoc
 */
-int ex__get_name(int exoid, int varid, size_t index, char *name, int name_size,
+int exi_get_name(int exoid, int varid, size_t index, char *name, int name_size,
                  ex_entity_type obj_type, const char *routine)
 {
 
@@ -478,7 +478,7 @@ int ex__get_name(int exoid, int varid, size_t index, char *name, int name_size,
   int api_name_size   = ex_inquire_int(exoid, EX_INQ_MAX_READ_NAME_LENGTH);
   name[api_name_size] = '\0';
 
-  ex__trim(name);
+  exi_trim(name);
   return (EX_NOERR);
 }
 
@@ -486,7 +486,7 @@ int ex__get_name(int exoid, int varid, size_t index, char *name, int name_size,
   \internal
   \undoc
 */
-void ex__trim(char *name)
+void exi_trim(char *name)
 {
   /* Thread-safe, reentrant */
   /* Trim trailing spaces... */
@@ -507,13 +507,13 @@ void ex__trim(char *name)
   *(end + 1) = '\0';
 }
 
-/** ex__catstr  - concatenate  string/number (where number is converted to ASCII)
+/** exi_catstr  - concatenate  string/number (where number is converted to ASCII)
  */
 /*!
   \internal
   \undoc
 */
-char *ex__catstr(const char *string, int num)
+char *exi_catstr(const char *string, int num)
 {
   /* Only called from an already locked function */
   char *tmp_string = cur_string;
@@ -524,12 +524,12 @@ char *ex__catstr(const char *string, int num)
   return (tmp_string);
 }
 
-/** ex__catstr2 - concatenate  string1num1string2num2   */
+/** exi_catstr2 - concatenate  string1num1string2num2   */
 /*!
   \internal
   \undoc
 */
-char *ex__catstr2(const char *string1, int num1, const char *string2, int num2)
+char *exi_catstr2(const char *string1, int num1, const char *string2, int num2)
 {
   /* Only called from an already locked function */
   char *tmp_string = cur_string;
@@ -617,7 +617,7 @@ ex_entity_type ex_var_type_to_ex_entity_type(char var_type)
   \internal
   \undoc
 */
-char *ex__dim_num_objects(ex_entity_type obj_type)
+char *exi_dim_num_objects(ex_entity_type obj_type)
 {
   switch (obj_type) {
   case EX_NODAL: return DIM_NUM_NODES;
@@ -649,7 +649,7 @@ char *ex__dim_num_objects(ex_entity_type obj_type)
   \internal
   \undoc
 */
-char *ex__dim_num_entries_in_object(ex_entity_type obj_type, int idx)
+char *exi_dim_num_entries_in_object(ex_entity_type obj_type, int idx)
 {
   switch (obj_type) {
   case EX_NODAL: return DIM_NUM_NODES;
@@ -677,7 +677,7 @@ char *ex__dim_num_entries_in_object(ex_entity_type obj_type, int idx)
   \internal
   \undoc
 */
-char *ex__name_var_of_object(ex_entity_type obj_type, int i, int j)
+char *exi_name_var_of_object(ex_entity_type obj_type, int i, int j)
 {
   switch (obj_type) {
   case EX_ASSEMBLY: return VAR_ASSEMBLY_VAR(i, j);
@@ -704,7 +704,7 @@ char *ex__name_var_of_object(ex_entity_type obj_type, int i, int j)
   \internal
   \undoc
 */
-char *ex__name_red_var_of_object(ex_entity_type obj_type, int id)
+char *exi_name_red_var_of_object(ex_entity_type obj_type, int id)
 {
   switch (obj_type) {
   case EX_ASSEMBLY: return VAR_ASSEMBLY_RED_VAR(id);
@@ -731,7 +731,7 @@ char *ex__name_red_var_of_object(ex_entity_type obj_type, int id)
   \internal
   \undoc
 */
-char *ex__name_of_map(ex_entity_type map_type, int map_index)
+char *exi_name_of_map(ex_entity_type map_type, int map_index)
 {
   switch (map_type) {
   case EX_NODE_MAP: return VAR_NODE_MAP(map_index);
@@ -744,7 +744,7 @@ char *ex__name_of_map(ex_entity_type map_type, int map_index)
 
 /*****************************************************************************
 *
-* ex__id_lkup - look up id
+* exi_id_lkup - look up id
 *
 * entry conditions -
 *   input parameters:
@@ -764,7 +764,7 @@ char *ex__name_of_map(ex_entity_type map_type, int map_index)
   \internal
   \undoc
 */
-int ex__id_lkup(int exoid, ex_entity_type id_type, ex_entity_id num)
+int exi_id_lkup(int exoid, ex_entity_type id_type, ex_entity_id num)
 {
   char    *id_table   = NULL;
   char    *id_dim     = NULL;
@@ -776,7 +776,7 @@ int ex__id_lkup(int exoid, ex_entity_type id_type, ex_entity_id num)
   int     *stat_vals = NULL;
 
   static bool           sequential = false;
-  struct ex__obj_stats *tmp_stats;
+  struct exi_obj_stats *tmp_stats;
   int                   status;
   char                  errmsg[MAX_ERR_LENGTH];
 
@@ -789,73 +789,73 @@ int ex__id_lkup(int exoid, ex_entity_type id_type, ex_entity_id num)
     id_table   = VAR_ID_EL_BLK;   /* id array name */
     id_dim     = DIM_NUM_EL_BLK;  /* id array dimension name*/
     stat_table = VAR_STAT_EL_BLK; /* id status array name */
-    tmp_stats  = ex__get_stat_ptr(exoid, &exoII_eb);
+    tmp_stats  = exi_get_stat_ptr(exoid, &exoII_eb);
     break;
   case EX_NODE_SET:
     id_table   = VAR_NS_IDS;
     id_dim     = DIM_NUM_NS;
     stat_table = VAR_NS_STAT;
-    tmp_stats  = ex__get_stat_ptr(exoid, &exoII_ns);
+    tmp_stats  = exi_get_stat_ptr(exoid, &exoII_ns);
     break;
   case EX_SIDE_SET:
     id_table   = VAR_SS_IDS;
     id_dim     = DIM_NUM_SS;
     stat_table = VAR_SS_STAT;
-    tmp_stats  = ex__get_stat_ptr(exoid, &exoII_ss);
+    tmp_stats  = exi_get_stat_ptr(exoid, &exoII_ss);
     break;
   case EX_EDGE_BLOCK:
     id_table   = VAR_ID_ED_BLK;
     id_dim     = DIM_NUM_ED_BLK;
     stat_table = VAR_STAT_ED_BLK;
-    tmp_stats  = ex__get_stat_ptr(exoid, &exoII_ed);
+    tmp_stats  = exi_get_stat_ptr(exoid, &exoII_ed);
     break;
   case EX_FACE_BLOCK:
     id_table   = VAR_ID_FA_BLK;
     id_dim     = DIM_NUM_FA_BLK;
     stat_table = VAR_STAT_FA_BLK;
-    tmp_stats  = ex__get_stat_ptr(exoid, &exoII_fa);
+    tmp_stats  = exi_get_stat_ptr(exoid, &exoII_fa);
     break;
   case EX_EDGE_SET:
     id_table   = VAR_ES_IDS;
     id_dim     = DIM_NUM_ES;
     stat_table = VAR_ES_STAT;
-    tmp_stats  = ex__get_stat_ptr(exoid, &exoII_es);
+    tmp_stats  = exi_get_stat_ptr(exoid, &exoII_es);
     break;
   case EX_FACE_SET:
     id_table   = VAR_FS_IDS;
     id_dim     = DIM_NUM_FS;
     stat_table = VAR_FS_STAT;
-    tmp_stats  = ex__get_stat_ptr(exoid, &exoII_fs);
+    tmp_stats  = exi_get_stat_ptr(exoid, &exoII_fs);
     break;
   case EX_ELEM_SET:
     id_table   = VAR_ELS_IDS;
     id_dim     = DIM_NUM_ELS;
     stat_table = VAR_ELS_STAT;
-    tmp_stats  = ex__get_stat_ptr(exoid, &exoII_els);
+    tmp_stats  = exi_get_stat_ptr(exoid, &exoII_els);
     break;
   case EX_NODE_MAP:
     id_table   = VAR_NM_PROP(1);
     id_dim     = DIM_NUM_NM;
     stat_table = "";
-    tmp_stats  = ex__get_stat_ptr(exoid, &exoII_nm);
+    tmp_stats  = exi_get_stat_ptr(exoid, &exoII_nm);
     break;
   case EX_EDGE_MAP:
     id_table   = VAR_EDM_PROP(1);
     id_dim     = DIM_NUM_EDM;
     stat_table = "";
-    tmp_stats  = ex__get_stat_ptr(exoid, &exoII_edm);
+    tmp_stats  = exi_get_stat_ptr(exoid, &exoII_edm);
     break;
   case EX_FACE_MAP:
     id_table   = VAR_FAM_PROP(1);
     id_dim     = DIM_NUM_FAM;
     stat_table = "";
-    tmp_stats  = ex__get_stat_ptr(exoid, &exoII_fam);
+    tmp_stats  = exi_get_stat_ptr(exoid, &exoII_fam);
     break;
   case EX_ELEM_MAP:
     id_table   = VAR_EM_PROP(1);
     id_dim     = DIM_NUM_EM;
     stat_table = "";
-    tmp_stats  = ex__get_stat_ptr(exoid, &exoII_em);
+    tmp_stats  = exi_get_stat_ptr(exoid, &exoII_em);
     break;
   default:
     snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: unsupported id array type %d for file id %d", id_type,
@@ -1046,7 +1046,7 @@ int ex__id_lkup(int exoid, ex_entity_type id_type, ex_entity_id num)
 
 /******************************************************************************
  *
- * ex__get_stat_ptr - returns a pointer to a structure of object ids
+ * exi_get_stat_ptr - returns a pointer to a structure of object ids
  *
  *****************************************************************************/
 
@@ -1056,9 +1056,9 @@ int ex__id_lkup(int exoid, ex_entity_type id_type, ex_entity_id num)
  * \internal
  */
 
-struct ex__obj_stats *ex__get_stat_ptr(int exoid, struct ex__obj_stats **obj_ptr)
+struct exi_obj_stats *exi_get_stat_ptr(int exoid, struct exi_obj_stats **obj_ptr)
 {
-  struct ex__obj_stats *tmp_ptr = *obj_ptr;
+  struct exi_obj_stats *tmp_ptr = *obj_ptr;
 
   while (tmp_ptr) {
     if ((tmp_ptr)->exoid == exoid) {
@@ -1068,7 +1068,7 @@ struct ex__obj_stats *ex__get_stat_ptr(int exoid, struct ex__obj_stats **obj_ptr
   }
 
   if (!tmp_ptr) { /* exoid not found */
-    tmp_ptr             = (struct ex__obj_stats *)calloc(1, sizeof(struct ex__obj_stats));
+    tmp_ptr             = (struct exi_obj_stats *)calloc(1, sizeof(struct exi_obj_stats));
     tmp_ptr->exoid      = exoid;
     tmp_ptr->next       = *obj_ptr;
     tmp_ptr->id_vals    = 0;
@@ -1083,7 +1083,7 @@ struct ex__obj_stats *ex__get_stat_ptr(int exoid, struct ex__obj_stats **obj_ptr
 
 /******************************************************************************
  *
- * ex__rm_stat_ptr - removes a pointer to a structure of object ids
+ * exi_rm_stat_ptr - removes a pointer to a structure of object ids
  *
  *****************************************************************************/
 
@@ -1094,10 +1094,10 @@ struct ex__obj_stats *ex__get_stat_ptr(int exoid, struct ex__obj_stats **obj_ptr
  * \internal
  */
 
-void ex__rm_stat_ptr(int exoid, struct ex__obj_stats **obj_ptr)
+void exi_rm_stat_ptr(int exoid, struct exi_obj_stats **obj_ptr)
 {
-  struct ex__obj_stats *tmp_ptr            = *obj_ptr;
-  struct ex__obj_stats *last_head_list_ptr = *obj_ptr; /* save last head pointer */
+  struct exi_obj_stats *tmp_ptr            = *obj_ptr;
+  struct exi_obj_stats *last_head_list_ptr = *obj_ptr; /* save last head pointer */
 
   while (tmp_ptr) /* Walk linked list of file ids/vals */
   {
@@ -1120,32 +1120,32 @@ void ex__rm_stat_ptr(int exoid, struct ex__obj_stats **obj_ptr)
 }
 
 /* structures to hold number of blocks of that type for each file id */
-static struct ex__list_item *ed_ctr_list = NULL; /* edge blocks */
-static struct ex__list_item *fa_ctr_list = NULL; /* face blocks */
-static struct ex__list_item *eb_ctr_list = NULL; /* element blocks */
+static struct exi_list_item *ed_ctr_list = NULL; /* edge blocks */
+static struct exi_list_item *fa_ctr_list = NULL; /* face blocks */
+static struct exi_list_item *eb_ctr_list = NULL; /* element blocks */
 
 /* structures to hold number of sets of that type for each file id */
-static struct ex__list_item *ns_ctr_list  = NULL; /* node sets */
-static struct ex__list_item *es_ctr_list  = NULL; /* edge sets */
-static struct ex__list_item *fs_ctr_list  = NULL; /* face sets */
-static struct ex__list_item *ss_ctr_list  = NULL; /* side sets */
-static struct ex__list_item *els_ctr_list = NULL; /* element sets */
+static struct exi_list_item *ns_ctr_list  = NULL; /* node sets */
+static struct exi_list_item *es_ctr_list  = NULL; /* edge sets */
+static struct exi_list_item *fs_ctr_list  = NULL; /* face sets */
+static struct exi_list_item *ss_ctr_list  = NULL; /* side sets */
+static struct exi_list_item *els_ctr_list = NULL; /* element sets */
 
 /* structures to hold number of blobs/assemblies for each file id */
-static struct ex__list_item *assm_ctr_list = NULL; /* assemblies */
-static struct ex__list_item *blob_ctr_list = NULL; /* blobs */
+static struct exi_list_item *assm_ctr_list = NULL; /* assemblies */
+static struct exi_list_item *blob_ctr_list = NULL; /* blobs */
 
 /* structures to hold number of maps of that type for each file id */
-static struct ex__list_item *nm_ctr_list  = NULL; /* node maps */
-static struct ex__list_item *edm_ctr_list = NULL; /* edge maps */
-static struct ex__list_item *fam_ctr_list = NULL; /* face maps */
-static struct ex__list_item *em_ctr_list  = NULL; /* element maps */
+static struct exi_list_item *nm_ctr_list  = NULL; /* node maps */
+static struct exi_list_item *edm_ctr_list = NULL; /* edge maps */
+static struct exi_list_item *fam_ctr_list = NULL; /* face maps */
+static struct exi_list_item *em_ctr_list  = NULL; /* element maps */
 
 /*!
   \internal
   \undoc
 */
-struct ex__list_item **ex__get_counter_list(ex_entity_type obj_type)
+struct exi_list_item **exi_get_counter_list(ex_entity_type obj_type)
 {
   /* Thread-safe, but is dealing with globals */
   /* Only called from a routine which will be using locks */
@@ -1170,7 +1170,7 @@ struct ex__list_item **ex__get_counter_list(ex_entity_type obj_type)
 
 /******************************************************************************
  *
- * ex__inc_file_item - increment file item
+ * exi_inc_file_item - increment file item
  *
  *****************************************************************************/
 
@@ -1196,10 +1196,10 @@ struct ex__list_item **ex__get_counter_list(ex_entity_type obj_type)
  * \internal
  */
 
-int ex__inc_file_item(int                    exoid,    /* file id */
-                      struct ex__list_item **list_ptr) /* ptr to ptr to list_item */
+int exi_inc_file_item(int                    exoid,    /* file id */
+                      struct exi_list_item **list_ptr) /* ptr to ptr to list_item */
 {
-  struct ex__list_item *tlist_ptr = *list_ptr; /* use temp list ptr to walk linked list */
+  struct exi_list_item *tlist_ptr = *list_ptr; /* use temp list ptr to walk linked list */
   while (tlist_ptr) {                          /* Walk linked list of file ids/vals */
     if (exoid == tlist_ptr->exo_id) {          /* linear search for exodus file id */
       break;                                   /* Quit if found */
@@ -1209,7 +1209,7 @@ int ex__inc_file_item(int                    exoid,    /* file id */
 
   if (!tlist_ptr) { /* ptr NULL? */
     /* allocate space for new structure record */
-    tlist_ptr         = (struct ex__list_item *)calloc(1, sizeof(struct ex__list_item));
+    tlist_ptr         = (struct exi_list_item *)calloc(1, sizeof(struct exi_list_item));
     tlist_ptr->exo_id = exoid;     /* insert file id */
     tlist_ptr->next   = *list_ptr; /* insert into head of list */
     *list_ptr         = tlist_ptr; /* fix up new head of list  */
@@ -1219,7 +1219,7 @@ int ex__inc_file_item(int                    exoid,    /* file id */
 
 /*****************************************************************************
  *
- * ex__get_file_item - return count
+ * exi_get_file_item - return count
  *
  *****************************************************************************/
 
@@ -1245,14 +1245,14 @@ int ex__inc_file_item(int                    exoid,    /* file id */
  * \internal
  */
 
-int ex__get_file_item(int                    exoid,    /* file id */
-                      struct ex__list_item **list_ptr) /* ptr to ptr to list_item */
+int exi_get_file_item(int                    exoid,    /* file id */
+                      struct exi_list_item **list_ptr) /* ptr to ptr to list_item */
 {
   /* Not thread-safe: list_ptr passed in is a global
    * Would probably work ok with multiple threads since read-only,
    * but possible that list_ptr will be modified while being used
    */
-  struct ex__list_item *tlist_ptr = *list_ptr; /* use temp list ptr to walk linked list */
+  struct exi_list_item *tlist_ptr = *list_ptr; /* use temp list ptr to walk linked list */
   while (tlist_ptr) {                          /* Walk linked list of file ids/vals */
     if (exoid == tlist_ptr->exo_id) {          /* linear search for exodus file id */
       break;                                   /* Quit if found */
@@ -1269,7 +1269,7 @@ int ex__get_file_item(int                    exoid,    /* file id */
 
 /*****************************************************************************
  *
- * ex__rm_file_item - remove file item
+ * exi_rm_file_item - remove file item
  *
  *****************************************************************************/
 
@@ -1292,13 +1292,13 @@ int ex__get_file_item(int                    exoid,    /* file id */
  * \internal
  */
 
-void ex__rm_file_item(int                    exoid,    /* file id */
-                      struct ex__list_item **list_ptr) /* ptr to ptr to list_item */
+void exi_rm_file_item(int                    exoid,    /* file id */
+                      struct exi_list_item **list_ptr) /* ptr to ptr to list_item */
 
 {
-  struct ex__list_item *last_head_list_ptr = *list_ptr; /* save last head pointer */
+  struct exi_list_item *last_head_list_ptr = *list_ptr; /* save last head pointer */
 
-  struct ex__list_item *tlist_ptr = *list_ptr;
+  struct exi_list_item *tlist_ptr = *list_ptr;
   while (tlist_ptr) {                  /* Walk linked list of file ids/vals */
     if (exoid == tlist_ptr->exo_id) {  /* linear search for exodus file id */
       if (tlist_ptr == *list_ptr) {    /* Are we at the head of the list? */
@@ -1367,7 +1367,7 @@ int ex_get_num_props(int exoid, ex_entity_type obj_type)
   \ingroup Utilities
   \undoc
 */
-int ex__get_cpu_ws(void) { return (sizeof(float)); }
+int exi_get_cpu_ws(void) { return (sizeof(float)); }
 
 /* swap - interchange v[i] and v[j] */
 /*!
@@ -1584,7 +1584,7 @@ static void ex_int_iisort64(int64_t v[], int64_t iv[], int64_t N)
  *       representable as 'int'.
  * \internal
  */
-void ex__iqsort(int v[], int iv[], size_t N)
+void exi_iqsort(int v[], int iv[], size_t N)
 {
   /* Thread-safe, reentrant */
   ex_int_iqsort(v, iv, 0, N - 1);
@@ -1599,8 +1599,8 @@ void ex__iqsort(int v[], int iv[], size_t N)
 #endif
 }
 
-/*! \sa ex__iqsort() */
-void ex__iqsort64(int64_t v[], int64_t iv[], int64_t N)
+/*! \sa exi_iqsort() */
+void exi_iqsort64(int64_t v[], int64_t iv[], int64_t N)
 {
   /* Thread-safe, reentrant */
   ex_int_iqsort64(v, iv, 0, N - 1);
@@ -1645,7 +1645,7 @@ int ex_large_model(int exoid)
   \internal
   \undoc
 */
-int ex__get_dimension(int exoid, const char *DIMENSION, const char *label, size_t *count,
+int exi_get_dimension(int exoid, const char *DIMENSION, const char *label, size_t *count,
                       int *dimid, const char *routine)
 {
   int status;
@@ -1694,7 +1694,7 @@ size_t ex_header_size(int exoid)
   return 0;
 }
 
-void ex__set_compact_storage(int exoid, int varid)
+void exi_set_compact_storage(int exoid, int varid)
 {
   /* Capability was released in version 4.7.4
      Only applicable to netcdf-4 files, but will
@@ -1717,14 +1717,14 @@ void ex__set_compact_storage(int exoid, int varid)
   \internal
   \undoc
 */
-void ex__compress_variable(int exoid, int varid, int type)
+void exi_compress_variable(int exoid, int varid, int type)
 {
 #if NC_HAS_HDF5
-  struct ex__file_item *file = ex__find_file_item(exoid);
+  struct exi_file_item *file = exi_find_file_item(exoid);
 
   if (!file) {
     char errmsg[MAX_ERR_LENGTH];
-    snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: unknown file id %d for ex__compress_variable().",
+    snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: unknown file id %d for exi_compress_variable().",
              exoid);
     ex_err_fn(exoid, __func__, errmsg, EX_BADFILEID);
   }
@@ -1777,7 +1777,7 @@ void ex__compress_variable(int exoid, int varid, int type)
   \internal
   \undoc
 */
-int ex__leavedef(int exoid, const char *call_rout)
+int exi_leavedef(int exoid, const char *call_rout)
 {
   int status;
 
@@ -1793,7 +1793,7 @@ int ex__leavedef(int exoid, const char *call_rout)
 
 static int warning_output = 0;
 
-int ex__check_version(int run_version)
+int exi_check_version(int run_version)
 {
   if (run_version != EX_API_VERS_NODOT && warning_output == 0) {
     int run_version_major = run_version / 100;
@@ -1815,7 +1815,7 @@ int ex__check_version(int run_version)
   \internal
   \undoc
 */
-int ex__handle_mode(unsigned int my_mode, int is_parallel, int run_version)
+int exi_handle_mode(unsigned int my_mode, int is_parallel, int run_version)
 {
   char       errmsg[MAX_ERR_LENGTH];
   int        nc_mode      = 0;
@@ -1832,7 +1832,7 @@ int ex__handle_mode(unsigned int my_mode, int is_parallel, int run_version)
   /* Do not include EX_64BIT_DATA in this list */
   static unsigned int all_modes = EX_NORMAL_MODEL | EX_64BIT_OFFSET | EX_NETCDF4 | EX_PNETCDF;
 
-  ex__check_version(run_version);
+  exi_check_version(run_version);
 
 /*
  * See if specified mode is supported in the version of netcdf we
@@ -2121,7 +2121,7 @@ int ex__handle_mode(unsigned int my_mode, int is_parallel, int run_version)
   \internal
   \undoc
 */
-int ex__populate_header(int exoid, const char *path, int my_mode, int is_parallel, int *comp_ws,
+int exi_populate_header(int exoid, const char *path, int my_mode, int is_parallel, int *comp_ws,
                         int *io_ws)
 {
   int  status;
@@ -2153,7 +2153,7 @@ int ex__populate_header(int exoid, const char *path, int my_mode, int is_paralle
      not know that file was closed and possibly new file opened for
      this exoid
   */
-  if (ex__find_file_item(exoid) != NULL) {
+  if (exi_find_file_item(exoid) != NULL) {
     snprintf(errmsg, MAX_ERR_LENGTH,
              "ERROR: There is an existing file already using the file "
              "id %d which was also assigned to file %s.\n\tWas "
@@ -2180,7 +2180,7 @@ int ex__populate_header(int exoid, const char *path, int my_mode, int is_paralle
     is_hdf5 = true;
   }
 
-  if (ex__conv_init(exoid, comp_ws, io_ws, 0, int64_status, is_parallel, is_hdf5, is_pnetcdf,
+  if (exi_conv_init(exoid, comp_ws, io_ws, 0, int64_status, is_parallel, is_hdf5, is_pnetcdf,
                     my_mode & EX_WRITE) != EX_NOERR) {
     snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to init conversion routines in file id %d",
              exoid);
@@ -2318,7 +2318,7 @@ char *ex_copy_string(char *dest, char const *source, size_t elements)
  *
  *   On failure, returns NULL.
  */
-char *ex__canonicalize_filename(char const *file_path)
+char *exi_canonicalize_filename(char const *file_path)
 {
 #if defined(WIN32) || defined(__WIN32__) || defined(_WIN32) || defined(_MSC_VER) ||                \
     defined(__MINGW32__) || defined(_WIN64) || defined(__MINGW64__)

--- a/packages/seacas/libraries/exodus_for/src/exo_jack-windows.c
+++ b/packages/seacas/libraries/exodus_for/src/exo_jack-windows.c
@@ -2036,7 +2036,7 @@ void F2C(EXPFRM)(int *idexo, int *nframe, void_int *cfids, real *coord, int *tag
 }
 
 /* Routine to return floating point word size */
-int F2C(EXCPWS)() { return (ex__get_cpu_ws()); }
+int F2C(EXCPWS)() { return (exi_get_cpu_ws()); }
 
 /* Routine to return large model setting */
 int F2C(EXLGMD)(int *idexo) { return (ex_large_model(*idexo)); }

--- a/packages/seacas/libraries/exodus_for/src/exo_jack.c
+++ b/packages/seacas/libraries/exodus_for/src/exo_jack.c
@@ -2424,9 +2424,9 @@ void F2C(expfrm, EXPFRM)(int *idexo, int *nframe, void_int *cfids, real *coord, 
 
 /*!
  *  Routine to return floating point word size
- * \sa ex__get_cpu_ws()
+ * \sa exi_get_cpu_ws()
  */
-int F2C(excpws, EXCPWS)(void) { return (ex__get_cpu_ws()); }
+int F2C(excpws, EXCPWS)(void) { return (exi_get_cpu_ws()); }
 
 /*!
  *  Routine to return large model setting

--- a/packages/seacas/libraries/ioss/src/Ioss_DatabaseIO.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_DatabaseIO.C
@@ -509,7 +509,7 @@ namespace Ioss {
     }
   }
 
-  /** \brief This function gets called inside closeDatabase__(), which checks if Cray Datawarp (DW)
+  /** \brief This function gets called inside closeDatabase_nl(), which checks if Cray Datawarp (DW)
    * is in use, if so, we want to call a stageout before actual close of this file.
    */
   void DatabaseIO::close_dw() const
@@ -569,9 +569,9 @@ namespace Ioss {
     }
   }
 
-  void DatabaseIO::openDatabase__() const { open_dw(get_filename()); }
+  void DatabaseIO::openDatabase_nl() const { open_dw(get_filename()); }
 
-  void DatabaseIO::closeDatabase__() const { close_dw(); }
+  void DatabaseIO::closeDatabase_nl() const { close_dw(); }
 
   IfDatabaseExistsBehavior DatabaseIO::open_create_behavior() const
   {
@@ -666,12 +666,12 @@ namespace Ioss {
     if (m_timeStateInOut) {
       m_stateStart = std::chrono::steady_clock::now();
     }
-    return begin_state__(state, time);
+    return begin_state_nl(state, time);
   }
   bool DatabaseIO::end_state(int state, double time)
   {
     IOSS_FUNC_ENTER(m_);
-    bool res = end_state__(state, time);
+    bool res = end_state_nl(state, time);
     if (m_timeStateInOut) {
       auto finish = std::chrono::steady_clock::now();
       log_time(m_stateStart, finish, state, time, is_input(), singleProcOnly, util_);
@@ -681,9 +681,9 @@ namespace Ioss {
   }
 
   // Default versions do nothing...
-  bool DatabaseIO::begin_state__(int /* state */, double /* time */) { return true; }
+  bool DatabaseIO::begin_state_nl(int /* state */, double /* time */) { return true; }
 
-  bool DatabaseIO::end_state__(int /* state */, double /* time */) { return true; }
+  bool DatabaseIO::end_state_nl(int /* state */, double /* time */) { return true; }
 
   void DatabaseIO::handle_groups()
   {
@@ -973,8 +973,8 @@ namespace Ioss {
     assert(!sideTopology.empty());
   }
 
-  void DatabaseIO::get_block_adjacencies__(const Ioss::ElementBlock *eb,
-                                           std::vector<std::string> &block_adjacency) const
+  void DatabaseIO::get_block_adjacencies_nl(const Ioss::ElementBlock *eb,
+                                            std::vector<std::string> &block_adjacency) const
   {
     if (!blockAdjacenciesCalculated) {
       compute_block_adjacencies();
@@ -1040,7 +1040,7 @@ namespace Ioss {
     std::vector<std::vector<int>> inv_con(nodeCount);
 
     {
-      Ioss::SerializeIO serializeIO__(this);
+      Ioss::SerializeIO serializeIO_(this);
       int               blk_position = -1;
       for (Ioss::ElementBlock *eb : element_blocks) {
         if (eb->property_exists("original_block_order")) {

--- a/packages/seacas/libraries/ioss/src/Ioss_DatabaseIO.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_DatabaseIO.h
@@ -82,7 +82,7 @@ namespace Ioss {
             int *bad_count = nullptr) const
     {
       IOSS_FUNC_ENTER(m_);
-      return ok__(write_message, error_message, bad_count);
+      return ok_nl(write_message, error_message, bad_count);
     }
 
     // Check capabilities of input/output database...  Returns an
@@ -103,13 +103,13 @@ namespace Ioss {
     int64_t node_global_to_local(int64_t global, bool must_exist) const
     {
       IOSS_FUNC_ENTER(m_);
-      return node_global_to_local__(global, must_exist);
+      return node_global_to_local_nl(global, must_exist);
     }
 
     int64_t element_global_to_local(int64_t global) const
     {
       IOSS_FUNC_ENTER(m_);
-      return element_global_to_local__(global);
+      return element_global_to_local_nl(global);
     }
 
     /** If there is a single block of nodes in the model, then it is
@@ -126,7 +126,7 @@ namespace Ioss {
     void release_memory()
     {
       IOSS_FUNC_ENTER(m_);
-      release_memory__();
+      release_memory_nl();
     }
 
     // Do anything that might be needed to the database prior to it
@@ -228,21 +228,21 @@ namespace Ioss {
     {
       IOSS_FUNC_ENTER(m_);
       progress(__func__);
-      openDatabase__();
+      openDatabase_nl();
     }
 
     void closeDatabase() const
     {
       IOSS_FUNC_ENTER(m_);
       progress(__func__);
-      closeDatabase__();
+      closeDatabase_nl();
     }
 
     void flush_database() const
     {
       IOSS_FUNC_ENTER(m_);
       progress(__func__);
-      flush_database__();
+      flush_database_nl();
     }
 
     /** \brief If a database type supports groups and if the database
@@ -259,7 +259,7 @@ namespace Ioss {
     bool open_group(const std::string &group_name)
     {
       IOSS_FUNC_ENTER(m_);
-      return open_group__(group_name);
+      return open_group_nl(group_name);
     }
 
     /** \brief If a database type supports groups, create the specified
@@ -275,7 +275,7 @@ namespace Ioss {
     bool create_subgroup(const std::string &group_name)
     {
       IOSS_FUNC_ENTER(m_);
-      return create_subgroup__(group_name);
+      return create_subgroup_nl(group_name);
     }
 
     /** \brief Set the database to the given State.
@@ -296,7 +296,7 @@ namespace Ioss {
     {
       IOSS_FUNC_ENTER(m_);
       progress(__func__);
-      return begin__(state);
+      return begin_nl(state);
     }
 
     /** \brief Return the database to STATE_CLOSED.
@@ -313,7 +313,7 @@ namespace Ioss {
     {
       IOSS_FUNC_ENTER(m_);
       progress(__func__);
-      return end__(state);
+      return end_nl(state);
     }
 
     bool begin_state(int state, double time);
@@ -324,14 +324,14 @@ namespace Ioss {
     {
       IOSS_FUNC_ENTER(m_);
       progress("Begin read_meta_data()");
-      read_meta_data__();
+      read_meta_data_nl();
       progress("End read_meta_data()");
     }
 
     void get_step_times()
     {
       IOSS_FUNC_ENTER(m_);
-      return get_step_times__();
+      return get_step_times_nl();
     }
 
     virtual bool internal_edges_available() const { return false; }
@@ -479,12 +479,12 @@ namespace Ioss {
     void get_block_adjacencies(const Ioss::ElementBlock *eb,
                                std::vector<std::string> &block_adjacency) const
     {
-      return get_block_adjacencies__(eb, block_adjacency);
+      return get_block_adjacencies_nl(eb, block_adjacency);
     }
     void compute_block_membership(Ioss::SideBlock          *efblock,
                                   std::vector<std::string> &block_membership) const
     {
-      return compute_block_membership__(efblock, block_membership);
+      return compute_block_membership_nl(efblock, block_membership);
     }
 
     AxisAlignedBoundingBox get_bounding_box(const Ioss::NodeBlock *nb) const;
@@ -725,13 +725,13 @@ namespace Ioss {
 
     mutable std::vector<std::vector<bool>> blockAdjacency;
 
-    virtual void openDatabase__() const;
-    virtual void closeDatabase__() const;
-    virtual void flush_database__() const {}
+    virtual void openDatabase_nl() const;
+    virtual void closeDatabase_nl() const;
+    virtual void flush_database_nl() const {}
 
   private:
-    virtual bool ok__(bool /* write_message */, std::string * /* error_message */,
-                      int *bad_count) const
+    virtual bool ok_nl(bool /* write_message */, std::string * /* error_message */,
+                       int *bad_count) const
     {
       if (bad_count != nullptr) {
         *bad_count = 0;
@@ -739,17 +739,17 @@ namespace Ioss {
       return dbState != Ioss::STATE_INVALID;
     }
 
-    virtual int64_t node_global_to_local__(int64_t global, bool must_exist) const
+    virtual int64_t node_global_to_local_nl(int64_t global, bool must_exist) const
     {
       return nodeMap.global_to_local(global, must_exist);
     }
 
-    virtual int64_t element_global_to_local__(int64_t global) const
+    virtual int64_t element_global_to_local_nl(int64_t global) const
     {
       return elemMap.global_to_local(global);
     }
 
-    virtual void release_memory__()
+    virtual void release_memory_nl()
     {
       nodeMap.release_memory();
       edgeMap.release_memory();
@@ -757,23 +757,24 @@ namespace Ioss {
       elemMap.release_memory();
     }
 
-    virtual bool open_group__(const std::string & /* group_name */) { return false; }
-    virtual bool create_subgroup__(const std::string & /* group_name */) { return false; }
+    virtual bool open_group_nl(const std::string & /* group_name */) { return false; }
+    virtual bool create_subgroup_nl(const std::string & /* group_name */) { return false; }
 
-    virtual bool begin__(Ioss::State state) = 0;
-    virtual bool end__(Ioss::State state)   = 0;
+    virtual bool begin_nl(Ioss::State state) = 0;
+    virtual bool end_nl(Ioss::State state)   = 0;
 
-    virtual void read_meta_data__() = 0;
-    virtual void get_step_times__() {}
+    virtual void read_meta_data_nl() = 0;
+    virtual void get_step_times_nl() {}
 
-    virtual bool begin_state__(int state, double time);
-    virtual bool end_state__(int state, double time);
+    virtual bool begin_state_nl(int state, double time);
+    virtual bool end_state_nl(int state, double time);
 
-    void get_block_adjacencies__(const Ioss::ElementBlock *eb,
-                                 std::vector<std::string> &block_adjacency) const;
+    void get_block_adjacencies_nl(const Ioss::ElementBlock *eb,
+                                  std::vector<std::string> &block_adjacency) const;
 
-    virtual void compute_block_membership__(Ioss::SideBlock * /* efblock */,
-                                            std::vector<std::string> & /* block_membership */) const
+    virtual void
+    compute_block_membership_nl(Ioss::SideBlock * /* efblock */,
+                                std::vector<std::string> & /* block_membership */) const
     {
     }
 

--- a/packages/seacas/libraries/ioss/src/Ioss_IOFactory.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_IOFactory.C
@@ -1,4 +1,4 @@
-// Copyright(C) 1999-2021 National Technology & Engineering Solutions
+// Copyright(C) 1999-2021, 2023 National Technology & Engineering Solutions
 // of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
 // NTESS, the U.S. Government retains certain rights in this software.
 //
@@ -27,7 +27,7 @@ namespace {
   std::mutex m_;
 #endif
 
-  int describe__(Ioss::IOFactoryMap *registry, Ioss::NameList *names)
+  int describe_nl(Ioss::IOFactoryMap *registry, Ioss::NameList *names)
   {
     int                                count = 0;
     Ioss::IOFactoryMap::const_iterator I;
@@ -85,7 +85,7 @@ Ioss::DatabaseIO *Ioss::IOFactory::create(const std::string &type, const std::st
       std::ostringstream errmsg;
       fmt::print(errmsg, "ERROR: The database type '{}' is not supported.\n", type);
       Ioss::NameList db_types;
-      describe__(registry(), &db_types);
+      describe_nl(registry(), &db_types);
       fmt::print(errmsg, "\nSupported database types:\n\t{}\n\n",
                  fmt::join(db_types.begin(), db_types.end(), " "));
       IOSS_ERROR(errmsg);
@@ -117,7 +117,7 @@ Ioss::DatabaseIO *Ioss::IOFactory::create(const std::string &type, const std::st
 int Ioss::IOFactory::describe(NameList *names)
 {
   IOSS_FUNC_ENTER(m_);
-  return describe__(registry(), names);
+  return describe_nl(registry(), names);
 }
 
 /** \brief Get the names of database formats known to IOSS.

--- a/packages/seacas/libraries/ioss/src/Ioss_Map.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Map.h
@@ -1,4 +1,4 @@
-// Copyright(C) 1999-2020, 2022 National Technology & Engineering Solutions
+// Copyright(C) 1999-2020, 2022, 2023 National Technology & Engineering Solutions
 // of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
 // NTESS, the U.S. Government retains certain rights in this software.
 //
@@ -101,9 +101,9 @@ namespace Ioss {
     template <typename INT> void map_data(INT *data, size_t count) const;
     template <typename INT> void map_implicit_data(INT *data, size_t count, size_t offset) const;
 
-    int64_t global_to_local__(int64_t global, bool must_exist = true) const;
-    void    build_reorder_map__(int64_t start, int64_t count);
-    void    build_reverse_map__(int64_t num_to_get, int64_t offset);
+    int64_t global_to_local_nl(int64_t global, bool must_exist = true) const;
+    void    build_reorder_map_nl(int64_t start, int64_t count);
+    void    build_reverse_map_nl(int64_t num_to_get, int64_t offset);
 #if defined MAP_USE_SORTED_VECTOR
     void verify_no_duplicate_ids(std::vector<Ioss::IdPair> &reverse_map);
 #endif

--- a/packages/seacas/libraries/ioss/src/Ioss_Region.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Region.C
@@ -627,7 +627,7 @@ namespace Ioss {
     bool success = false;
     {
       IOSS_FUNC_ENTER(m_);
-      success = begin_mode__(new_state);
+      success = begin_mode_nl(new_state);
     }
     // Pass the 'begin state' message on to the database so it can do any
     // cleanup/data checking/manipulations it needs to do.
@@ -645,7 +645,7 @@ namespace Ioss {
     return success;
   }
 
-  bool Region::begin_mode__(State new_state)
+  bool Region::begin_mode_nl(State new_state)
   {
     bool success = false;
     if (new_state == STATE_CLOSED) {
@@ -688,7 +688,7 @@ namespace Ioss {
   {
     {
       IOSS_FUNC_ENTER(m_);
-      end_mode__(current_state);
+      end_mode_nl(current_state);
     }
 
     // Pass the 'end state' message on to the database so it can do any
@@ -698,7 +698,7 @@ namespace Ioss {
     return success;
   }
 
-  bool Region::end_mode__(State current_state)
+  bool Region::end_mode_nl(State current_state)
   {
     bool success = true;
     // Check that 'current_state' matches the current state of the
@@ -796,7 +796,7 @@ namespace Ioss {
    *  \param[in] time The time at the new state.
    *  \returns The state index (1-based).
    */
-  int Region::add_state__(double time)
+  int Region::add_state_nl(double time)
   {
 
     // NOTE:  For restart input databases, it is possible that the time
@@ -1103,7 +1103,7 @@ namespace Ioss {
       structured_block->property_add(Ioss::Property("zone", (int)structuredBlocks.size()));
       structured_block->property_add(Ioss::Property("base", 1));
       // Add name as alias to itself to simplify later uses...
-      add_alias__(structured_block);
+      add_alias_nl(structured_block);
       return true;
     }
     return false;
@@ -1124,7 +1124,7 @@ namespace Ioss {
     if (get_state() == STATE_DEFINE_MODEL) {
       nodeBlocks.push_back(node_block);
       // Add name as alias to itself to simplify later uses...
-      add_alias__(node_block);
+      add_alias_nl(node_block);
 
       return true;
     }
@@ -1180,7 +1180,7 @@ namespace Ioss {
     if (get_state() == STATE_DEFINE_MODEL) {
       assemblies.push_back(assembly);
       // Add name as alias to itself to simplify later uses...
-      add_alias__(assembly);
+      add_alias_nl(assembly);
 
       return true;
     }
@@ -1202,7 +1202,7 @@ namespace Ioss {
     if (get_state() == STATE_DEFINE_MODEL) {
       blobs.push_back(blob);
       // Add name as alias to itself to simplify later uses...
-      add_alias__(blob);
+      add_alias_nl(blob);
 
       return true;
     }
@@ -1239,7 +1239,7 @@ namespace Ioss {
     // Check that region is in correct state for adding entities
     if (get_state() == STATE_DEFINE_MODEL) {
       // Add name as alias to itself to simplify later uses...
-      add_alias__(element_block);
+      add_alias_nl(element_block);
 
       // An input database defines these in the order matching the order
       // on the "file".  For output, we need to order based on the
@@ -1301,7 +1301,7 @@ namespace Ioss {
     // Check that region is in correct state for adding entities
     if (get_state() == STATE_DEFINE_MODEL) {
       // Add name as alias to itself to simplify later uses...
-      add_alias__(face_block);
+      add_alias_nl(face_block);
 
       // An input database defines these in the order matching the order
       // on the "file".  For output, we need to order based on the
@@ -1337,7 +1337,7 @@ namespace Ioss {
     // Check that region is in correct state for adding entities
     if (get_state() == STATE_DEFINE_MODEL) {
       // Add name as alias to itself to simplify later uses...
-      add_alias__(edge_block);
+      add_alias_nl(edge_block);
 
       // An input database defines these in the order matching the order
       // on the "file".  For output, we need to order based on the
@@ -1372,13 +1372,13 @@ namespace Ioss {
     // Check that region is in correct state for adding entities
     if (get_state() == STATE_DEFINE_MODEL) {
       // Add name as alias to itself to simplify later uses...
-      add_alias__(sideset);
+      add_alias_nl(sideset);
 
       // Also add "sideset_{id}" as an alias.
       auto id = sideset->get_optional_property(id_str(), -1);
       if (id != -1) {
         std::string ss_alias = fmt::format("sideset_{}", id);
-        add_alias__(sideset->name(), ss_alias, sideset->type());
+        add_alias_nl(sideset->name(), ss_alias, sideset->type());
       }
       sideSets.push_back(sideset);
       return true;
@@ -1399,13 +1399,13 @@ namespace Ioss {
     // Check that region is in correct state for adding entities
     if (get_state() == STATE_DEFINE_MODEL) {
       // Add name as alias to itself to simplify later uses...
-      add_alias__(nodeset);
+      add_alias_nl(nodeset);
 
       // Also add "nodeset_{id}" as an alias.
       auto id = nodeset->get_optional_property(id_str(), -1);
       if (id != -1) {
         std::string ns_alias = fmt::format("nodeset_{}", id);
-        add_alias__(nodeset->name(), ns_alias, nodeset->type());
+        add_alias_nl(nodeset->name(), ns_alias, nodeset->type());
       }
       nodeSets.push_back(nodeset);
       return true;
@@ -1426,7 +1426,7 @@ namespace Ioss {
     // Check that region is in correct state for adding entities
     if (get_state() == STATE_DEFINE_MODEL) {
       // Add name as alias to itself to simplify later uses...
-      add_alias__(edgeset);
+      add_alias_nl(edgeset);
       edgeSets.push_back(edgeset);
       return true;
     }
@@ -1446,7 +1446,7 @@ namespace Ioss {
     // Check that region is in correct state for adding entities
     if (get_state() == STATE_DEFINE_MODEL) {
       // Add name as alias to itself to simplify later uses...
-      add_alias__(faceset);
+      add_alias_nl(faceset);
       faceSets.push_back(faceset);
       return true;
     }
@@ -1466,7 +1466,7 @@ namespace Ioss {
     // Check that region is in correct state for adding entities
     if (get_state() == STATE_DEFINE_MODEL) {
       // Add name as alias to itself to simplify later uses...
-      add_alias__(elementset);
+      add_alias_nl(elementset);
       elementSets.push_back(elementset);
       return true;
     }
@@ -1486,7 +1486,7 @@ namespace Ioss {
     // Check that region is in correct state for adding entities
     if (get_state() == STATE_DEFINE_MODEL) {
       // Add name as alias to itself to simplify later uses...
-      add_alias__(commset);
+      add_alias_nl(commset);
       commSets.push_back(commset);
       return true;
     }
@@ -1585,14 +1585,14 @@ namespace Ioss {
   bool Region::add_alias(const GroupingEntity *ge)
   {
     IOSS_FUNC_ENTER(m_);
-    return add_alias__(ge);
+    return add_alias_nl(ge);
   }
 
-  bool Region::add_alias__(const GroupingEntity *ge)
+  bool Region::add_alias_nl(const GroupingEntity *ge)
   {
     // See if an entity with this name and type already exists...
     const auto       &db_name = ge->name();
-    const std::string alias   = get_alias__(db_name, ge->type());
+    const std::string alias   = get_alias_nl(db_name, ge->type());
 
     if (!alias.empty()) {
       const GroupingEntity *old_ge = get_entity(db_name, ge->type());
@@ -1611,13 +1611,13 @@ namespace Ioss {
         }
       }
     }
-    bool success = add_alias__(db_name, db_name, ge->type());
+    bool success = add_alias_nl(db_name, db_name, ge->type());
 
     // "db_name" property is used with the canonical name setting.
     if (success && ge->property_exists("db_name")) {
       std::string canon_name = ge->get_property("db_name").get_string();
       if (canon_name != db_name) {
-        success = add_alias__(db_name, canon_name, ge->type());
+        success = add_alias_nl(db_name, canon_name, ge->type());
       }
     }
 
@@ -1637,16 +1637,16 @@ namespace Ioss {
   bool Region::add_alias(const std::string &db_name, const std::string &alias, EntityType type)
   {
     IOSS_FUNC_ENTER(m_);
-    return add_alias__(db_name, alias, type);
+    return add_alias_nl(db_name, alias, type);
   }
 
-  bool Region::add_alias__(const std::string &db_name, const std::string &alias, EntityType type)
+  bool Region::add_alias_nl(const std::string &db_name, const std::string &alias, EntityType type)
   {
     // Possible that 'db_name' is itself an alias, resolve down to "canonical"
     // name...
     std::string canon = db_name;
     if (db_name != alias) {
-      canon = get_alias__(db_name, type);
+      canon = get_alias_nl(db_name, type);
     }
 
     if (!canon.empty()) {
@@ -1673,7 +1673,7 @@ namespace Ioss {
     auto *entity = get_entity(db_name);
     IOSS_FUNC_ENTER(m_);
     if (entity != nullptr) {
-      return add_alias__(db_name, alias, entity->type());
+      return add_alias_nl(db_name, alias, entity->type());
     }
     return false;
   }
@@ -1687,10 +1687,10 @@ namespace Ioss {
   std::string Region::get_alias(const std::string &alias, EntityType type) const
   {
     IOSS_FUNC_ENTER(m_);
-    return get_alias__(alias, type);
+    return get_alias_nl(alias, type);
   }
 
-  std::string Region::get_alias__(const std::string &alias, EntityType type) const
+  std::string Region::get_alias_nl(const std::string &alias, EntityType type) const
   {
     std::string ci_alias = Ioss::Utils::uppercase(alias);
     auto        I        = aliases_[type].find(ci_alias);
@@ -1949,7 +1949,7 @@ namespace Ioss {
   Assembly *Region::get_assembly(const std::string &my_name) const
   {
     IOSS_FUNC_ENTER(m_);
-    const std::string db_name = get_alias__(my_name, ASSEMBLY);
+    const std::string db_name = get_alias_nl(my_name, ASSEMBLY);
     unsigned int      db_hash = Ioss::Utils::hash(db_name);
 
     Assembly *ge = nullptr;
@@ -1970,7 +1970,7 @@ namespace Ioss {
   Blob *Region::get_blob(const std::string &my_name) const
   {
     IOSS_FUNC_ENTER(m_);
-    const std::string db_name = get_alias__(my_name, BLOB);
+    const std::string db_name = get_alias_nl(my_name, BLOB);
     unsigned int      db_hash = Ioss::Utils::hash(db_name);
 
     Blob *ge = nullptr;
@@ -1991,7 +1991,7 @@ namespace Ioss {
   NodeBlock *Region::get_node_block(const std::string &my_name) const
   {
     IOSS_FUNC_ENTER(m_);
-    const std::string db_name = get_alias__(my_name, NODEBLOCK);
+    const std::string db_name = get_alias_nl(my_name, NODEBLOCK);
     unsigned int      db_hash = Ioss::Utils::hash(db_name);
 
     NodeBlock *ge = nullptr;
@@ -2012,7 +2012,7 @@ namespace Ioss {
   EdgeBlock *Region::get_edge_block(const std::string &my_name) const
   {
     IOSS_FUNC_ENTER(m_);
-    const std::string db_name = get_alias__(my_name, EDGEBLOCK);
+    const std::string db_name = get_alias_nl(my_name, EDGEBLOCK);
     unsigned int      db_hash = Ioss::Utils::hash(db_name);
 
     EdgeBlock *ge = nullptr;
@@ -2033,7 +2033,7 @@ namespace Ioss {
   FaceBlock *Region::get_face_block(const std::string &my_name) const
   {
     IOSS_FUNC_ENTER(m_);
-    const std::string db_name = get_alias__(my_name, FACEBLOCK);
+    const std::string db_name = get_alias_nl(my_name, FACEBLOCK);
     unsigned int      db_hash = Ioss::Utils::hash(db_name);
 
     FaceBlock *ge = nullptr;
@@ -2054,7 +2054,7 @@ namespace Ioss {
   ElementBlock *Region::get_element_block(const std::string &my_name) const
   {
     IOSS_FUNC_ENTER(m_);
-    const std::string db_name = get_alias__(my_name, ELEMENTBLOCK);
+    const std::string db_name = get_alias_nl(my_name, ELEMENTBLOCK);
     unsigned int      db_hash = Ioss::Utils::hash(db_name);
 
     ElementBlock *ge = nullptr;
@@ -2075,7 +2075,7 @@ namespace Ioss {
   StructuredBlock *Region::get_structured_block(const std::string &my_name) const
   {
     IOSS_FUNC_ENTER(m_);
-    const std::string db_name = get_alias__(my_name, STRUCTUREDBLOCK);
+    const std::string db_name = get_alias_nl(my_name, STRUCTUREDBLOCK);
     unsigned int      db_hash = Ioss::Utils::hash(db_name);
 
     StructuredBlock *ge = nullptr;
@@ -2096,7 +2096,7 @@ namespace Ioss {
   SideSet *Region::get_sideset(const std::string &my_name) const
   {
     IOSS_FUNC_ENTER(m_);
-    const std::string db_name = get_alias__(my_name, SIDESET);
+    const std::string db_name = get_alias_nl(my_name, SIDESET);
     unsigned int      db_hash = Ioss::Utils::hash(db_name);
 
     SideSet *ge = nullptr;
@@ -2135,7 +2135,7 @@ namespace Ioss {
   NodeSet *Region::get_nodeset(const std::string &my_name) const
   {
     IOSS_FUNC_ENTER(m_);
-    const std::string db_name = get_alias__(my_name, NODESET);
+    const std::string db_name = get_alias_nl(my_name, NODESET);
     unsigned int      db_hash = Ioss::Utils::hash(db_name);
 
     NodeSet *ge = nullptr;
@@ -2156,7 +2156,7 @@ namespace Ioss {
   EdgeSet *Region::get_edgeset(const std::string &my_name) const
   {
     IOSS_FUNC_ENTER(m_);
-    const std::string db_name = get_alias__(my_name, EDGESET);
+    const std::string db_name = get_alias_nl(my_name, EDGESET);
     unsigned int      db_hash = Ioss::Utils::hash(db_name);
 
     EdgeSet *ge = nullptr;
@@ -2177,7 +2177,7 @@ namespace Ioss {
   FaceSet *Region::get_faceset(const std::string &my_name) const
   {
     IOSS_FUNC_ENTER(m_);
-    const std::string db_name = get_alias__(my_name, FACESET);
+    const std::string db_name = get_alias_nl(my_name, FACESET);
     unsigned int      db_hash = Ioss::Utils::hash(db_name);
 
     FaceSet *ge = nullptr;
@@ -2198,7 +2198,7 @@ namespace Ioss {
   ElementSet *Region::get_elementset(const std::string &my_name) const
   {
     IOSS_FUNC_ENTER(m_);
-    const std::string db_name = get_alias__(my_name, ELEMENTSET);
+    const std::string db_name = get_alias_nl(my_name, ELEMENTSET);
     unsigned int      db_hash = Ioss::Utils::hash(db_name);
 
     ElementSet *ge = nullptr;
@@ -2219,7 +2219,7 @@ namespace Ioss {
   CommSet *Region::get_commset(const std::string &my_name) const
   {
     IOSS_FUNC_ENTER(m_);
-    const std::string db_name = get_alias__(my_name, COMMSET);
+    const std::string db_name = get_alias_nl(my_name, COMMSET);
     unsigned int      db_hash = Ioss::Utils::hash(db_name);
 
     CommSet *ge = nullptr;
@@ -2558,7 +2558,7 @@ namespace Ioss {
         std::string alias = alias_pair.first;
         std::string base  = alias_pair.second;
         if (alias != base && to->get_entity(base) != nullptr) {
-          to->add_alias__(base, alias, alias_map.first);
+          to->add_alias_nl(base, alias, alias_map.first);
         }
       }
     }
@@ -2704,7 +2704,7 @@ namespace Ioss {
         if (alias != base) {
           GroupingEntity *ge = get_entity(base);
           if (ge != nullptr) {
-            add_alias__(base, alias, alias_map.first);
+            add_alias_nl(base, alias, alias_map.first);
           }
         }
       }
@@ -2716,7 +2716,7 @@ namespace Ioss {
     const std::string &name = entity->name();
 
     // See if any alias with this name...
-    std::string alias = get_alias__(name, entity->type());
+    std::string alias = get_alias_nl(name, entity->type());
 
     if (!alias.empty()) {
       // There is an entity with this name...

--- a/packages/seacas/libraries/ioss/src/Ioss_Region.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Region.h
@@ -116,9 +116,9 @@ namespace Ioss {
     virtual int add_state(double time)
     {
       IOSS_FUNC_ENTER(m_);
-      return add_state__(time);
+      return add_state_nl(time);
     }
-    virtual int add_state__(double time);
+    virtual int add_state_nl(double time);
 
     // Get time corresponding to specified state
 
@@ -223,7 +223,8 @@ namespace Ioss {
     bool        add_alias(const std::string &db_name, const std::string &alias);
     bool        add_alias(const GroupingEntity *ge);
     std::string get_alias(const std::string &alias, EntityType type) const;
-    std::string get_alias__(const std::string &alias, EntityType type) const; // Not locked by mutex
+    std::string get_alias_nl(const std::string &alias,
+                             EntityType         type) const; // Not locked by mutex
 
     const AliasMap &get_alias_map(EntityType entity_type) const;
 
@@ -299,11 +300,11 @@ namespace Ioss {
     // Add the name 'alias' as an alias for the database entity with the
     // name 'db_name'. Returns true if alias added; false if problems
     // adding alias. Not protected by mutex -- call internally only.
-    bool add_alias__(const std::string &db_name, const std::string &alias, EntityType type);
-    bool add_alias__(const GroupingEntity *ge);
+    bool add_alias_nl(const std::string &db_name, const std::string &alias, EntityType type);
+    bool add_alias_nl(const GroupingEntity *ge);
 
-    bool begin_mode__(State new_state);
-    bool end_mode__(State current_state);
+    bool begin_mode_nl(State new_state);
+    bool end_mode_nl(State current_state);
 
     void delete_database() override;
 

--- a/packages/seacas/libraries/ioss/src/Ioss_SerializeIO.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_SerializeIO.C
@@ -48,7 +48,7 @@ namespace Ioss {
         do {
           util.barrier();
         } while (++s_owner != s_groupRank);
-        m_databaseIO->openDatabase__();
+        m_databaseIO->openDatabase_nl();
       }
       else {
         s_owner = s_groupRank;
@@ -65,7 +65,7 @@ namespace Ioss {
       IOSS_FUNC_ENTER(m_);
       if (!m_activeFallThru) {
         if (s_groupFactor > 0) {
-          m_databaseIO->closeDatabase__();
+          m_databaseIO->closeDatabase_nl();
           s_owner                        = s_groupRank;
           const Ioss::ParallelUtils util = m_databaseIO->util();
           do {

--- a/packages/seacas/libraries/ioss/src/adios/Ioad_DatabaseIO.C
+++ b/packages/seacas/libraries/ioss/src/adios/Ioad_DatabaseIO.C
@@ -60,14 +60,14 @@ namespace Ioad {
   // Used to force `rank` initialization before creating `adios_wrapper`.
   int DatabaseIO::RankInit()
   {
-    Ioss::SerializeIO serializeIO__(this);
+    Ioss::SerializeIO serializeIO_(this);
     number_proc = Ioss::SerializeIO::getSize();
     return Ioss::SerializeIO::getRank();
   }
 
   DatabaseIO::~DatabaseIO() {}
 
-  bool DatabaseIO::begin__(Ioss::State state)
+  bool DatabaseIO::begin_nl(Ioss::State state)
   {
     // initialization
     Ioss::Region *this_region = get_region();
@@ -259,7 +259,7 @@ namespace Ioad {
     }
   }
 
-  bool DatabaseIO::end__(Ioss::State state)
+  bool DatabaseIO::end_nl(Ioss::State state)
   {
     // Transitioning out of state 'state'
     assert(state == dbState);
@@ -294,7 +294,7 @@ namespace Ioad {
     return true;
   }
 
-  bool DatabaseIO::begin_state__(int state, double time)
+  bool DatabaseIO::begin_state_nl(int state, double time)
   {
     Ioss::Region *this_region = get_region();
     if (!is_input()) {
@@ -321,7 +321,7 @@ namespace Ioad {
   }
 
   // common
-  bool DatabaseIO::end_state__(int state, double time)
+  bool DatabaseIO::end_state_nl(int state, double time)
   {
     Ioss::Region *this_region = get_region();
 
@@ -1191,7 +1191,7 @@ namespace Ioad {
   {
     // Check "time" attribute and global variable.
     timeScaleFactor = adios_wrapper.GetAttribute<double>(Time_scale_factor, true, 1.0);
-    Ioss::SerializeIO serializeIO__(this);
+    Ioss::SerializeIO serializeIO_(this);
     Ioss::Region     *this_region = get_region();
     if (globals_map.find(Time_meta) != globals_map.end()) {
       // Load time steps
@@ -1213,7 +1213,7 @@ namespace Ioad {
         adios_wrapper.GetSync(time_var, tsteps.data());
         for (size_t step = 0; step < time_var.Steps(); step++) {
           // if (tsteps[i] <= last_time) { TODO: Check last time step before writing everything
-          this_region->add_state__(tsteps[step] * timeScaleFactor);
+          this_region->add_state_nl(tsteps[step] * timeScaleFactor);
         }
       }
       else {
@@ -1226,7 +1226,7 @@ namespace Ioad {
     add_entity_properties(this_region, properties_map, region_name);
   }
 
-  void DatabaseIO::read_meta_data__()
+  void DatabaseIO::read_meta_data_nl()
   {
     check_processor_info();
     Ioss::Region *region = get_region();
@@ -1602,8 +1602,8 @@ namespace Ioad {
     }
   }
 
-  void DatabaseIO::compute_block_membership__(Ioss::SideBlock          *efblock,
-                                              std::vector<std::string> &block_membership) const
+  void DatabaseIO::compute_block_membership_nl(Ioss::SideBlock          *efblock,
+                                               std::vector<std::string> &block_membership) const
   {
     const Ioss::ElementBlockContainer &element_blocks = get_region()->get_element_blocks();
     assert(Ioss::Utils::check_block_order(element_blocks));

--- a/packages/seacas/libraries/ioss/src/adios/Ioad_DatabaseIO.h
+++ b/packages/seacas/libraries/ioss/src/adios/Ioad_DatabaseIO.h
@@ -46,8 +46,8 @@ namespace Ioad {
 
     std::string get_format() const override { return "ADIOS2"; }
 
-    bool begin__(Ioss::State state) override;
-    bool end__(Ioss::State state) override;
+    bool begin_nl(Ioss::State state) override;
+    bool end_nl(Ioss::State state) override;
 
     unsigned entity_field_support() const override;
     int      int_byte_size_db() const override;
@@ -242,20 +242,20 @@ namespace Ioad {
                                              const std::string &string_variable) const;
 
     void get_globals(const GlobalMapType &globals_map, const FieldsMapType &properties_map);
-    void compute_block_membership__(Ioss::SideBlock          *efblock,
-                                    std::vector<std::string> &block_membership) const override;
+    void compute_block_membership_nl(Ioss::SideBlock          *efblock,
+                                     std::vector<std::string> &block_membership) const override;
     void define_properties(const Ioss::GroupingEntity *entity_block,
                            const std::string          &encoded_entity_name);
 
-    void read_meta_data__() override;
+    void read_meta_data_nl() override;
     void read_communication_metadata();
     void read_region(const FieldsMapType &fields_map);
     void check_processor_info();
     void check_model();
 
     int           RankInit();
-    bool          begin_state__(int state, double time) override;
-    bool          end_state__(int state, double time) override;
+    bool          begin_state_nl(int state, double time) override;
+    bool          end_state_nl(int state, double time) override;
     unsigned long rank; // rank needs to be declared first to be initialized before adios_wrapper.
     mutable AdiosWrapper adios_wrapper; // adios_wrapper needs to be declared before bpio
                                         // and bp_engine to be initialized first.

--- a/packages/seacas/libraries/ioss/src/catalyst/Iocatalyst_DatabaseIO.C
+++ b/packages/seacas/libraries/ioss/src/catalyst/Iocatalyst_DatabaseIO.C
@@ -1,4 +1,4 @@
-// Copyright(C) 1999-2021 National Technology & Engineering Solutions
+// Copyright(C) 1999-2021, 2023 National Technology & Engineering Solutions
 // of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
 // NTESS, the U.S. Government retains certain rights in this software.
 //
@@ -476,13 +476,13 @@ namespace Iocatalyst {
     }
   }
 
-  bool DatabaseIO::begin__(Ioss::State state)
+  bool DatabaseIO::begin_nl(Ioss::State state)
   {
     this->dbState = state;
     return true;
   }
 
-  bool DatabaseIO::end__(Ioss::State state)
+  bool DatabaseIO::end_nl(Ioss::State state)
   {
     assert(this->dbState == state);
 
@@ -521,10 +521,10 @@ namespace Iocatalyst {
     return true;
   }
 
-  bool DatabaseIO::begin_state__(int state, double time) { return true; }
+  bool DatabaseIO::begin_state_nl(int state, double time) { return true; }
 
   // common
-  bool DatabaseIO::end_state__(int state, double time)
+  bool DatabaseIO::end_state_nl(int state, double time)
   {
     if (this->is_input()) {}
     else {
@@ -552,7 +552,7 @@ namespace Iocatalyst {
            Ioss::SIDEBLOCK | Ioss::REGION;
   }
 
-  void DatabaseIO::read_meta_data__()
+  void DatabaseIO::read_meta_data_nl()
   {
     auto region = this->get_region();
     assert(region != nullptr);
@@ -561,7 +561,7 @@ namespace Iocatalyst {
     impl.readModel(region);
   }
 
-  void DatabaseIO::get_step_times__()
+  void DatabaseIO::get_step_times_nl()
   {
     auto region = this->get_region();
     assert(region != nullptr);

--- a/packages/seacas/libraries/ioss/src/catalyst/Iocatalyst_DatabaseIO.h
+++ b/packages/seacas/libraries/ioss/src/catalyst/Iocatalyst_DatabaseIO.h
@@ -77,21 +77,21 @@ namespace Iocatalyst {
     bool deep_copy() const { return this->useDeepCopy; }
 
   private:
-    bool open_group__(const std::string & /* group_name */) override { return false; }
-    bool create_subgroup__(const std::string & /* group_name */) override { return false; }
+    bool open_group_nl(const std::string & /* group_name */) override { return false; }
+    bool create_subgroup_nl(const std::string & /* group_name */) override { return false; }
 
-    bool begin__(Ioss::State state) override;
-    bool end__(Ioss::State state) override;
+    bool begin_nl(Ioss::State state) override;
+    bool end_nl(Ioss::State state) override;
 
-    void read_meta_data__() override;
-    void get_step_times__() override;
+    void read_meta_data_nl() override;
+    void get_step_times_nl() override;
 
-    bool begin_state__(int state, double time) override;
-    bool end_state__(int state, double time) override;
+    bool begin_state_nl(int state, double time) override;
+    bool end_state_nl(int state, double time) override;
 
     void
-    compute_block_membership__(Ioss::SideBlock * /* efblock */,
-                               std::vector<std::string> & /* block_membership */) const override
+    compute_block_membership_nl(Ioss::SideBlock * /* efblock */,
+                                std::vector<std::string> & /* block_membership */) const override
     {
     }
 

--- a/packages/seacas/libraries/ioss/src/cgns/Iocgns_DatabaseIO.h
+++ b/packages/seacas/libraries/ioss/src/cgns/Iocgns_DatabaseIO.h
@@ -67,9 +67,6 @@ namespace Iocgns {
     // database supports that type (e.g. return_value & Ioss::FACESET)
     unsigned entity_field_support() const override;
 
-    int64_t node_global_to_local__(int64_t global, bool must_exist) const override;
-    int64_t element_global_to_local__(int64_t global) const override;
-
     ~DatabaseIO() override;
 
     std::string get_format() const override { return "CGNS"; }
@@ -81,13 +78,17 @@ namespace Iocgns {
     bool node_major() const override { return false; }
 
     // Metadata-related functions.
-    void read_meta_data__() override;
     void write_meta_data();
     void write_results_meta_data();
 
     int get_file_pointer() const override;
 
   private:
+    int64_t node_global_to_local__(int64_t global, bool must_exist) const override;
+    int64_t element_global_to_local__(int64_t global) const override;
+
+    void read_meta_data__() override;
+
     void open_state_file(int state);
     void free_state_pointer();
 

--- a/packages/seacas/libraries/ioss/src/cgns/Iocgns_DatabaseIO.h
+++ b/packages/seacas/libraries/ioss/src/cgns/Iocgns_DatabaseIO.h
@@ -84,30 +84,30 @@ namespace Iocgns {
     int get_file_pointer() const override;
 
   private:
-    int64_t node_global_to_local__(int64_t global, bool must_exist) const override;
-    int64_t element_global_to_local__(int64_t global) const override;
+    int64_t node_global_to_local_nl(int64_t global, bool must_exist) const override;
+    int64_t element_global_to_local_nl(int64_t global) const override;
 
-    void read_meta_data__() override;
+    void read_meta_data_nl() override;
 
     void open_state_file(int state);
     void free_state_pointer();
 
-    void openDatabase__() const override;
-    void closeDatabase__() const override;
+    void openDatabase_nl() const override;
+    void closeDatabase_nl() const override;
 
-    bool begin__(Ioss::State state) override;
-    bool end__(Ioss::State state) override;
+    bool begin_nl(Ioss::State state) override;
+    bool end_nl(Ioss::State state) override;
 
-    bool begin_state__(int state, double time) override;
-    bool end_state__(int state, double time) override;
-    void flush_database__() const override;
+    bool begin_state_nl(int state, double time) override;
+    bool end_state_nl(int state, double time) override;
+    void flush_database_nl() const override;
 
     bool   check_valid_file_open(int status) const;
     void   create_structured_block(int base, int zone, size_t &num_node);
     void   create_structured_block_fpp(int base, int num_zones, size_t &num_node);
     size_t finalize_structured_blocks();
     void   finalize_database() const override;
-    void   get_step_times__() override;
+    void   get_step_times_nl() override;
 
     void create_unstructured_block(int base, int zone, size_t &num_node);
     void write_adjacency_data();

--- a/packages/seacas/libraries/ioss/src/cgns/Iocgns_ParallelDatabaseIO.C
+++ b/packages/seacas/libraries/ioss/src/cgns/Iocgns_ParallelDatabaseIO.C
@@ -169,7 +169,7 @@ namespace Iocgns {
       }
     }
 
-    Ioss::DatabaseIO::openDatabase__();
+    Ioss::DatabaseIO::openDatabase_nl();
   }
 
   ParallelDatabaseIO::~ParallelDatabaseIO()
@@ -178,8 +178,8 @@ namespace Iocgns {
       delete gtb.second;
     }
     try {
-      closeBaseDatabase__();
-      closeDatabase__();
+      closeBaseDatabase_nl();
+      closeDatabase_nl();
     }
     catch (...) {
     }
@@ -188,12 +188,12 @@ namespace Iocgns {
   int ParallelDatabaseIO::get_file_pointer() const
   {
     if (m_cgnsFilePtr < 0) {
-      openDatabase__();
+      openDatabase_nl();
     }
     return m_cgnsFilePtr;
   }
 
-  void ParallelDatabaseIO::openDatabase__() const
+  void ParallelDatabaseIO::openDatabase_nl() const
   {
     if (m_cgnsFilePtr < 0) {
       int mode = is_input() ? CG_MODE_READ : CG_MODE_WRITE;
@@ -229,7 +229,7 @@ namespace Iocgns {
       cgp_mpi_comm(util().communicator());
 #endif
       CGCHECKM(cgp_pio_mode(CGP_COLLECTIVE));
-      Ioss::DatabaseIO::openDatabase__();
+      Ioss::DatabaseIO::openDatabase_nl();
       int ierr = cgp_open(get_dw_name().c_str(), mode, &m_cgnsFilePtr);
 
       if (do_timer) {
@@ -279,7 +279,7 @@ namespace Iocgns {
     assert(m_cgnsFilePtr >= 0);
   }
 
-  void ParallelDatabaseIO::closeBaseDatabase__() const
+  void ParallelDatabaseIO::closeBaseDatabase_nl() const
   {
     if (m_cgnsBasePtr > 0) {
       bool do_timer = false;
@@ -300,7 +300,7 @@ namespace Iocgns {
     }
   }
 
-  void ParallelDatabaseIO::closeDatabase__() const
+  void ParallelDatabaseIO::closeDatabase_nl() const
   {
     if (m_cgnsFilePtr > 0) {
       bool do_timer = false;
@@ -345,7 +345,7 @@ namespace Iocgns {
     }
   }
 
-  void ParallelDatabaseIO::release_memory__()
+  void ParallelDatabaseIO::release_memory_nl()
   {
     nodeMap.release_memory();
     elemMap.release_memory();
@@ -356,21 +356,21 @@ namespace Iocgns {
     }
   }
 
-  int64_t ParallelDatabaseIO::node_global_to_local__(int64_t global, bool /* must_exist */) const
+  int64_t ParallelDatabaseIO::node_global_to_local_nl(int64_t global, bool /* must_exist */) const
   {
     // TODO: Fix
     return global;
   }
 
-  int64_t ParallelDatabaseIO::element_global_to_local__(int64_t global) const
+  int64_t ParallelDatabaseIO::element_global_to_local_nl(int64_t global) const
   {
     // TODO: Fix
     return global;
   }
 
-  void ParallelDatabaseIO::read_meta_data__()
+  void ParallelDatabaseIO::read_meta_data_nl()
   {
-    openDatabase__();
+    openDatabase_nl();
 
     // Determine the number of bases in the grid.
     // Currently only handle 1.
@@ -384,7 +384,7 @@ namespace Iocgns {
       IOSS_ERROR(errmsg);
     }
 
-    get_step_times__();
+    get_step_times_nl();
 
     if (open_create_behavior() == Ioss::DB_APPEND) {
       return;
@@ -800,7 +800,7 @@ namespace Iocgns {
         Utils::common_write_meta_data(get_file_pointer(), *get_region(), m_zoneOffset, true);
   }
 
-  void ParallelDatabaseIO::get_step_times__()
+  void ParallelDatabaseIO::get_step_times_nl()
   {
     Utils::get_step_times(get_file_pointer(), m_timesteps, get_region(), timeScaleFactor,
                           myProcessor);
@@ -938,7 +938,7 @@ namespace Iocgns {
     }
   }
 
-  bool ParallelDatabaseIO::begin__(Ioss::State state)
+  bool ParallelDatabaseIO::begin_nl(Ioss::State state)
   {
     dbState = state;
     return true;
@@ -953,7 +953,7 @@ namespace Iocgns {
       m_cgnsBasePtr = m_cgnsFilePtr;
       m_cgnsFilePtr = -1;
     }
-    closeDatabase__();
+    closeDatabase_nl();
   }
 
   void ParallelDatabaseIO::open_state_file(int state)
@@ -977,7 +977,7 @@ namespace Iocgns {
     Iocgns::Utils::write_state_meta_data(get_file_pointer(), *get_region(), true);
   }
 
-  bool ParallelDatabaseIO::end__(Ioss::State state)
+  bool ParallelDatabaseIO::end_nl(Ioss::State state)
   {
     // Transitioning out of state 'state'
     switch (state) {
@@ -1008,7 +1008,7 @@ namespace Iocgns {
     return true;
   }
 
-  bool ParallelDatabaseIO::begin_state__(int state, double /* time */)
+  bool ParallelDatabaseIO::begin_state_nl(int state, double /* time */)
   {
     if (is_input()) {
       return true;
@@ -1025,7 +1025,7 @@ namespace Iocgns {
     return true;
   }
 
-  bool ParallelDatabaseIO::end_state__(int state, double time)
+  bool ParallelDatabaseIO::end_state_nl(int state, double time)
   {
     if (!is_input()) {
       m_timesteps.push_back(time);
@@ -1041,21 +1041,21 @@ namespace Iocgns {
       }
 
       if (do_flush) {
-        flush_database__();
+        flush_database_nl();
       }
     }
 
     return true;
   }
 
-  void ParallelDatabaseIO::flush_database__() const
+  void ParallelDatabaseIO::flush_database_nl() const
   {
     // For HDF5 files, it looks like we need to close the database between
     // writes if we want to have a valid database for external access or
     // to protect against a crash corrupting the file.
     finalize_database();
-    closeDatabase__();
-    m_cgnsFilePtr = -2; // Tell openDatabase__ that we want to append
+    closeDatabase_nl();
+    m_cgnsFilePtr = -2; // Tell openDatabase_nl that we want to append
   }
 
   const Ioss::Map &ParallelDatabaseIO::get_map(entity_type type) const

--- a/packages/seacas/libraries/ioss/src/cgns/Iocgns_ParallelDatabaseIO.h
+++ b/packages/seacas/libraries/ioss/src/cgns/Iocgns_ParallelDatabaseIO.h
@@ -86,33 +86,33 @@ namespace Iocgns {
     void write_results_meta_data();
 
   private:
-    void read_meta_data__() override;
+    void read_meta_data_nl() override;
 
-    int64_t node_global_to_local__(int64_t global, bool must_exist) const override;
-    int64_t element_global_to_local__(int64_t global) const override;
+    int64_t node_global_to_local_nl(int64_t global, bool must_exist) const override;
+    int64_t element_global_to_local_nl(int64_t global) const override;
 
-    void release_memory__() override;
+    void release_memory_nl() override;
 
     void open_state_file(int state);
     void free_state_pointer();
 
-    void openDatabase__() const override;
-    void closeDatabase__() const override;
-    void closeBaseDatabase__() const;
+    void openDatabase_nl() const override;
+    void closeDatabase_nl() const override;
+    void closeBaseDatabase_nl() const;
 
-    bool begin__(Ioss::State state) override;
-    bool end__(Ioss::State state) override;
+    bool begin_nl(Ioss::State state) override;
+    bool end_nl(Ioss::State state) override;
 
-    bool begin_state__(int state, double time) override;
-    bool end_state__(int state, double time) override;
-    void flush_database__() const override;
+    bool begin_state_nl(int state, double time) override;
+    bool end_state_nl(int state, double time) override;
+    void flush_database_nl() const override;
 
     void    handle_structured_blocks();
     void    handle_unstructured_blocks();
     size_t  finalize_structured_blocks();
     int64_t handle_node_ids(void *ids, int64_t num_to_get) const;
     void    finalize_database() const override;
-    void    get_step_times__() override;
+    void    get_step_times_nl() override;
     void    write_adjacency_data();
 
     int64_t get_field_internal(const Ioss::Region *reg, const Ioss::Field &field, void *data,

--- a/packages/seacas/libraries/ioss/src/cgns/Iocgns_ParallelDatabaseIO.h
+++ b/packages/seacas/libraries/ioss/src/cgns/Iocgns_ParallelDatabaseIO.h
@@ -71,11 +71,6 @@ namespace Iocgns {
     // database supports that type (e.g. return_value & Ioss::FACESET)
     unsigned entity_field_support() const override;
 
-    int64_t node_global_to_local__(int64_t global, bool must_exist) const override;
-    int64_t element_global_to_local__(int64_t global) const override;
-
-    void release_memory__() override;
-
     int get_file_pointer() const override;
 
     bool node_major() const override { return false; }
@@ -87,11 +82,17 @@ namespace Iocgns {
     int int_byte_size_db() const override { return CG_SIZEOF_SIZE; }
 
     // Metadata-related functions.
-    void read_meta_data__() override;
     void write_meta_data();
     void write_results_meta_data();
 
   private:
+    void read_meta_data__() override;
+
+    int64_t node_global_to_local__(int64_t global, bool must_exist) const override;
+    int64_t element_global_to_local__(int64_t global) const override;
+
+    void release_memory__() override;
+
     void open_state_file(int state);
     void free_state_pointer();
 

--- a/packages/seacas/libraries/ioss/src/exodus/Ioex_BaseDatabaseIO.C
+++ b/packages/seacas/libraries/ioss/src/exodus/Ioex_BaseDatabaseIO.C
@@ -418,7 +418,7 @@ namespace Ioex {
     return m_exodusFilePtr;
   }
 
-  bool BaseDatabaseIO::ok__(bool write_message, std::string *error_message, int *bad_count) const
+  bool BaseDatabaseIO::ok_nl(bool write_message, std::string *error_message, int *bad_count) const
   {
     // For input, we try to open the existing file.
 
@@ -480,7 +480,7 @@ namespace Ioex {
     ex_set_max_name_length(m_exodusFilePtr, maximumNameLength);
   }
 
-  bool BaseDatabaseIO::open_group__(const std::string &group_name)
+  bool BaseDatabaseIO::open_group_nl(const std::string &group_name)
   {
     // Get existing file pointer...
     bool success = false;
@@ -500,7 +500,7 @@ namespace Ioex {
     return success;
   }
 
-  bool BaseDatabaseIO::create_subgroup__(const std::string &group_name)
+  bool BaseDatabaseIO::create_subgroup_nl(const std::string &group_name)
   {
     bool success = false;
     if (!is_input()) {
@@ -683,7 +683,7 @@ namespace Ioex {
 
   void BaseDatabaseIO::update_block_omissions_from_assemblies()
   {
-    Ioss::SerializeIO serializeIO__(this);
+    Ioss::SerializeIO serializeIO_(this);
 
     if (!assemblyOmissions.empty()) {
       assert(blockInclusions.empty());
@@ -731,7 +731,7 @@ namespace Ioex {
 
   void BaseDatabaseIO::get_assemblies()
   {
-    Ioss::SerializeIO serializeIO__(this);
+    Ioss::SerializeIO serializeIO_(this);
 
     auto assemblies = get_exodus_assemblies(get_file_pointer());
     if (!assemblies.empty()) {
@@ -814,7 +814,7 @@ namespace Ioex {
 
   void BaseDatabaseIO::get_blobs()
   {
-    Ioss::SerializeIO serializeIO__(this);
+    Ioss::SerializeIO serializeIO_(this);
     // Query number of blobs...
     int nblob = ex_inquire_int(get_file_pointer(), EX_INQ_BLOB);
 
@@ -899,7 +899,7 @@ namespace Ioex {
 
     int num_attr = 0;
     {
-      Ioss::SerializeIO serializeIO__(this);
+      Ioss::SerializeIO serializeIO_(this);
       int               ierr = ex_get_attr_param(get_file_pointer(), EX_NODE_BLOCK, 1, &num_attr);
       if (ierr < 0) {
         Ioex::exodus_error(get_file_pointer(), __LINE__, __func__, __FILE__);
@@ -1008,8 +1008,8 @@ namespace Ioex {
   }
 
   // common
-  void BaseDatabaseIO::compute_block_membership__(Ioss::SideBlock          *efblock,
-                                                  std::vector<std::string> &block_membership) const
+  void BaseDatabaseIO::compute_block_membership_nl(Ioss::SideBlock          *efblock,
+                                                   std::vector<std::string> &block_membership) const
   {
     const Ioss::ElementBlockContainer &element_blocks = get_region()->get_element_blocks();
     assert(Ioss::Utils::check_block_order(element_blocks));
@@ -1072,7 +1072,7 @@ namespace Ioex {
     // 'globalVariables' array
     {
       size_t            num_to_get = field.verify(data_size);
-      Ioss::SerializeIO serializeIO__(this);
+      Ioss::SerializeIO serializeIO_(this);
 
       Ioss::Field::RoleType role = field.get_role();
 
@@ -1099,7 +1099,7 @@ namespace Ioex {
     // and output them all at one time.  The storage location is a
     // 'globalVariables' array
     {
-      Ioss::SerializeIO serializeIO__(this);
+      Ioss::SerializeIO serializeIO_(this);
 
       Ioss::Field::RoleType role       = field.get_role();
       size_t                num_to_get = field.verify(data_size);
@@ -1348,14 +1348,14 @@ namespace Ioex {
   }
 
   // common
-  bool BaseDatabaseIO::begin__(Ioss::State state)
+  bool BaseDatabaseIO::begin_nl(Ioss::State state)
   {
     dbState = state;
     return true;
   }
 
   // common
-  bool BaseDatabaseIO::end__(Ioss::State state)
+  bool BaseDatabaseIO::end_nl(Ioss::State state)
   {
     // Transitioning out of state 'state'
     assert(state == dbState);
@@ -1375,7 +1375,7 @@ namespace Ioex {
     }
 
     {
-      Ioss::SerializeIO serializeIO__(this);
+      Ioss::SerializeIO serializeIO_(this);
 
       if (!is_input()) {
         ex_update(get_file_pointer());
@@ -1454,9 +1454,9 @@ namespace Ioex {
     }
   }
 
-  bool BaseDatabaseIO::begin_state__(int state, double time)
+  bool BaseDatabaseIO::begin_state_nl(int state, double time)
   {
-    Ioss::SerializeIO serializeIO__(this);
+    Ioss::SerializeIO serializeIO_(this);
 
     time /= timeScaleFactor;
 
@@ -1488,9 +1488,9 @@ namespace Ioex {
   }
 
   // common
-  bool BaseDatabaseIO::end_state__(int state, double time)
+  bool BaseDatabaseIO::end_state_nl(int state, double time)
   {
-    Ioss::SerializeIO serializeIO__(this);
+    Ioss::SerializeIO serializeIO_(this);
 
     if (!is_input()) {
       write_reduction_fields();
@@ -1530,7 +1530,7 @@ namespace Ioex {
     // Get "global attributes"
     // These are single key-value per grouping entity
     // Stored as Ioss::Property with origin of ATTRIBUTE
-    Ioss::SerializeIO serializeIO__(this);
+    Ioss::SerializeIO serializeIO_(this);
     auto              type      = Ioex::map_exodus_type(entity->type());
     int               att_count = ex_get_attribute_count(get_file_pointer(), type, id);
 
@@ -1597,7 +1597,7 @@ namespace Ioex {
   {
     int nvar = 0;
     {
-      Ioss::SerializeIO serializeIO__(this);
+      Ioss::SerializeIO serializeIO_(this);
 
       int ierr = ex_get_variable_param(get_file_pointer(), type, &nvar);
       if (ierr < 0) {
@@ -1618,7 +1618,7 @@ namespace Ioex {
           std::fill(truth_table.begin(), truth_table.end(), 1);
         }
         else {
-          Ioss::SerializeIO serializeIO__(this);
+          Ioss::SerializeIO serializeIO_(this);
           int               ierr =
               ex_get_truth_table(get_file_pointer(), type, block_count, nvar, truth_table.data());
           if (ierr < 0) {
@@ -1645,7 +1645,7 @@ namespace Ioex {
       // Read the names...
       // (Currently, names are read for every block.  We could save them...)
       {
-        Ioss::SerializeIO serializeIO__(this);
+        Ioss::SerializeIO serializeIO_(this);
 
         int ierr = ex_get_variable_names(get_file_pointer(), type, nvar, names);
         if (ierr < 0) {
@@ -1697,7 +1697,7 @@ namespace Ioex {
     ex_entity_type type = Ioex::map_exodus_type(entity->type());
     int            nvar = 0;
     {
-      Ioss::SerializeIO serializeIO__(this);
+      Ioss::SerializeIO serializeIO_(this);
 
       int ierr = ex_get_reduction_variable_param(get_file_pointer(), type, &nvar);
       if (ierr < 0) {
@@ -1714,7 +1714,7 @@ namespace Ioex {
       // Read the names...
       // (Currently, names are read for every block.  We could save them...)
       {
-        Ioss::SerializeIO serializeIO__(this);
+        Ioss::SerializeIO serializeIO_(this);
 
         int ierr = ex_get_reduction_variable_names(get_file_pointer(), type, nvar, names);
         if (ierr < 0) {
@@ -1845,7 +1845,7 @@ namespace Ioex {
       }
 
       {
-        Ioss::SerializeIO serializeIO__(this);
+        Ioss::SerializeIO serializeIO_(this);
 
         int ierr = ex_put_all_var_param_ext(get_file_pointer(), &exo_params);
         if (ierr < 0) {
@@ -2118,7 +2118,7 @@ namespace Ioex {
   }
 
   // common
-  void BaseDatabaseIO::flush_database__() const
+  void BaseDatabaseIO::flush_database_nl() const
   {
     if (!is_input()) {
       if (isParallel || myProcessor == 0) {
@@ -2192,7 +2192,7 @@ namespace Ioex {
     }
 
     if (do_flush) {
-      flush_database__();
+      flush_database_nl();
     }
   }
 
@@ -2251,7 +2251,7 @@ namespace Ioex {
       else {
         // Use attribute names if they exist.
         {
-          Ioss::SerializeIO serializeIO__(this);
+          Ioss::SerializeIO serializeIO_(this);
           if (block->entity_count() != 0) {
             ex_entity_type entity_type = Ioex::map_exodus_type(block->type());
             int            ierr = ex_get_attr_names(get_file_pointer(), entity_type, id, &names[0]);

--- a/packages/seacas/libraries/ioss/src/exodus/Ioex_BaseDatabaseIO.h
+++ b/packages/seacas/libraries/ioss/src/exodus/Ioex_BaseDatabaseIO.h
@@ -98,20 +98,20 @@ namespace Ioex {
     // If 'error_message' non-null, then put the warning message into the string and return it.
     // If 'bad_count' non-null, it counts the number of processors where the file does not exist.
     //    if ok returns false, but *bad_count==0, then the routine does not support this argument.
-    bool ok__(bool write_message = false, std::string *error_message = nullptr,
-              int *bad_count = nullptr) const override;
+    bool ok_nl(bool write_message = false, std::string *error_message = nullptr,
+               int *bad_count = nullptr) const override;
 
-    bool open_group__(const std::string &group_name) override;
-    bool create_subgroup__(const std::string &group_name) override;
+    bool open_group_nl(const std::string &group_name) override;
+    bool create_subgroup_nl(const std::string &group_name) override;
 
-    bool begin__(Ioss::State state) override;
-    bool end__(Ioss::State state) override;
+    bool begin_nl(Ioss::State state) override;
+    bool end_nl(Ioss::State state) override;
 
     void open_state_file(int state);
 
-    bool begin_state__(int state, double time) override;
-    bool end_state__(int state, double time) override;
-    void get_step_times__() override = 0;
+    bool begin_state_nl(int state, double time) override;
+    bool end_state_nl(int state, double time) override;
+    void get_step_times_nl() override = 0;
 
     int maximum_symbol_length() const override { return maximumNameLength; }
 
@@ -128,8 +128,8 @@ namespace Ioex {
                             Ioss::Map &entity_map, void *ids, size_t num_to_get,
                             size_t offset) const;
 
-    void compute_block_membership__(Ioss::SideBlock          *efblock,
-                                    std::vector<std::string> &block_membership) const override;
+    void compute_block_membership_nl(Ioss::SideBlock          *efblock,
+                                     std::vector<std::string> &block_membership) const override;
 
     int  int_byte_size_db() const override;
     void set_int_byte_size_api(Ioss::DataSize size) const override;
@@ -199,9 +199,9 @@ namespace Ioex {
     virtual void write_meta_data(Ioss::IfDatabaseExistsBehavior behavior) = 0;
     void         write_results_metadata(bool gather_data, Ioss::IfDatabaseExistsBehavior behavior);
 
-    void openDatabase__() const override { get_file_pointer(); }
+    void openDatabase_nl() const override { get_file_pointer(); }
 
-    void closeDatabase__() const override
+    void closeDatabase_nl() const override
     {
       free_file_pointer();
       close_dw();
@@ -264,7 +264,7 @@ namespace Ioex {
     // Given the global region step, return the step on the database...
     int get_database_step(int global_step) const;
 
-    void flush_database__() const override;
+    void flush_database_nl() const override;
     void finalize_write(int state, double sim_time);
 
     mutable int m_exodusFilePtr{-1};

--- a/packages/seacas/libraries/ioss/src/exodus/Ioex_DatabaseIO.C
+++ b/packages/seacas/libraries/ioss/src/exodus/Ioex_DatabaseIO.C
@@ -436,7 +436,7 @@ namespace Ioex {
     return Ioex::BaseDatabaseIO::get_file_pointer();
   }
 
-  void DatabaseIO::read_meta_data__()
+  void DatabaseIO::read_meta_data_nl()
   {
     // If this is a HISTORY file, there isn't really any metadata
     // Other than a single node and single element.  Just hardwire
@@ -453,7 +453,7 @@ namespace Ioex {
         eb->property_add(Ioss::Property("id", 1));
         eb->property_add(Ioss::Property("guid", util().generate_guid(1)));
         get_region()->add(eb);
-        get_step_times__();
+        get_step_times_nl();
         add_region_fields();
       }
       return;
@@ -467,12 +467,12 @@ namespace Ioex {
     // anything since it is already there.  We do need the number of
     // steps though...
     if (open_create_behavior() == Ioss::DB_APPEND || dbUsage == Ioss::QUERY_TIMESTEPS_ONLY) {
-      get_step_times__();
+      get_step_times_nl();
       return;
     }
 
     {
-      Ioss::SerializeIO serializeIO__(this);
+      Ioss::SerializeIO serializeIO_(this);
 
       if (isParallel) {
         Ioex::check_processor_info(decoded_filename(), get_file_pointer(), util().parallel_size(),
@@ -483,7 +483,7 @@ namespace Ioex {
       read_communication_metadata();
     }
 
-    get_step_times__();
+    get_step_times_nl();
 
     get_nodeblocks();
     get_edgeblocks();
@@ -633,7 +633,7 @@ namespace Ioex {
     }
   }
 
-  void DatabaseIO::get_step_times__()
+  void DatabaseIO::get_step_times_nl()
   {
     bool                exists         = false;
     double              last_time      = DBL_MAX;
@@ -668,14 +668,14 @@ namespace Ioex {
         Ioss::Region *this_region = get_region();
         for (int i = 0; i < max_step; i++) {
           if (tsteps[i] <= max_time) {
-            this_region->add_state__(tsteps[i] * timeScaleFactor);
+            this_region->add_state_nl(tsteps[i] * timeScaleFactor);
           }
         }
       }
     }
     else {
       {
-        Ioss::SerializeIO serializeIO__(this);
+        Ioss::SerializeIO serializeIO_(this);
         timestep_count = ex_inquire_int(get_file_pointer(), EX_INQ_TIME);
         if (timestep_count <= 0) {
           return;
@@ -739,7 +739,7 @@ namespace Ioex {
       Ioss::Region *this_region = get_region();
       for (int i = 0; i < max_step; i++) {
         if (tsteps[i] <= last_time) {
-          this_region->add_state__(tsteps[i] * timeScaleFactor);
+          this_region->add_state_nl(tsteps[i] * timeScaleFactor);
         }
         else {
           if (myProcessor == 0 && max_time == std::numeric_limits<double>::max()) {
@@ -960,7 +960,7 @@ namespace Ioex {
 
       if (is_input() || open_create_behavior() == Ioss::DB_APPEND) {
 
-        Ioss::SerializeIO serializeIO__(this);
+        Ioss::SerializeIO serializeIO_(this);
         // Check whether there is a "original_global_id_map" map on
         // the database. If so, use it instead of the "node_num_map".
         bool map_read  = false;
@@ -1074,7 +1074,7 @@ namespace Ioex {
 
     int error;
     {
-      Ioss::SerializeIO serializeIO__(this);
+      Ioss::SerializeIO serializeIO_(this);
 
       if ((ex_int64_status(get_file_pointer()) & EX_IDS_INT64_API) != 0) {
         error = ex_get_ids(get_file_pointer(), entity_type, X_block_ids.data());
@@ -1100,7 +1100,7 @@ namespace Ioex {
     int               iblk;
 
     {
-      Ioss::SerializeIO serializeIO__(this);
+      Ioss::SerializeIO serializeIO_(this);
 
       for (iblk = 0; iblk < m_groupCount[entity_type]; iblk++) {
         int     index = 4 * iblk;
@@ -1173,7 +1173,7 @@ namespace Ioex {
         block_name = alias;
       }
       else {
-        Ioss::SerializeIO serializeIO__(this);
+        Ioss::SerializeIO serializeio_(this);
         block_name = Ioex::get_entity_name(get_file_pointer(), entity_type, id, basename,
                                            maximumNameLength, db_has_name);
       }
@@ -1288,7 +1288,7 @@ namespace Ioex {
       add_mesh_reduction_fields(id, block);
 
       if (entity_type == EX_ELEM_BLOCK) {
-        Ioss::SerializeIO serializeIO__(this);
+        Ioss::SerializeIO serializeio_(this);
         if (nmap > 0) {
           auto *elb = dynamic_cast<Ioss::ElementBlock *>(block);
           Ioss::Utils::check_dynamic_cast(elb);
@@ -1443,7 +1443,7 @@ namespace Ioex {
 
       Ioss::Int64Vector side_set_ids(m_groupCount[EX_SIDE_SET]);
       {
-        Ioss::SerializeIO serializeIO__(this);
+        Ioss::SerializeIO serializeio_(this);
         int               error;
         if ((ex_int64_status(get_file_pointer()) & EX_IDS_INT64_API) != 0) {
           error = ex_get_ids(get_file_pointer(), EX_SIDE_SET, side_set_ids.data());
@@ -1499,7 +1499,7 @@ namespace Ioex {
 
         bool db_has_name = false;
         {
-          Ioss::SerializeIO serializeIO__(this);
+          Ioss::SerializeIO serializeio_(this);
 
           std::string alias = Ioss::Utils::encode_entity_name("surface", id);
           if (ignore_database_names()) {
@@ -1832,7 +1832,7 @@ namespace Ioex {
 
               int num_attr = 0;
               {
-                Ioss::SerializeIO serializeIO__(this);
+                Ioss::SerializeIO serializeio_(this);
                 int ierr = ex_get_attr_param(get_file_pointer(), EX_SIDE_SET, 1, &num_attr);
                 if (ierr < 0) {
                   Ioex::exodus_error(get_file_pointer(), __LINE__, __func__, __FILE__);
@@ -1870,7 +1870,7 @@ namespace Ioex {
       Ioss::IntVector   attributes(count);
       std::vector<T *>  Xsets(count);
       {
-        Ioss::SerializeIO serializeIO__(this);
+        Ioss::SerializeIO serializeio_(this);
         if (ex_int64_status(get_file_pointer()) & EX_IDS_INT64_API) {
           int error = ex_get_ids(get_file_pointer(), type, Xset_ids.data());
           if (error < 0) {
@@ -2016,7 +2016,7 @@ namespace Ioex {
     // nodesets, just return an empty container.
 
     if (isParallel || isSerialParallel) {
-      Ioss::SerializeIO serializeIO__(this);
+      Ioss::SerializeIO serializeio_(this);
       // This is a parallel run. There should be communications data
       // Get nemesis commset metadata
       int64_t my_node_count = 0;
@@ -2089,7 +2089,7 @@ namespace Ioex {
                                          void *data, size_t data_size) const
   {
     {
-      Ioss::SerializeIO serializeIO__(this);
+      Ioss::SerializeIO serializeio_(this);
 
       size_t num_to_get = field.verify(data_size);
       if (num_to_get > 0) {
@@ -2284,7 +2284,7 @@ namespace Ioex {
                                          void *data, size_t data_size) const
   {
     {
-      Ioss::SerializeIO serializeIO__(this);
+      Ioss::SerializeIO serializeio_(this);
 
       size_t num_to_get = field.verify(data_size);
       if (num_to_get > 0) {
@@ -2333,7 +2333,7 @@ namespace Ioex {
                                          void *data, size_t data_size) const
   {
     {
-      Ioss::SerializeIO serializeIO__(this);
+      Ioss::SerializeIO serializeio_(this);
 
       size_t num_to_get = field.verify(data_size);
       if (num_to_get > 0) {
@@ -2382,7 +2382,7 @@ namespace Ioex {
                                          void *data, size_t data_size) const
   {
     {
-      Ioss::SerializeIO serializeIO__(this);
+      Ioss::SerializeIO serializeio_(this);
 
       size_t num_to_get = field.verify(data_size);
       if (num_to_get > 0) {
@@ -2557,7 +2557,7 @@ namespace Ioex {
                                          void *data, size_t data_size) const
   {
     {
-      Ioss::SerializeIO serializeIO__(this);
+      Ioss::SerializeIO serializeio_(this);
 
       size_t num_to_get = field.verify(data_size);
       if (num_to_get > 0) {
@@ -2636,7 +2636,7 @@ namespace Ioex {
                                          void *data, size_t data_size) const
   {
     {
-      Ioss::SerializeIO serializeIO__(this);
+      Ioss::SerializeIO serializeio_(this);
 
       size_t num_to_get = field.verify(data_size);
       if (num_to_get > 0) {
@@ -2707,7 +2707,7 @@ namespace Ioex {
   {
     {
       int               ierr;
-      Ioss::SerializeIO serializeIO__(this);
+      Ioss::SerializeIO serializeio_(this);
 
       size_t num_to_get = field.verify(data_size);
       if (num_to_get > 0) {
@@ -2808,7 +2808,7 @@ namespace Ioex {
     size_t db_size = ns->get_property("filtered_db_set_size").get_int();
 
     int               ierr;
-    Ioss::SerializeIO serializeIO__(this);
+    Ioss::SerializeIO serializeio_(this);
 
     size_t num_to_get = field.verify(data_size);
     if (num_to_get > 0) {
@@ -2925,7 +2925,7 @@ namespace Ioex {
                                          void *data, size_t data_size) const
   {
     {
-      Ioss::SerializeIO serializeIO__(this);
+      Ioss::SerializeIO serializeio_(this);
 
       size_t num_to_get = field.verify(data_size);
 
@@ -3083,7 +3083,7 @@ namespace Ioex {
   int64_t DatabaseIO::get_field_internal(const Ioss::SideBlock *fb, const Ioss::Field &field,
                                          void *data, size_t data_size) const
   {
-    Ioss::SerializeIO serializeIO__(this);
+    Ioss::SerializeIO serializeio_(this);
     int64_t           num_to_get = field.verify(data_size);
     if (num_to_get > 0) {
 
@@ -4033,7 +4033,7 @@ namespace Ioex {
                                          void *data, size_t data_size) const
   {
     {
-      Ioss::SerializeIO serializeIO__(this);
+      Ioss::SerializeIO serializeio_(this);
 
       size_t num_to_get = field.verify(data_size);
       if (num_to_get > 0) {
@@ -4147,7 +4147,7 @@ namespace Ioex {
                                          void *data, size_t data_size) const
   {
     {
-      Ioss::SerializeIO serializeIO__(this);
+      Ioss::SerializeIO serializeio_(this);
 
       size_t num_to_get = field.verify(data_size);
       if (num_to_get > 0) {
@@ -4203,7 +4203,7 @@ namespace Ioex {
                                          void *data, size_t data_size) const
   {
     {
-      Ioss::SerializeIO serializeIO__(this);
+      Ioss::SerializeIO serializeio_(this);
 
       size_t num_to_get = field.verify(data_size);
       if (num_to_get > 0) {
@@ -4259,7 +4259,7 @@ namespace Ioex {
                                          void *data, size_t data_size) const
   {
     {
-      Ioss::SerializeIO serializeIO__(this);
+      Ioss::SerializeIO serializeio_(this);
 
       size_t num_to_get = field.verify(data_size);
 
@@ -4380,7 +4380,7 @@ namespace Ioex {
                                          void *data, size_t data_size) const
   {
     {
-      Ioss::SerializeIO serializeIO__(this);
+      Ioss::SerializeIO serializeio_(this);
 
       size_t num_to_get = field.verify(data_size);
 
@@ -4454,7 +4454,7 @@ namespace Ioex {
                                          void *data, size_t data_size) const
   {
     {
-      Ioss::SerializeIO serializeIO__(this);
+      Ioss::SerializeIO serializeio_(this);
 
       size_t num_to_get = field.verify(data_size);
 
@@ -4829,7 +4829,7 @@ namespace Ioex {
                                               void *data, size_t data_size) const
   {
     {
-      Ioss::SerializeIO serializeIO__(this);
+      Ioss::SerializeIO serializeio_(this);
       //    ex_update(get_file_pointer());
 
       size_t entity_count = ns->entity_count();
@@ -4939,7 +4939,7 @@ namespace Ioex {
       std::vector<char> procs(entity_count * int_byte_size_api());
 
       if (type == "node") {
-        Ioss::SerializeIO serializeIO__(this);
+        Ioss::SerializeIO serializeio_(this);
         // Convert global node id to local node id and store in 'entities'
         if (int_byte_size_api() == 4) {
           int *entity_proc = static_cast<int *>(data);
@@ -5008,7 +5008,7 @@ namespace Ioex {
         }
       }
       else if (type == "side") {
-        Ioss::SerializeIO serializeIO__(this);
+        Ioss::SerializeIO serializeio_(this);
         std::vector<char> sides(entity_count * int_byte_size_api());
         if (int_byte_size_api() == 4) {
           int *entity_proc = static_cast<int *>(data);
@@ -5095,7 +5095,7 @@ namespace Ioex {
   int64_t DatabaseIO::put_field_internal(const Ioss::SideBlock *fb, const Ioss::Field &field,
                                          void *data, size_t data_size) const
   {
-    Ioss::SerializeIO serializeIO__(this);
+    Ioss::SerializeIO serializeio_(this);
     size_t            num_to_get = field.verify(data_size);
     if (num_to_get > 0) {
 
@@ -5351,7 +5351,7 @@ namespace Ioex {
         mesh.full_nemesis_data = false;
       }
 
-      Ioss::SerializeIO serializeIO__(this);
+      Ioss::SerializeIO serializeio_(this);
       mesh.populate(region);
       gather_communication_metadata(&mesh.comm);
 

--- a/packages/seacas/libraries/ioss/src/exodus/Ioex_DatabaseIO.h
+++ b/packages/seacas/libraries/ioss/src/exodus/Ioex_DatabaseIO.h
@@ -71,7 +71,7 @@ namespace Ioex {
     int get_file_pointer() const override; // Open file and set exodusFilePtr.
 
   private:
-    void get_step_times__() override;
+    void get_step_times_nl() override;
 
     bool open_input_file(bool write_message, std::string *error_msg, int *bad_count,
                          bool abort_if_error) const override;
@@ -163,7 +163,7 @@ namespace Ioex {
     void compute_node_status() const;
 
     // Metadata-related functions.
-    void read_meta_data__() override;
+    void read_meta_data_nl() override;
     void read_communication_metadata();
 
     int64_t read_transient_field(const Ioex::VariableNameMap &variables, const Ioss::Field &field,

--- a/packages/seacas/libraries/ioss/src/exodus/Ioex_Internals.C
+++ b/packages/seacas/libraries/ioss/src/exodus/Ioex_Internals.C
@@ -595,12 +595,12 @@ int Internals::initialize_state_file(Mesh &mesh, const ex_var_params &var_params
       return (EX_FATAL);
     }
 
-    struct ex__file_item *file = ex__find_file_item(exodusFilePtr);
+    struct exi_file_item *file = exi_find_file_item(exodusFilePtr);
     if (file) {
       file->time_varid = varid;
     }
 
-    ex__compress_variable(exodusFilePtr, varid, -2); /* don't compress, but do set collective io */
+    exi_compress_variable(exodusFilePtr, varid, -2); /* don't compress, but do set collective io */
   }                                                  // Exit redefine mode
 
   bool output_global_data = (mesh.comm.outputNemesis && mesh.comm.processorCount > 1);
@@ -1165,12 +1165,12 @@ int Internals::put_metadata(const Mesh &mesh, const CommunicationMetaData &comm)
     return (EX_FATAL);
   }
   {
-    struct ex__file_item *file = ex__find_file_item(exodusFilePtr);
+    struct exi_file_item *file = exi_find_file_item(exodusFilePtr);
     if (file != nullptr) {
       file->time_varid = varid;
     }
   }
-  ex__compress_variable(exodusFilePtr, varid, -2);
+  exi_compress_variable(exodusFilePtr, varid, -2);
 
   if (!mesh.nodeblocks.empty() && mesh.nodeblocks[0].entityCount > 0) {
     status = nc_def_dim(exodusFilePtr, DIM_NUM_NODES, mesh.nodeblocks[0].entityCount, &numnoddim);
@@ -1200,7 +1200,7 @@ int Internals::put_metadata(const Mesh &mesh, const CommunicationMetaData &comm)
         }
         return (EX_FATAL);
       }
-      ex__compress_variable(exodusFilePtr, varid, 1);
+      exi_compress_variable(exodusFilePtr, varid, 1);
     }
   }
 
@@ -1229,7 +1229,7 @@ int Internals::put_metadata(const Mesh &mesh, const CommunicationMetaData &comm)
       ex_err_fn(exodusFilePtr, __func__, errmsg.c_str(), status);
       return (EX_FATAL);
     }
-    ex__compress_variable(exodusFilePtr, varid, 2);
+    exi_compress_variable(exodusFilePtr, varid, 2);
 
     // Attribute name array...
     dims[0] = numattrdim;
@@ -1245,7 +1245,7 @@ int Internals::put_metadata(const Mesh &mesh, const CommunicationMetaData &comm)
       ex_err_fn(exodusFilePtr, __func__, errmsg.c_str(), status);
       return (EX_FATAL);
     }
-    ex__set_compact_storage(exodusFilePtr, varid);
+    exi_set_compact_storage(exodusFilePtr, varid);
   }
 
   size_t elem_count = 0;
@@ -1283,7 +1283,7 @@ int Internals::put_metadata(const Mesh &mesh, const CommunicationMetaData &comm)
         }
         return (EX_FATAL);
       }
-      ex__compress_variable(exodusFilePtr, varid, 1);
+      exi_compress_variable(exodusFilePtr, varid, 1);
     }
   }
 
@@ -1322,7 +1322,7 @@ int Internals::put_metadata(const Mesh &mesh, const CommunicationMetaData &comm)
         }
         return (EX_FATAL);
       }
-      ex__compress_variable(exodusFilePtr, varid, 1);
+      exi_compress_variable(exodusFilePtr, varid, 1);
     }
   }
 
@@ -1361,7 +1361,7 @@ int Internals::put_metadata(const Mesh &mesh, const CommunicationMetaData &comm)
         }
         return (EX_FATAL);
       }
-      ex__compress_variable(exodusFilePtr, varid, 1);
+      exi_compress_variable(exodusFilePtr, varid, 1);
     }
   }
 
@@ -1464,10 +1464,10 @@ int Internals::put_metadata(const Mesh &mesh, const CommunicationMetaData &comm)
         return (EX_FATAL);
       }
     }
-    ex__set_compact_storage(exodusFilePtr, varid);
+    exi_set_compact_storage(exodusFilePtr, varid);
 
     // Output the file version
-    int ierr = ex__put_nemesis_version(exodusFilePtr);
+    int ierr = exi_put_nemesis_version(exodusFilePtr);
     if (ierr < 0) {
       return (ierr);
     }
@@ -1685,7 +1685,7 @@ int Internals::put_metadata(const std::vector<Assembly> &assemblies)
     return EX_NOERR;
   }
   int status;
-  if ((status = ex__check_valid_file_id(exodusFilePtr, __func__)) != EX_NOERR) {
+  if ((status = exi_check_valid_file_id(exodusFilePtr, __func__)) != EX_NOERR) {
     std::string errmsg = fmt::format("Error: Invalid exodus file handle: {}", exodusFilePtr);
     ex_err_fn(exodusFilePtr, __func__, errmsg.c_str(), status);
     return (EX_FATAL);
@@ -1720,7 +1720,7 @@ int Internals::put_metadata(const std::vector<Assembly> &assemblies)
       ex_err_fn(exodusFilePtr, __func__, errmsg.c_str(), status);
       return (EX_FATAL);
     }
-    ex__compress_variable(exodusFilePtr, entlst_id, 1);
+    exi_compress_variable(exodusFilePtr, entlst_id, 1);
 
     if (ex_int64_status(exodusFilePtr) & EX_IDS_INT64_DB) {
       long long tmp = assembly.id;
@@ -1772,7 +1772,7 @@ int Internals::put_metadata(const std::vector<Assembly> &assemblies)
     }
 
     /* Increment assembly count */
-    struct ex__file_item *file = ex__find_file_item(exodusFilePtr);
+    struct exi_file_item *file = exi_find_file_item(exodusFilePtr);
     if (file != nullptr) {
       file->assembly_count++;
     }
@@ -1822,7 +1822,7 @@ int Internals::put_metadata(const std::vector<Blob> &blobs)
       ex_err_fn(exodusFilePtr, __func__, errmsg.c_str(), status);
       return (EX_FATAL);
     }
-    ex__set_compact_storage(exodusFilePtr, entlst);
+    exi_set_compact_storage(exodusFilePtr, entlst);
 
     if (ex_int64_status(exodusFilePtr) & EX_IDS_INT64_DB) {
       long long tmp = blob.id;
@@ -1895,7 +1895,7 @@ int Internals::put_metadata(const std::vector<ElemBlock> &blocks, bool count_onl
 
   // Iterate over blocks ...
   for (size_t iblk = 0; iblk < num_elem_blk; iblk++) {
-    ex__inc_file_item(exodusFilePtr, ex__get_counter_list(EX_ELEM_BLOCK));
+    exi_inc_file_item(exodusFilePtr, exi_get_counter_list(EX_ELEM_BLOCK));
 
     if (blocks[iblk].entityCount == 0) {
       continue;
@@ -1952,7 +1952,7 @@ int Internals::put_metadata(const std::vector<ElemBlock> &blocks, bool count_onl
         ex_err_fn(exodusFilePtr, __func__, errmsg.c_str(), status);
         return (EX_FATAL);
       }
-      ex__compress_variable(exodusFilePtr, connid, 1);
+      exi_compress_variable(exodusFilePtr, connid, 1);
 
       // store element type as attribute of connectivity variable
       status = nc_put_att_text(exodusFilePtr, connid, ATT_NAME_ELB,
@@ -1996,7 +1996,7 @@ int Internals::put_metadata(const std::vector<ElemBlock> &blocks, bool count_onl
         ex_err_fn(exodusFilePtr, __func__, errmsg.c_str(), status);
         return (EX_FATAL);
       }
-      ex__compress_variable(exodusFilePtr, connid, 1);
+      exi_compress_variable(exodusFilePtr, connid, 1);
     }
 
     if (blocks[iblk].facesPerEntity > 0) {
@@ -2027,7 +2027,7 @@ int Internals::put_metadata(const std::vector<ElemBlock> &blocks, bool count_onl
         ex_err_fn(exodusFilePtr, __func__, errmsg.c_str(), status);
         return (EX_FATAL);
       }
-      ex__compress_variable(exodusFilePtr, connid, 1);
+      exi_compress_variable(exodusFilePtr, connid, 1);
     }
 
     // element attribute array
@@ -2058,7 +2058,7 @@ int Internals::put_metadata(const std::vector<ElemBlock> &blocks, bool count_onl
           ex_err_fn(exodusFilePtr, __func__, errmsg.c_str(), status);
           return (EX_FATAL);
         }
-        ex__compress_variable(exodusFilePtr, varid, 2);
+        exi_compress_variable(exodusFilePtr, varid, 2);
 
 #if defined(PARALLEL_AWARE_EXODUS)
         // There is currently a bug in netcdf-4.5.1-devel and earlier
@@ -2066,7 +2066,7 @@ int Internals::put_metadata(const std::vector<ElemBlock> &blocks, bool count_onl
         // mode for netcdf-4-based output.  If the number of attributes >
         // 1 and in parallel mode, set the mode to independent.
         if (blocks[iblk].attributeCount > 1) {
-          struct ex__file_item *file = ex__find_file_item(exodusFilePtr);
+          struct exi_file_item *file = exi_find_file_item(exodusFilePtr);
           if (file && file->is_parallel && file->is_hdf5) {
             nc_var_par_access(exodusFilePtr, varid, NC_INDEPENDENT);
           }
@@ -2089,7 +2089,7 @@ int Internals::put_metadata(const std::vector<ElemBlock> &blocks, bool count_onl
           ex_err_fn(exodusFilePtr, __func__, errmsg.c_str(), status);
           return (EX_FATAL);
         }
-        ex__set_compact_storage(exodusFilePtr, varid);
+        exi_set_compact_storage(exodusFilePtr, varid);
       }
     }
   }
@@ -2140,7 +2140,7 @@ int Internals::put_metadata(const std::vector<FaceBlock> &blocks, bool count_onl
 
   // Iterate over blocks ...
   for (size_t iblk = 0; iblk < num_face_blk; iblk++) {
-    ex__inc_file_item(exodusFilePtr, ex__get_counter_list(EX_FACE_BLOCK));
+    exi_inc_file_item(exodusFilePtr, exi_get_counter_list(EX_FACE_BLOCK));
 
     if (blocks[iblk].entityCount == 0) {
       continue;
@@ -2210,7 +2210,7 @@ int Internals::put_metadata(const std::vector<FaceBlock> &blocks, bool count_onl
           ex_err_fn(exodusFilePtr, __func__, errmsg.c_str(), status);
           return (EX_FATAL);
         }
-        ex__compress_variable(exodusFilePtr, varid, 2);
+        exi_compress_variable(exodusFilePtr, varid, 2);
       }
       {
         // Attribute name array...
@@ -2228,7 +2228,7 @@ int Internals::put_metadata(const std::vector<FaceBlock> &blocks, bool count_onl
           ex_err_fn(exodusFilePtr, __func__, errmsg.c_str(), status);
           return (EX_FATAL);
         }
-        ex__set_compact_storage(exodusFilePtr, varid);
+        exi_set_compact_storage(exodusFilePtr, varid);
       }
     }
 
@@ -2245,7 +2245,7 @@ int Internals::put_metadata(const std::vector<FaceBlock> &blocks, bool count_onl
         ex_err_fn(exodusFilePtr, __func__, errmsg.c_str(), status);
         return (EX_FATAL);
       }
-      ex__compress_variable(exodusFilePtr, connid, 1);
+      exi_compress_variable(exodusFilePtr, connid, 1);
 
       // store element type as attribute of connectivity variable
       status = nc_put_att_text(exodusFilePtr, connid, ATT_NAME_ELB,
@@ -2304,7 +2304,7 @@ int Internals::put_metadata(const std::vector<EdgeBlock> &blocks, bool count_onl
 
   // Iterate over blocks ...
   for (size_t iblk = 0; iblk < num_edge_blk; iblk++) {
-    ex__inc_file_item(exodusFilePtr, ex__get_counter_list(EX_EDGE_BLOCK));
+    exi_inc_file_item(exodusFilePtr, exi_get_counter_list(EX_EDGE_BLOCK));
 
     if (blocks[iblk].entityCount == 0) {
       continue;
@@ -2374,7 +2374,7 @@ int Internals::put_metadata(const std::vector<EdgeBlock> &blocks, bool count_onl
         ex_err_fn(exodusFilePtr, __func__, errmsg.c_str(), status);
         return (EX_FATAL);
       }
-      ex__compress_variable(exodusFilePtr, varid, 2);
+      exi_compress_variable(exodusFilePtr, varid, 2);
 
       // Attribute name array...
       dims[0] = numattrdim;
@@ -2391,7 +2391,7 @@ int Internals::put_metadata(const std::vector<EdgeBlock> &blocks, bool count_onl
         ex_err_fn(exodusFilePtr, __func__, errmsg.c_str(), status);
         return (EX_FATAL);
       }
-      ex__set_compact_storage(exodusFilePtr, varid);
+      exi_set_compact_storage(exodusFilePtr, varid);
     }
 
     // edge connectivity array
@@ -2408,7 +2408,7 @@ int Internals::put_metadata(const std::vector<EdgeBlock> &blocks, bool count_onl
       ex_err_fn(exodusFilePtr, __func__, errmsg.c_str(), status);
       return (EX_FATAL);
     }
-    ex__compress_variable(exodusFilePtr, connid, 1);
+    exi_compress_variable(exodusFilePtr, connid, 1);
 
     // store element type as attribute of connectivity variable
     status = nc_put_att_text(exodusFilePtr, connid, ATT_NAME_ELB,
@@ -2661,7 +2661,7 @@ int Internals::put_non_define_data(const std::vector<Blob> &blobs)
       return (EX_FATAL);
     }
   }
-  ex__update_max_name_length(exodusFilePtr, name_length);
+  exi_update_max_name_length(exodusFilePtr, name_length);
   return EX_NOERR;
 }
 
@@ -2693,7 +2693,7 @@ int Internals::put_non_define_data(const std::vector<Assembly> &assemblies)
       }
     }
   }
-  ex__update_max_name_length(exodusFilePtr, name_length);
+  exi_update_max_name_length(exodusFilePtr, name_length);
   return EX_NOERR;
 }
 
@@ -2911,9 +2911,9 @@ int Internals::put_metadata(const std::vector<NodeSet> &nodesets, bool count_onl
 
   for (int i = 0; i < num_node_sets; i++) {
 
-    //  NOTE: ex__inc_file_item is used to find the number of node sets
+    //  NOTE: exi_inc_file_item is used to find the number of node sets
     // for a specific file and returns that value incremented.
-    int cur_num_node_sets = ex__inc_file_item(exodusFilePtr, ex__get_counter_list(EX_NODE_SET));
+    int cur_num_node_sets = exi_inc_file_item(exodusFilePtr, exi_get_counter_list(EX_NODE_SET));
 
     if (nodesets[i].entityCount == 0) {
       continue;
@@ -2961,7 +2961,7 @@ int Internals::put_metadata(const std::vector<NodeSet> &nodesets, bool count_onl
       }
       return (EX_FATAL);
     }
-    ex__compress_variable(exodusFilePtr, varid, 1);
+    exi_compress_variable(exodusFilePtr, varid, 1);
 
     // Create variable for distribution factors if required
     if (nodesets[i].dfCount > 0) {
@@ -2995,7 +2995,7 @@ int Internals::put_metadata(const std::vector<NodeSet> &nodesets, bool count_onl
         }
         return (EX_FATAL);
       }
-      ex__compress_variable(exodusFilePtr, varid, 2);
+      exi_compress_variable(exodusFilePtr, varid, 2);
     }
 
     if (nodesets[i].attributeCount > 0) {
@@ -3025,7 +3025,7 @@ int Internals::put_metadata(const std::vector<NodeSet> &nodesets, bool count_onl
           ex_err_fn(exodusFilePtr, __func__, errmsg.c_str(), status);
           return (EX_FATAL);
         }
-        ex__compress_variable(exodusFilePtr, varid, 2);
+        exi_compress_variable(exodusFilePtr, varid, 2);
       }
 
       {
@@ -3043,7 +3043,7 @@ int Internals::put_metadata(const std::vector<NodeSet> &nodesets, bool count_onl
           ex_err_fn(exodusFilePtr, __func__, errmsg.c_str(), status);
           return (EX_FATAL);
         }
-        ex__set_compact_storage(exodusFilePtr, varid);
+        exi_set_compact_storage(exodusFilePtr, varid);
       }
     }
   }
@@ -3093,9 +3093,9 @@ int Internals::put_metadata(const std::vector<EdgeSet> &edgesets, bool count_onl
 
   for (int i = 0; i < num_edge_sets; i++) {
 
-    //  NOTE: ex__inc_file_item is used to find the number of edge sets
+    //  NOTE: exi_inc_file_item is used to find the number of edge sets
     // for a specific file and returns that value incremented.
-    int cur_num_edge_sets = ex__inc_file_item(exodusFilePtr, ex__get_counter_list(EX_EDGE_SET));
+    int cur_num_edge_sets = exi_inc_file_item(exodusFilePtr, exi_get_counter_list(EX_EDGE_SET));
 
     if (edgesets[i].entityCount == 0) {
       continue;
@@ -3143,7 +3143,7 @@ int Internals::put_metadata(const std::vector<EdgeSet> &edgesets, bool count_onl
       }
       return (EX_FATAL);
     }
-    ex__compress_variable(exodusFilePtr, varid, 1);
+    exi_compress_variable(exodusFilePtr, varid, 1);
 
     // Orientation variable
     status = nc_def_var(exodusFilePtr, VAR_ORNT_ES(cur_num_edge_sets + 1), bulk_type, 1,
@@ -3164,7 +3164,7 @@ int Internals::put_metadata(const std::vector<EdgeSet> &edgesets, bool count_onl
       }
       return (EX_FATAL);
     }
-    ex__compress_variable(exodusFilePtr, varid, 1);
+    exi_compress_variable(exodusFilePtr, varid, 1);
 
     // Create variable for distribution factors if required
     if (edgesets[i].dfCount > 0) {
@@ -3198,7 +3198,7 @@ int Internals::put_metadata(const std::vector<EdgeSet> &edgesets, bool count_onl
         }
         return (EX_FATAL);
       }
-      ex__compress_variable(exodusFilePtr, varid, 2);
+      exi_compress_variable(exodusFilePtr, varid, 2);
     }
     if (edgesets[i].attributeCount > 0) {
       int numattrdim;
@@ -3227,7 +3227,7 @@ int Internals::put_metadata(const std::vector<EdgeSet> &edgesets, bool count_onl
           ex_err_fn(exodusFilePtr, __func__, errmsg.c_str(), status);
           return (EX_FATAL);
         }
-        ex__compress_variable(exodusFilePtr, varid, 2);
+        exi_compress_variable(exodusFilePtr, varid, 2);
       }
 
       {
@@ -3245,7 +3245,7 @@ int Internals::put_metadata(const std::vector<EdgeSet> &edgesets, bool count_onl
           ex_err_fn(exodusFilePtr, __func__, errmsg.c_str(), status);
           return (EX_FATAL);
         }
-        ex__set_compact_storage(exodusFilePtr, varid);
+        exi_set_compact_storage(exodusFilePtr, varid);
       }
     }
   }
@@ -3295,9 +3295,9 @@ int Internals::put_metadata(const std::vector<FaceSet> &facesets, bool count_onl
 
   for (int i = 0; i < num_face_sets; i++) {
 
-    //  NOTE: ex__inc_file_item is used to find the number of face sets
+    //  NOTE: exi_inc_file_item is used to find the number of face sets
     // for a specific file and returns that value incremented.
-    int cur_num_face_sets = ex__inc_file_item(exodusFilePtr, ex__get_counter_list(EX_FACE_SET));
+    int cur_num_face_sets = exi_inc_file_item(exodusFilePtr, exi_get_counter_list(EX_FACE_SET));
 
     if (facesets[i].entityCount == 0) {
       continue;
@@ -3345,7 +3345,7 @@ int Internals::put_metadata(const std::vector<FaceSet> &facesets, bool count_onl
       }
       return (EX_FATAL);
     }
-    ex__compress_variable(exodusFilePtr, varid, 1);
+    exi_compress_variable(exodusFilePtr, varid, 1);
 
     // Orientation variable
     status = nc_def_var(exodusFilePtr, VAR_ORNT_FS(cur_num_face_sets + 1), bulk_type, 1,
@@ -3366,7 +3366,7 @@ int Internals::put_metadata(const std::vector<FaceSet> &facesets, bool count_onl
       }
       return (EX_FATAL);
     }
-    ex__compress_variable(exodusFilePtr, varid, 1);
+    exi_compress_variable(exodusFilePtr, varid, 1);
 
     // Create variable for distribution factors if required
     if (facesets[i].dfCount > 0) {
@@ -3400,7 +3400,7 @@ int Internals::put_metadata(const std::vector<FaceSet> &facesets, bool count_onl
         }
         return (EX_FATAL);
       }
-      ex__compress_variable(exodusFilePtr, varid, 2);
+      exi_compress_variable(exodusFilePtr, varid, 2);
     }
     if (facesets[i].attributeCount > 0) {
       int numattrdim;
@@ -3429,7 +3429,7 @@ int Internals::put_metadata(const std::vector<FaceSet> &facesets, bool count_onl
           ex_err_fn(exodusFilePtr, __func__, errmsg.c_str(), status);
           return (EX_FATAL);
         }
-        ex__compress_variable(exodusFilePtr, varid, 2);
+        exi_compress_variable(exodusFilePtr, varid, 2);
       }
 
       {
@@ -3447,7 +3447,7 @@ int Internals::put_metadata(const std::vector<FaceSet> &facesets, bool count_onl
           ex_err_fn(exodusFilePtr, __func__, errmsg.c_str(), status);
           return (EX_FATAL);
         }
-        ex__set_compact_storage(exodusFilePtr, varid);
+        exi_set_compact_storage(exodusFilePtr, varid);
       }
     }
   }
@@ -3496,9 +3496,9 @@ int Internals::put_metadata(const std::vector<ElemSet> &elemsets, bool count_onl
 
   for (int i = 0; i < num_elem_sets; i++) {
 
-    //  NOTE: ex__inc_file_item is used to find the number of elem sets
+    //  NOTE: exi_inc_file_item is used to find the number of elem sets
     // for a specific file and returns that value incremented.
-    int cur_num_elem_sets = ex__inc_file_item(exodusFilePtr, ex__get_counter_list(EX_ELEM_SET));
+    int cur_num_elem_sets = exi_inc_file_item(exodusFilePtr, exi_get_counter_list(EX_ELEM_SET));
 
     if (elemsets[i].entityCount == 0) {
       continue;
@@ -3547,7 +3547,7 @@ int Internals::put_metadata(const std::vector<ElemSet> &elemsets, bool count_onl
       }
       return (EX_FATAL);
     }
-    ex__compress_variable(exodusFilePtr, varid, 1);
+    exi_compress_variable(exodusFilePtr, varid, 1);
 
     // Create variable for distribution factors if required
     if (elemsets[i].dfCount > 0) {
@@ -3581,7 +3581,7 @@ int Internals::put_metadata(const std::vector<ElemSet> &elemsets, bool count_onl
         }
         return (EX_FATAL);
       }
-      ex__compress_variable(exodusFilePtr, varid, 2);
+      exi_compress_variable(exodusFilePtr, varid, 2);
     }
     if (elemsets[i].attributeCount > 0) {
       int numattrdim;
@@ -3610,7 +3610,7 @@ int Internals::put_metadata(const std::vector<ElemSet> &elemsets, bool count_onl
           ex_err_fn(exodusFilePtr, __func__, errmsg.c_str(), status);
           return (EX_FATAL);
         }
-        ex__compress_variable(exodusFilePtr, varid, 2);
+        exi_compress_variable(exodusFilePtr, varid, 2);
       }
 
       {
@@ -3628,7 +3628,7 @@ int Internals::put_metadata(const std::vector<ElemSet> &elemsets, bool count_onl
           ex_err_fn(exodusFilePtr, __func__, errmsg.c_str(), status);
           return (EX_FATAL);
         }
-        ex__set_compact_storage(exodusFilePtr, varid);
+        exi_set_compact_storage(exodusFilePtr, varid);
       }
     }
   }
@@ -3802,9 +3802,9 @@ int Internals::put_metadata(const std::vector<SideSet> &sidesets, bool count_onl
 
   for (int i = 0; i < num_side_sets; i++) {
 
-    //  NOTE: ex__inc_file_item is used to find the number of side sets
+    //  NOTE: exi_inc_file_item is used to find the number of side sets
     // for a specific file and returns that value incremented.
-    int cur_num_side_sets = ex__inc_file_item(exodusFilePtr, ex__get_counter_list(EX_SIDE_SET));
+    int cur_num_side_sets = exi_inc_file_item(exodusFilePtr, exi_get_counter_list(EX_SIDE_SET));
 
     if (sidesets[i].entityCount == 0) {
       continue;
@@ -3851,7 +3851,7 @@ int Internals::put_metadata(const std::vector<SideSet> &sidesets, bool count_onl
       }
       return (EX_FATAL);
     }
-    ex__compress_variable(exodusFilePtr, varid, 1);
+    exi_compress_variable(exodusFilePtr, varid, 1);
 
     // create side list variable for side set
     status = nc_def_var(exodusFilePtr, VAR_SIDE_SS(cur_num_side_sets + 1), bulk_type, 1,
@@ -3872,7 +3872,7 @@ int Internals::put_metadata(const std::vector<SideSet> &sidesets, bool count_onl
       }
       return (EX_FATAL);
     }
-    ex__compress_variable(exodusFilePtr, varid, 1);
+    exi_compress_variable(exodusFilePtr, varid, 1);
 
     // Create variable for distribution factors if required
     if (sidesets[i].dfCount > 0) {
@@ -3917,7 +3917,7 @@ int Internals::put_metadata(const std::vector<SideSet> &sidesets, bool count_onl
         return (EX_FATAL);
       }
     }
-    ex__compress_variable(exodusFilePtr, varid, 2);
+    exi_compress_variable(exodusFilePtr, varid, 2);
   }
   return (EX_NOERR);
 }
@@ -4004,7 +4004,7 @@ namespace {
         return (EX_FATAL);
       }
     }
-    ex__compress_variable(exodusFilePtr, *varid, 1);
+    exi_compress_variable(exodusFilePtr, *varid, 1);
     return (EX_NOERR);
   }
 
@@ -4032,7 +4032,7 @@ namespace {
         ex_err_fn(exodusFilePtr, __func__, errmsg.c_str(), status);
         return (EX_FATAL);
       }
-      ex__compress_variable(exodusFilePtr, varid, 1);
+      exi_compress_variable(exodusFilePtr, varid, 1);
     }
     return (EX_NOERR);
   }
@@ -4062,7 +4062,7 @@ namespace {
           ex_err_fn(exodusFilePtr, __func__, errmsg.c_str(), status);
           return (EX_FATAL);
         }
-        ex__set_compact_storage(exodusFilePtr, varid);
+        exi_set_compact_storage(exodusFilePtr, varid);
         i++;
       }
     }
@@ -4171,7 +4171,7 @@ namespace {
           ex_err_fn(exodusFilePtr, __func__, errmsg.c_str(), status);
           return (EX_FATAL);
         }
-        ex__compress_variable(exodusFilePtr, varid, 2);
+        exi_compress_variable(exodusFilePtr, varid, 2);
       }
 
       if (dimension > 1) {
@@ -4184,7 +4184,7 @@ namespace {
           ex_err_fn(exodusFilePtr, __func__, errmsg.c_str(), status);
           return (EX_FATAL);
         }
-        ex__compress_variable(exodusFilePtr, varid, 2);
+        exi_compress_variable(exodusFilePtr, varid, 2);
       }
 
       if (dimension > 2) {
@@ -4197,7 +4197,7 @@ namespace {
           ex_err_fn(exodusFilePtr, __func__, errmsg.c_str(), status);
           return (EX_FATAL);
         }
-        ex__compress_variable(exodusFilePtr, varid, 2);
+        exi_compress_variable(exodusFilePtr, varid, 2);
       }
     }
 
@@ -4212,7 +4212,7 @@ namespace {
       ex_err_fn(exodusFilePtr, __func__, errmsg.c_str(), status);
       return (EX_FATAL);
     }
-    ex__set_compact_storage(exodusFilePtr, varid);
+    exi_set_compact_storage(exodusFilePtr, varid);
     return (EX_NOERR);
   }
 
@@ -4255,7 +4255,7 @@ namespace {
       return (EX_FATAL);
     }
     if (count * 4 < sixty_four_kb) {
-      ex__set_compact_storage(exoid, varid);
+      exi_set_compact_storage(exoid, varid);
     }
 
     // id array:
@@ -4270,7 +4270,7 @@ namespace {
       return (EX_FATAL);
     }
     if (count * ids_size < sixty_four_kb) {
-      ex__set_compact_storage(exoid, varid);
+      exi_set_compact_storage(exoid, varid);
     }
 
     // store property name as attribute of property array variable
@@ -4293,7 +4293,7 @@ namespace {
         ex_err_fn(exoid, __func__, errmsg.c_str(), status);
         return (EX_FATAL);
       }
-      ex__set_compact_storage(exoid, varid);
+      exi_set_compact_storage(exoid, varid);
     }
     return (EX_NOERR);
   }

--- a/packages/seacas/libraries/ioss/src/exodus/Ioex_ParallelDatabaseIO.C
+++ b/packages/seacas/libraries/ioss/src/exodus/Ioex_ParallelDatabaseIO.C
@@ -395,7 +395,7 @@ namespace Ioex {
 
   ParallelDatabaseIO::~ParallelDatabaseIO() = default;
 
-  void ParallelDatabaseIO::release_memory__()
+  void ParallelDatabaseIO::release_memory_nl()
   {
     free_file_pointer();
     nodeMap.release_memory();
@@ -612,7 +612,7 @@ namespace Ioex {
 
     MPI_Info info        = MPI_INFO_NULL;
     int      app_opt_val = ex_opts(EX_VERBOSE);
-    Ioss::DatabaseIO::openDatabase__();
+    Ioss::DatabaseIO::openDatabase_nl();
 
     std::string filename = get_dw_name();
 
@@ -755,7 +755,7 @@ namespace Ioex {
     return Ioex::BaseDatabaseIO::free_file_pointer();
   }
 
-  void ParallelDatabaseIO::read_meta_data__()
+  void ParallelDatabaseIO::read_meta_data_nl()
   {
     int exoid = get_file_pointer(); // get_file_pointer() must be called first.
 
@@ -768,7 +768,7 @@ namespace Ioex {
     // we don't write anything since it is already there.  We do
     // need the number of steps though...
     if (open_create_behavior() == Ioss::DB_APPEND || dbUsage == Ioss::QUERY_TIMESTEPS_ONLY) {
-      get_step_times__();
+      get_step_times_nl();
       return;
     }
 
@@ -784,7 +784,7 @@ namespace Ioex {
     read_region();
     get_elemblocks();
 
-    get_step_times__();
+    get_step_times_nl();
 
     get_nodeblocks();
     get_edgeblocks();
@@ -903,7 +903,7 @@ namespace Ioex {
     }
   }
 
-  void ParallelDatabaseIO::get_step_times__()
+  void ParallelDatabaseIO::get_step_times_nl()
   {
     double              last_time      = DBL_MAX;
     int                 timestep_count = 0;
@@ -2046,7 +2046,7 @@ namespace Ioex {
                                                  void *data, size_t data_size) const
   {
     {
-      Ioss::SerializeIO serializeIO__(this);
+      Ioss::SerializeIO serializeIO_(this);
 
       size_t num_to_get = field.verify(data_size);
       if (num_to_get > 0) {
@@ -2096,7 +2096,7 @@ namespace Ioex {
                                                  size_t data_size) const
   {
     {
-      Ioss::SerializeIO serializeIO__(this);
+      Ioss::SerializeIO serializeIO_(this);
 
       size_t num_to_get = field.verify(data_size);
       if (num_to_get > 0) {
@@ -3729,7 +3729,7 @@ namespace Ioex {
                                                  void *data, size_t data_size) const
   {
     {
-      Ioss::SerializeIO serializeIO__(this);
+      Ioss::SerializeIO serializeIO_(this);
 
       size_t num_to_get = field.verify(data_size);
       if (num_to_get > 0) {
@@ -3786,7 +3786,7 @@ namespace Ioex {
                                                  size_t data_size) const
   {
     {
-      Ioss::SerializeIO serializeIO__(this);
+      Ioss::SerializeIO serializeIO_(this);
 
       size_t num_to_get = field.verify(data_size);
       if (num_to_get > 0) {

--- a/packages/seacas/libraries/ioss/src/exodus/Ioex_ParallelDatabaseIO.h
+++ b/packages/seacas/libraries/ioss/src/exodus/Ioex_ParallelDatabaseIO.h
@@ -1,4 +1,4 @@
-// Copyright(C) 1999-2022 National Technology & Engineering Solutions
+// Copyright(C) 1999-2023 National Technology & Engineering Solutions
 // of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
 // NTESS, the U.S. Government retains certain rights in this software.
 //
@@ -83,9 +83,9 @@ namespace Ioex {
   private:
     void compute_node_status() const;
 
-    void release_memory__() override;
+    void release_memory_nl() override;
 
-    void get_step_times__() override;
+    void get_step_times_nl() override;
 
     bool open_input_file(bool write_message, std::string *error_msg, int *bad_count,
                          bool abort_if_error) const override;
@@ -177,7 +177,7 @@ namespace Ioex {
     void output_node_map() const;
 
     // Metadata-related functions.
-    void read_meta_data__() override;
+    void read_meta_data_nl() override;
 
     int64_t read_transient_field(const Ioex::VariableNameMap &variables, const Ioss::Field &field,
                                  const Ioss::GroupingEntity *ge, void *data) const;

--- a/packages/seacas/libraries/ioss/src/exonull/Ioexnl_BaseDatabaseIO.C
+++ b/packages/seacas/libraries/ioss/src/exonull/Ioexnl_BaseDatabaseIO.C
@@ -220,7 +220,7 @@ namespace Ioexnl {
 
   int BaseDatabaseIO::free_file_pointer() const { return 0; }
 
-  bool BaseDatabaseIO::ok__(bool, std::string *, int *) const { return true; }
+  bool BaseDatabaseIO::ok_nl(bool, std::string *, int *) const { return true; }
 
   // common
   void BaseDatabaseIO::put_qa()
@@ -433,8 +433,8 @@ namespace Ioexnl {
   }
 
   // common
-  void BaseDatabaseIO::compute_block_membership__(Ioss::SideBlock          *efblock,
-                                                  std::vector<std::string> &block_membership) const
+  void BaseDatabaseIO::compute_block_membership_nl(Ioss::SideBlock          *efblock,
+                                                   std::vector<std::string> &block_membership) const
   {
     const Ioss::ElementBlockContainer &element_blocks = get_region()->get_element_blocks();
     assert(Ioss::Utils::check_block_order(element_blocks));
@@ -702,14 +702,14 @@ namespace Ioexnl {
   void BaseDatabaseIO::write_reduction_fields() const {}
 
   // common
-  bool BaseDatabaseIO::begin__(Ioss::State state)
+  bool BaseDatabaseIO::begin_nl(Ioss::State state)
   {
     dbState = state;
     return true;
   }
 
   // common
-  bool BaseDatabaseIO::end__(Ioss::State state)
+  bool BaseDatabaseIO::end_nl(Ioss::State state)
   {
     // Transitioning out of state 'state'
     assert(state == dbState);
@@ -740,7 +740,7 @@ namespace Ioexnl {
     return true;
   }
 
-  bool BaseDatabaseIO::begin_state__(int, double)
+  bool BaseDatabaseIO::begin_state_nl(int, double)
   {
     if (!is_input()) {
       // Zero global variable array...
@@ -756,7 +756,7 @@ namespace Ioexnl {
   }
 
   // common
-  bool BaseDatabaseIO::end_state__(int state, double time)
+  bool BaseDatabaseIO::end_state_nl(int state, double time)
   {
     if (!is_input()) {
       write_reduction_fields();
@@ -1052,7 +1052,7 @@ namespace Ioexnl {
   }
 
   // common
-  void BaseDatabaseIO::flush_database__() const {}
+  void BaseDatabaseIO::flush_database_nl() const {}
 
   void BaseDatabaseIO::finalize_write(int, double) {}
 

--- a/packages/seacas/libraries/ioss/src/exonull/Ioexnl_BaseDatabaseIO.h
+++ b/packages/seacas/libraries/ioss/src/exonull/Ioexnl_BaseDatabaseIO.h
@@ -98,17 +98,17 @@ namespace Ioexnl {
     // If 'error_message' non-null, then put the warning message into the string and return it.
     // If 'bad_count' non-null, it counts the number of processors where the file does not exist.
     //    if ok returns false, but *bad_count==0, then the routine does not support this argument.
-    bool ok__(bool write_message = false, std::string *error_message = nullptr,
-              int *bad_count = nullptr) const override;
+    bool ok_nl(bool write_message = false, std::string *error_message = nullptr,
+               int *bad_count = nullptr) const override;
 
-    bool begin__(Ioss::State state) override;
-    bool end__(Ioss::State state) override;
+    bool begin_nl(Ioss::State state) override;
+    bool end_nl(Ioss::State state) override;
 
     void open_state_file(int state);
 
-    bool begin_state__(int state, double time) override;
-    bool end_state__(int state, double time) override;
-    void get_step_times__() override = 0;
+    bool begin_state_nl(int state, double time) override;
+    bool end_state_nl(int state, double time) override;
+    void get_step_times_nl() override = 0;
 
     int maximum_symbol_length() const override { return maximumNameLength; }
 
@@ -125,8 +125,8 @@ namespace Ioexnl {
                             Ioss::Map &entity_map, void *ids, size_t num_to_get,
                             size_t offset) const;
 
-    void compute_block_membership__(Ioss::SideBlock          *efblock,
-                                    std::vector<std::string> &block_membership) const override;
+    void compute_block_membership_nl(Ioss::SideBlock          *efblock,
+                                     std::vector<std::string> &block_membership) const override;
 
     int  int_byte_size_db() const override;
     void set_int_byte_size_api(Ioss::DataSize size) const override;
@@ -181,9 +181,9 @@ namespace Ioexnl {
     virtual void write_meta_data(Ioss::IfDatabaseExistsBehavior behavior) = 0;
     void         write_results_metadata(bool gather_data, Ioss::IfDatabaseExistsBehavior behavior);
 
-    void openDatabase__() const override { get_file_pointer(); }
+    void openDatabase_nl() const override { get_file_pointer(); }
 
-    void closeDatabase__() const override
+    void closeDatabase_nl() const override
     {
       free_file_pointer();
       close_dw();
@@ -243,7 +243,7 @@ namespace Ioexnl {
     // Given the global region step, return the step on the database...
     int get_database_step(int global_step) const;
 
-    void flush_database__() const override;
+    void flush_database_nl() const override;
     void finalize_write(int state, double sim_time);
 
     mutable int m_exodusFilePtr{-1};

--- a/packages/seacas/libraries/ioss/src/exonull/Ioexnl_DatabaseIO.C
+++ b/packages/seacas/libraries/ioss/src/exonull/Ioexnl_DatabaseIO.C
@@ -120,11 +120,11 @@ namespace Ioexnl {
 
   int DatabaseIO::get_file_pointer() const { return 0; }
 
-  void DatabaseIO::read_meta_data__() {}
+  void DatabaseIO::read_meta_data_nl() {}
 
   void DatabaseIO::read_region() {}
 
-  void DatabaseIO::get_step_times__() {}
+  void DatabaseIO::get_step_times_nl() {}
 
   int64_t DatabaseIO::write_attribute_field(const Ioss::Field          &field,
                                             const Ioss::GroupingEntity *ge, void *data) const

--- a/packages/seacas/libraries/ioss/src/exonull/Ioexnl_DatabaseIO.h
+++ b/packages/seacas/libraries/ioss/src/exonull/Ioexnl_DatabaseIO.h
@@ -71,7 +71,7 @@ namespace Ioexnl {
     int get_file_pointer() const override; // Open file and set exodusFilePtr.
 
   private:
-    void get_step_times__() override;
+    void get_step_times_nl() override;
 
     bool handle_output_file(bool write_message, std::string *error_msg, int *bad_count,
                             bool overwrite, bool abort_if_error) const override;
@@ -124,7 +124,7 @@ namespace Ioexnl {
     void compute_node_status() const;
 
     // Metadata-related functions.
-    void read_meta_data__() override;
+    void read_meta_data_nl() override;
     void read_communication_metadata();
 
     int64_t read_transient_field(const Ioexnl::VariableNameMap &variables, const Ioss::Field &field,

--- a/packages/seacas/libraries/ioss/src/exonull/Ioexnl_ParallelDatabaseIO.C
+++ b/packages/seacas/libraries/ioss/src/exonull/Ioexnl_ParallelDatabaseIO.C
@@ -296,7 +296,7 @@ namespace Ioexnl {
 
   ParallelDatabaseIO::~ParallelDatabaseIO() = default;
 
-  void ParallelDatabaseIO::release_memory__()
+  void ParallelDatabaseIO::release_memory_nl()
   {
     free_file_pointer();
     nodeMap.release_memory();
@@ -338,7 +338,7 @@ namespace Ioexnl {
     return Ioexnl::BaseDatabaseIO::free_file_pointer();
   }
 
-  void ParallelDatabaseIO::read_meta_data__() {}
+  void ParallelDatabaseIO::read_meta_data_nl() {}
 
   int64_t ParallelDatabaseIO::write_attribute_field(const Ioss::Field          &field,
                                                     const Ioss::GroupingEntity *ge,

--- a/packages/seacas/libraries/ioss/src/exonull/Ioexnl_ParallelDatabaseIO.h
+++ b/packages/seacas/libraries/ioss/src/exonull/Ioexnl_ParallelDatabaseIO.h
@@ -78,9 +78,9 @@ namespace Ioexnl {
   private:
     void compute_node_status() const;
 
-    void release_memory__() override;
+    void release_memory_nl() override;
 
-    void get_step_times__() override {}
+    void get_step_times_nl() override {}
 
     bool handle_output_file(bool write_message, std::string *error_msg, int *bad_count,
                             bool overwrite, bool abort_if_error) const override;
@@ -136,7 +136,7 @@ namespace Ioexnl {
     void output_node_map() const;
 
     // Metadata-related functions.
-    void read_meta_data__() override;
+    void read_meta_data_nl() override;
 
     int64_t read_transient_field(const Ioexnl::VariableNameMap &variables, const Ioss::Field &field,
                                  const Ioss::GroupingEntity *ge, void *data) const;

--- a/packages/seacas/libraries/ioss/src/faodel/Iofaodel_DatabaseIO.C
+++ b/packages/seacas/libraries/ioss/src/faodel/Iofaodel_DatabaseIO.C
@@ -301,13 +301,13 @@ mpisyncstart.enable true
 
   std::string DatabaseIO::get_format() const { return "faodel"; }
 
-  bool DatabaseIO::begin_state__(int /* state */, double /* time */) { return false; }
+  bool DatabaseIO::begin_state_nl(int /* state */, double /* time */) { return false; }
 
-  bool DatabaseIO::end_state__(int /* state */, double /* time */) { return false; }
+  bool DatabaseIO::end_state_nl(int /* state */, double /* time */) { return false; }
 
-  void DatabaseIO::read_meta_data__()
+  void DatabaseIO::read_meta_data_nl()
   {
-    this->get_step_times__();
+    this->get_step_times_nl();
 
     this->read_region();
 
@@ -325,7 +325,7 @@ mpisyncstart.enable true
     this->get_commsets();
   }
 
-  void DatabaseIO::get_step_times__()
+  void DatabaseIO::get_step_times_nl()
   {
     auto                     search_key = make_states_search_key(parallel_rank(), *get_region());
     kelpie::ObjectCapacities oc;

--- a/packages/seacas/libraries/ioss/src/faodel/Iofaodel_DatabaseIO.h
+++ b/packages/seacas/libraries/ioss/src/faodel/Iofaodel_DatabaseIO.h
@@ -100,17 +100,17 @@ namespace Iofaodel {
 
     void finalize_database() const override;
 
-    void read_meta_data__() override;
+    void read_meta_data_nl() override;
 
-    bool begin_state__(int /* state */, double /* time */) override;
-    bool end_state__(int /* state */, double /* time */) override;
+    bool begin_state_nl(int /* state */, double /* time */) override;
+    bool end_state_nl(int /* state */, double /* time */) override;
 
-    bool begin__(Ioss::State state) override
+    bool begin_nl(Ioss::State state) override
     {
       dbState = state;
       return true;
     };
-    bool end__(Ioss::State state) override
+    bool end_nl(Ioss::State state) override
     {
       dbState = Ioss::STATE_UNKNOWN;
       return true;
@@ -126,7 +126,7 @@ namespace Iofaodel {
     /*
      * TODO identify all the get_*{blocks|sets} needed here
      */
-    void get_step_times__() override;
+    void get_step_times_nl() override;
 
     void get_edgeblocks();
     void get_elemblocks();

--- a/packages/seacas/libraries/ioss/src/gen_struc/Iogs_DatabaseIO.C
+++ b/packages/seacas/libraries/ioss/src/gen_struc/Iogs_DatabaseIO.C
@@ -128,7 +128,7 @@ namespace Iogs {
 
   DatabaseIO::~DatabaseIO() { delete m_generatedMesh; }
 
-  void DatabaseIO::read_meta_data__()
+  void DatabaseIO::read_meta_data_nl()
   {
     if (m_generatedMesh == nullptr) {
       if (get_filename() == "external") {
@@ -154,7 +154,7 @@ namespace Iogs {
     nodeCount        = m_generatedMesh->node_count_proc();
     elementCount     = m_generatedMesh->element_count_proc();
 
-    get_step_times__();
+    get_step_times_nl();
 
     add_transient_fields(this_region);
     get_nodeblocks();
@@ -165,11 +165,11 @@ namespace Iogs {
         Ioss::Property(std::string("title"), std::string("GeneratedMesh: ") += get_filename()));
   }
 
-  bool DatabaseIO::begin__(Ioss::State /* state */) { return true; }
+  bool DatabaseIO::begin_nl(Ioss::State /* state */) { return true; }
 
-  bool DatabaseIO::end__(Ioss::State /* state */) { return true; }
+  bool DatabaseIO::end_nl(Ioss::State /* state */) { return true; }
 
-  bool DatabaseIO::begin_state__(int /* state */, double time)
+  bool DatabaseIO::begin_state_nl(int /* state */, double time)
   {
     currentTime = time;
     return true;
@@ -481,7 +481,7 @@ namespace Iogs {
     add_transient_fields(block);
   }
 
-  void DatabaseIO::get_step_times__()
+  void DatabaseIO::get_step_times_nl()
   {
     int time_step_count = m_generatedMesh->timestep_count();
     for (int i = 0; i < time_step_count; i++) {

--- a/packages/seacas/libraries/ioss/src/gen_struc/Iogs_DatabaseIO.h
+++ b/packages/seacas/libraries/ioss/src/gen_struc/Iogs_DatabaseIO.h
@@ -91,14 +91,14 @@ namespace Iogs {
     const std::vector<std::string> &get_sideset_names() const { return m_sideset_names; }
 
   private:
-    void read_meta_data__() override;
+    void read_meta_data_nl() override;
 
-    bool begin__(Ioss::State state) override;
-    bool end__(Ioss::State state) override;
+    bool begin_nl(Ioss::State state) override;
+    bool end_nl(Ioss::State state) override;
 
-    bool begin_state__(int state, double time) override;
+    bool begin_state_nl(int state, double time) override;
 
-    void get_step_times__() override;
+    void get_step_times_nl() override;
     void get_nodeblocks();
     void get_structured_blocks();
     void get_nodesets();

--- a/packages/seacas/libraries/ioss/src/generated/Iogn_DatabaseIO.C
+++ b/packages/seacas/libraries/ioss/src/generated/Iogn_DatabaseIO.C
@@ -126,7 +126,7 @@ namespace Iogn {
 
   DatabaseIO::~DatabaseIO() { delete m_generatedMesh; }
 
-  void DatabaseIO::read_meta_data__()
+  void DatabaseIO::read_meta_data_nl()
   {
     if (m_generatedMesh == nullptr) {
       if (get_filename() == "external") {
@@ -172,7 +172,7 @@ namespace Iogn {
     nodesetCount      = m_generatedMesh->nodeset_count();
     sidesetCount      = m_generatedMesh->sideset_count();
 
-    get_step_times__();
+    get_step_times_nl();
 
     add_transient_fields(this_region);
     get_nodeblocks();
@@ -185,11 +185,11 @@ namespace Iogn {
         Ioss::Property(std::string("title"), std::string("GeneratedMesh: ") += get_filename()));
   }
 
-  bool DatabaseIO::begin__(Ioss::State /* state */) { return true; }
+  bool DatabaseIO::begin_nl(Ioss::State /* state */) { return true; }
 
-  bool DatabaseIO::end__(Ioss::State /* state */) { return true; }
+  bool DatabaseIO::end_nl(Ioss::State /* state */) { return true; }
 
-  bool DatabaseIO::begin_state__(int /* state */, double time)
+  bool DatabaseIO::begin_state_nl(int /* state */, double time)
   {
     currentTime = time;
     return true;
@@ -582,7 +582,7 @@ namespace Iogn {
     add_transient_fields(block);
   }
 
-  void DatabaseIO::get_step_times__()
+  void DatabaseIO::get_step_times_nl()
   {
     auto time_step_count = m_generatedMesh->timestep_count();
     for (int i = 0; i < time_step_count; i++) {

--- a/packages/seacas/libraries/ioss/src/generated/Iogn_DatabaseIO.h
+++ b/packages/seacas/libraries/ioss/src/generated/Iogn_DatabaseIO.h
@@ -102,14 +102,14 @@ namespace Iogn {
     const std::vector<std::string> &get_sideset_names() const { return m_sideset_names; }
 
   private:
-    void read_meta_data__() override;
+    void read_meta_data_nl() override;
 
-    bool begin__(Ioss::State state) override;
-    bool end__(Ioss::State state) override;
+    bool begin_nl(Ioss::State state) override;
+    bool end_nl(Ioss::State state) override;
 
-    bool begin_state__(int state, double time) override;
+    bool begin_state_nl(int state, double time) override;
 
-    void        get_step_times__() override;
+    void        get_step_times_nl() override;
     void        get_nodeblocks();
     void        get_elemblocks();
     void        get_nodesets();

--- a/packages/seacas/libraries/ioss/src/heartbeat/Iohb_DatabaseIO.C
+++ b/packages/seacas/libraries/ioss/src/heartbeat/Iohb_DatabaseIO.C
@@ -278,11 +278,11 @@ namespace Iohb {
     }
   }
 
-  bool DatabaseIO::begin__(Ioss::State /* state */) { return true; }
+  bool DatabaseIO::begin_nl(Ioss::State /* state */) { return true; }
 
-  bool DatabaseIO::end__(Ioss::State /* state */) { return true; }
+  bool DatabaseIO::end_nl(Ioss::State /* state */) { return true; }
 
-  bool DatabaseIO::begin_state__(int /* state */, double time)
+  bool DatabaseIO::begin_state_nl(int /* state */, double time)
   {
     // If this is the first time, open the output stream and see if user wants a legend
     initialize();
@@ -301,14 +301,14 @@ namespace Iohb {
     return true;
   }
 
-  void DatabaseIO::flush_database__() const
+  void DatabaseIO::flush_database_nl() const
   {
     if (myProcessor == 0) {
       logStream->flush();
     }
   }
 
-  bool DatabaseIO::end_state__(int /* state */, double /* time */)
+  bool DatabaseIO::end_state_nl(int /* state */, double /* time */)
   {
     if (legend_ != nullptr) {
       if (fileFormat == Iohb::Format::SPYHIS) {

--- a/packages/seacas/libraries/ioss/src/heartbeat/Iohb_DatabaseIO.h
+++ b/packages/seacas/libraries/ioss/src/heartbeat/Iohb_DatabaseIO.h
@@ -82,21 +82,21 @@ namespace Iohb {
     int int_byte_size_db() const override { return int_byte_size_api(); }
 
   private:
-    int64_t node_global_to_local__(int64_t /* global */, bool /* must_exist */) const override
+    int64_t node_global_to_local_nl(int64_t /* global */, bool /* must_exist */) const override
     {
       return 0;
     }
-    int64_t element_global_to_local__(int64_t /* global */) const override { return 0; }
+    int64_t element_global_to_local_nl(int64_t /* global */) const override { return 0; }
 
-    void read_meta_data__() override {}
+    void read_meta_data_nl() override {}
 
-    void flush_database__() const override;
+    void flush_database_nl() const override;
 
-    bool begin__(Ioss::State state) override;
-    bool end__(Ioss::State state) override;
+    bool begin_nl(Ioss::State state) override;
+    bool end_nl(Ioss::State state) override;
 
-    bool begin_state__(int state, double time) override;
-    bool end_state__(int state, double time) override;
+    bool begin_state_nl(int state, double time) override;
+    bool end_state_nl(int state, double time) override;
 
     void initialize() const;
 

--- a/packages/seacas/libraries/ioss/src/null/Ionull_DatabaseIO.C
+++ b/packages/seacas/libraries/ioss/src/null/Ionull_DatabaseIO.C
@@ -29,7 +29,7 @@ namespace Ionull {
 
   DatabaseIO::~DatabaseIO() = default;
 
-  void DatabaseIO::read_meta_data__() {}
+  void DatabaseIO::read_meta_data_nl() {}
 
   unsigned DatabaseIO::entity_field_support() const
   {
@@ -39,13 +39,13 @@ namespace Ionull {
            Ioss::STRUCTUREDBLOCK;
   }
 
-  bool DatabaseIO::begin__(Ioss::State /* state */) { return true; }
+  bool DatabaseIO::begin_nl(Ioss::State /* state */) { return true; }
 
-  bool DatabaseIO::end__(Ioss::State /* state */) { return true; }
+  bool DatabaseIO::end_nl(Ioss::State /* state */) { return true; }
 
-  bool DatabaseIO::begin_state__(int /* state */, double) { return true; }
+  bool DatabaseIO::begin_state_nl(int /* state */, double) { return true; }
 
-  bool DatabaseIO::end_state__(int /* state */, double) { return true; }
+  bool DatabaseIO::end_state_nl(int /* state */, double) { return true; }
 
   int64_t DatabaseIO::put_field_internal(const Ioss::Region *, const Ioss::Field &field, void *,
                                          size_t data_size) const

--- a/packages/seacas/libraries/ioss/src/null/Ionull_DatabaseIO.h
+++ b/packages/seacas/libraries/ioss/src/null/Ionull_DatabaseIO.h
@@ -64,13 +64,13 @@ namespace Ionull {
     int  int_byte_size_db() const override { return 8; }
     void set_int_byte_size_api(Ioss::DataSize) const override {}
 
-    bool begin__(Ioss::State state) override;
-    bool end__(Ioss::State state) override;
+    bool begin_nl(Ioss::State state) override;
+    bool end_nl(Ioss::State state) override;
 
-    bool begin_state__(int state, double time) override;
-    bool end_state__(int state, double time) override;
+    bool begin_state_nl(int state, double time) override;
+    bool end_state_nl(int state, double time) override;
 
-    bool ok__(bool, std::string *, int *) const override { return true; }
+    bool ok_nl(bool, std::string *, int *) const override { return true; }
 
   private:
     // Input only database -- these will never be called...
@@ -90,8 +90,8 @@ namespace Ionull {
     IOSS_NOOP_GFI(Ioss::Assembly)
     IOSS_NOOP_GFI(Ioss::Blob)
 
-    void read_meta_data__() override;
-    void get_step_times__() override {}
+    void read_meta_data_nl() override;
+    void get_step_times_nl() override {}
 
     int64_t put_field_internal(const Ioss::Region *reg, const Ioss::Field &field, void *data,
                                size_t data_size) const override;

--- a/packages/seacas/libraries/ioss/src/pamgen/Iopg_DatabaseIO.C
+++ b/packages/seacas/libraries/ioss/src/pamgen/Iopg_DatabaseIO.C
@@ -154,7 +154,7 @@ namespace Iopg {
     return mesh_description;
   }
 
-  void DatabaseIO::read_meta_data__()
+  void DatabaseIO::read_meta_data_nl()
   {
     // The file for pamgen contains the mesh description.
     // The Iopg routine is expecting the mesh description to be a
@@ -941,9 +941,9 @@ namespace Iopg {
     }
   } // namespace Iopg
 
-  bool DatabaseIO::begin__(Ioss::State /* state */) { return true; }
+  bool DatabaseIO::begin_nl(Ioss::State /* state */) { return true; }
 
-  bool DatabaseIO::end__(Ioss::State /* state */) { return true; }
+  bool DatabaseIO::end_nl(Ioss::State /* state */) { return true; }
 
   int64_t DatabaseIO::get_field_internal(const Ioss::NodeBlock *nb, const Ioss::Field &field,
                                          void *data, size_t data_size) const
@@ -1121,7 +1121,7 @@ namespace Iopg {
                                          void *data, size_t data_size) const
   {
     {
-      Ioss::SerializeIO serializeIO__(this);
+      Ioss::SerializeIO serializeIO_(this);
 
       size_t num_to_get = field.verify(data_size);
 
@@ -1473,8 +1473,8 @@ namespace Iopg {
     return elemMap;
   }
 
-  void DatabaseIO::compute_block_membership__(Ioss::SideBlock          *sideblock,
-                                              std::vector<std::string> &block_membership) const
+  void DatabaseIO::compute_block_membership_nl(Ioss::SideBlock          *sideblock,
+                                               std::vector<std::string> &block_membership) const
   {
     Ioss::IntVector block_ids(elementBlockCount);
     if (elementBlockCount == 1) {

--- a/packages/seacas/libraries/ioss/src/pamgen/Iopg_DatabaseIO.h
+++ b/packages/seacas/libraries/ioss/src/pamgen/Iopg_DatabaseIO.h
@@ -81,14 +81,14 @@ namespace Iopg {
     std::string title() const { return databaseTitle; }
     int         maximum_symbol_length() const override { return 32; }
 
-    void compute_block_membership__(Ioss::SideBlock          *efblock,
-                                    std::vector<std::string> &block_membership) const override;
+    void compute_block_membership_nl(Ioss::SideBlock          *efblock,
+                                     std::vector<std::string> &block_membership) const override;
 
   private:
-    void read_meta_data__() override;
+    void read_meta_data_nl() override;
 
-    bool begin__(Ioss::State state) override;
-    bool end__(Ioss::State state) override;
+    bool begin_nl(Ioss::State state) override;
+    bool end_nl(Ioss::State state) override;
 
     void read_region();
     void read_communication_metadata();

--- a/packages/seacas/libraries/ioss/src/text_mesh/Iotm_DatabaseIO.h
+++ b/packages/seacas/libraries/ioss/src/text_mesh/Iotm_DatabaseIO.h
@@ -88,14 +88,14 @@ namespace Iotm {
     void set_text_mesh(Iotm::TextMesh *textMesh) { m_textMesh = textMesh; }
 
   private:
-    void read_meta_data__() override;
+    void read_meta_data_nl() override;
 
-    bool begin__(Ioss::State state) override;
-    bool end__(Ioss::State state) override;
+    bool begin_nl(Ioss::State state) override;
+    bool end_nl(Ioss::State state) override;
 
-    bool begin_state__(int state, double time) override;
+    bool begin_state_nl(int state, double time) override;
 
-    void get_step_times__() override;
+    void get_step_times_nl() override;
     void get_nodeblocks();
     void get_elemblocks();
     void get_nodesets();

--- a/packages/seacas/libraries/ioss/src/visualization/cgns/Iovs_cgns_DatabaseIO.C
+++ b/packages/seacas/libraries/ioss/src/visualization/cgns/Iovs_cgns_DatabaseIO.C
@@ -1,4 +1,4 @@
-// Copyright(C) 1999-2021 National Technology & Engineering Solutions
+// Copyright(C) 1999-2021, 2023 National Technology & Engineering Solutions
 // of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
 // NTESS, the U.S. Government retains certain rights in this software.
 //
@@ -38,9 +38,9 @@ namespace Iovs_cgns {
 
   DatabaseIO::~DatabaseIO() { this->catCGNSMesh->Delete(); }
 
-  bool DatabaseIO::begin__(Ioss::State /*state*/) { return true; }
+  bool DatabaseIO::begin_nl(Ioss::State /*state*/) { return true; }
 
-  bool DatabaseIO::end__(Ioss::State state)
+  bool DatabaseIO::end_nl(Ioss::State state)
   {
     switch (state) {
     case Ioss::STATE_DEFINE_MODEL: {
@@ -52,7 +52,7 @@ namespace Iovs_cgns {
     return true;
   }
 
-  bool DatabaseIO::begin_state__(int state, double time)
+  bool DatabaseIO::begin_state_nl(int state, double time)
   {
     this->catCGNSMesh->ReleaseMemory();
     if (!isIdOutputCreated) {
@@ -63,7 +63,7 @@ namespace Iovs_cgns {
     return true;
   }
 
-  bool DatabaseIO::end_state__(int /*state*/, double /*time*/)
+  bool DatabaseIO::end_state_nl(int /*state*/, double /*time*/)
   {
     std::vector<int>         error_codes;
     std::vector<std::string> error_messages;
@@ -76,7 +76,7 @@ namespace Iovs_cgns {
     return true;
   }
 
-  void DatabaseIO::read_meta_data__() {}
+  void DatabaseIO::read_meta_data_nl() {}
 
   void DatabaseIO::write_meta_data()
   {
@@ -105,7 +105,7 @@ namespace Iovs_cgns {
       isCellField = true;
       outputId("cell_ids", ids, isCellField, sb);
 
-      auto             zone_id = sb->get_property("zone").get_int();
+      auto                 zone_id = sb->get_property("zone").get_int();
       std::vector<int64_t> object_id(cell_count, zone_id);
       outputId("object_id", object_id, isCellField, sb);
     }
@@ -139,12 +139,12 @@ namespace Iovs_cgns {
   int64_t DatabaseIO::put_field_internal(const Ioss::StructuredBlock *sb, const Ioss::Field &field,
                                          void *data, size_t data_size) const
   {
-    size_t node_count             = sb->get_property("node_count").get_int();
-    size_t num_to_get             = field.verify(data_size);
-    auto   var_type               = field.transformed_storage();
-    auto   ioss_type              = field.get_type();
-    int    comp_count             = var_type->component_count();
-    void  *rdata                  = num_to_get > 0 ? data : nullptr;
+    size_t node_count = sb->get_property("node_count").get_int();
+    size_t num_to_get = field.verify(data_size);
+    auto   var_type   = field.transformed_storage();
+    auto   ioss_type  = field.get_type();
+    int    comp_count = var_type->component_count();
+    void  *rdata      = num_to_get > 0 ? data : nullptr;
 
     bool is_cell_field = true;
     if (node_count == num_to_get) {

--- a/packages/seacas/libraries/ioss/src/visualization/cgns/Iovs_cgns_DatabaseIO.h
+++ b/packages/seacas/libraries/ioss/src/visualization/cgns/Iovs_cgns_DatabaseIO.h
@@ -28,13 +28,13 @@ namespace Iovs_cgns {
     void write_meta_data();
 
   private:
-    bool begin__(Ioss::State state) override;
-    bool end__(Ioss::State state) override;
+    bool begin_nl(Ioss::State state) override;
+    bool end_nl(Ioss::State state) override;
 
-    bool begin_state__(int state, double time) override;
-    bool end_state__(int state, double time) override;
+    bool begin_state_nl(int state, double time) override;
+    bool end_state_nl(int state, double time) override;
 
-    void read_meta_data__() override;
+    void read_meta_data_nl() override;
 
     int64_t get_field_internal(const Ioss::Region * /*reg*/, const Ioss::Field & /*field*/,
                                void * /*data*/, size_t /*data_size*/) const override

--- a/packages/seacas/libraries/ioss/src/visualization/exodus/Iovs_exodus_DatabaseIO.C
+++ b/packages/seacas/libraries/ioss/src/visualization/exodus/Iovs_exodus_DatabaseIO.C
@@ -1,4 +1,4 @@
-// Copyright(C) 1999-2022 National Technology & Engineering Solutions
+// Copyright(C) 1999-2023 National Technology & Engineering Solutions
 // of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
 // NTESS, the U.S. Government retains certain rights in this software.
 //
@@ -59,7 +59,7 @@ namespace Iovs_exodus {
 
   DatabaseIO::~DatabaseIO() { this->catExoMesh->Delete(); }
 
-  bool DatabaseIO::begin__(Ioss::State state)
+  bool DatabaseIO::begin_nl(Ioss::State state)
   {
     dbState              = state;
     Ioss::Region *region = this->get_region();
@@ -75,7 +75,7 @@ namespace Iovs_exodus {
     return true;
   }
 
-  bool DatabaseIO::end__(Ioss::State state)
+  bool DatabaseIO::end_nl(Ioss::State state)
   {
     // Transitioning out of state 'state'
     assert(state == dbState);
@@ -95,9 +95,9 @@ namespace Iovs_exodus {
 
   // Default versions do nothing at this time...
   // Will be used for global variables...
-  bool DatabaseIO::begin_state__(int state, double time)
+  bool DatabaseIO::begin_state_nl(int state, double time)
   {
-    Ioss::SerializeIO serializeIO__(this);
+    Ioss::SerializeIO serializeIO_(this);
 
     if (!this->globalNodeAndElementIDsCreated) {
       this->create_global_node_and_element_ids();
@@ -108,9 +108,9 @@ namespace Iovs_exodus {
     return true;
   }
 
-  bool DatabaseIO::end_state__(int /*state*/, double /*time*/)
+  bool DatabaseIO::end_state_nl(int /*state*/, double /*time*/)
   {
-    Ioss::SerializeIO        serializeIO__(this);
+    Ioss::SerializeIO        serializeIO_(this);
     std::vector<int>         error_codes;
     std::vector<std::string> error_messages;
     this->catExoMesh->logMemoryUsageAndTakeTimerReading();
@@ -123,7 +123,7 @@ namespace Iovs_exodus {
     return true;
   }
 
-  void DatabaseIO::read_meta_data__() {}
+  void DatabaseIO::read_meta_data_nl() {}
 
   void DatabaseIO::create_global_node_and_element_ids() const
   {
@@ -150,7 +150,7 @@ namespace Iovs_exodus {
     // are REDUCTION fields (1 value).  We need to gather these
     // and output them all at one time.  The storage location is a
     // 'globalVariables' array
-    Ioss::SerializeIO serializeIO__(this);
+    Ioss::SerializeIO serializeIO_(this);
 
     size_t                num_to_get = field.verify(data_size);
     Ioss::Field::RoleType role       = field.get_role();
@@ -194,7 +194,7 @@ namespace Iovs_exodus {
   int64_t DatabaseIO::put_field_internal(const Ioss::NodeBlock *nb, const Ioss::Field &field,
                                          void *data, size_t data_size) const
   {
-    Ioss::SerializeIO serializeIO__(this);
+    Ioss::SerializeIO serializeIO_(this);
     size_t            num_to_get = field.verify(data_size);
 
     if (num_to_get > 0) {
@@ -254,7 +254,7 @@ namespace Iovs_exodus {
   int64_t DatabaseIO::put_field_internal(const Ioss::ElementBlock *eb, const Ioss::Field &field,
                                          void *data, size_t data_size) const
   {
-    Ioss::SerializeIO serializeIO__(this);
+    Ioss::SerializeIO serializeIO_(this);
 
     size_t num_to_get = field.verify(data_size);
     if (num_to_get > 0) {

--- a/packages/seacas/libraries/ioss/src/visualization/exodus/Iovs_exodus_DatabaseIO.h
+++ b/packages/seacas/libraries/ioss/src/visualization/exodus/Iovs_exodus_DatabaseIO.h
@@ -54,13 +54,13 @@ namespace Iovs_exodus {
     int int_byte_size_db() const override { return int_byte_size_api(); }
 
   private:
-    bool begin__(Ioss::State state) override;
-    bool end__(Ioss::State state) override;
+    bool begin_nl(Ioss::State state) override;
+    bool end_nl(Ioss::State state) override;
 
-    bool begin_state__(int state, double time) override;
-    bool end_state__(int state, double time) override;
+    bool begin_state_nl(int state, double time) override;
+    bool end_state_nl(int state, double time) override;
 
-    void read_meta_data__() override;
+    void read_meta_data_nl() override;
 
     // For the time being, treat vis as write only. Consider glue pipelines.
     int64_t get_field_internal(const Ioss::Region * /*reg*/, const Ioss::Field & /*field*/,

--- a/packages/seacas/libraries/nemesis/nemesis_wrapper.c
+++ b/packages/seacas/libraries/nemesis/nemesis_wrapper.c
@@ -13,8 +13,8 @@
  *     Initial Information Routines
  *===========================================================================*/
 int ne_get_init_info(int   neid,          /* NemesisI file ID */
-                     int * num_proc,      /* Number of processors */
-                     int * num_proc_in_f, /* Number of procs in this file */
+                     int  *num_proc,      /* Number of processors */
+                     int  *num_proc_in_f, /* Number of procs in this file */
                      char *ftype)
 {
   return ex_get_init_info(neid, num_proc, num_proc_in_f, ftype);
@@ -52,7 +52,7 @@ int ne_put_init_global(int     neid,            /* NemesisI file ID */
                             num_side_sets_g);
 }
 
-int ne_put_version(int neid) { return ex__put_nemesis_version(neid); }
+int ne_put_version(int neid) { return exi_put_nemesis_version(neid); }
 
 /*=============================================================================
  *     Loadbalance Parameter Routines
@@ -165,8 +165,8 @@ int ne_get_n_side_set(int          neid,               /* NetCDF/Exodus file ID 
                       ex_entity_id side_set_id,        /* Side-set ID to read */
                       int64_t      start_side_num,     /* Starting element number */
                       int64_t      num_sides,          /* Number of sides to read */
-                      void_int *   side_set_elem_list, /* List of element IDs */
-                      void_int *   side_set_side_list  /* List of side IDs */
+                      void_int    *side_set_elem_list, /* List of element IDs */
+                      void_int    *side_set_side_list  /* List of side IDs */
 )
 {
   return ex_get_partial_set(neid, EX_SIDE_SET, side_set_id, start_side_num, num_sides,
@@ -189,7 +189,7 @@ int ne_get_n_side_set_df(int          neid,          /* NetCDF/Exodus file ID */
                          ex_entity_id side_set_id,   /* Side-set ID */
                          int64_t      start_num,     /* Starting df number */
                          int64_t      num_df_to_get, /* Number of df's to read */
-                         void *       side_set_df    /* Distribution factors */
+                         void        *side_set_df    /* Distribution factors */
 )
 {
   return ex_get_partial_set_dist_fact(neid, EX_SIDE_SET, side_set_id, start_num, num_df_to_get,
@@ -200,7 +200,7 @@ int ne_put_n_side_set_df(int          neid,          /* NetCDF/Exodus file ID */
                          ex_entity_id side_set_id,   /* Side-set ID */
                          int64_t      start_num,     /* Starting df number */
                          int64_t      num_df_to_get, /* Number of df's to write */
-                         void *       side_set_df    /* Distribution factors */
+                         void        *side_set_df    /* Distribution factors */
 )
 {
   return ex_put_partial_set_dist_fact(neid, EX_SIDE_SET, side_set_id, start_num, num_df_to_get,
@@ -211,7 +211,7 @@ int ne_get_n_node_set(int          neid,              /* NetCDF/Exodus file ID *
                       ex_entity_id node_set_id,       /* Node set ID */
                       int64_t      start_node_num,    /* Node index to start reading at */
                       int64_t      num_node,          /* Number of nodes to read */
-                      void_int *   node_set_node_list /* List of nodes in node set */
+                      void_int    *node_set_node_list /* List of nodes in node set */
 )
 {
   return ex_get_partial_set(neid, EX_NODE_SET, node_set_id, start_node_num, num_node,
@@ -233,7 +233,7 @@ int ne_get_n_node_set_df(int          neid,          /* NetCDF/Exodus file ID */
                          ex_entity_id node_set_id,   /* Node-set ID */
                          int64_t      start_num,     /* Starting df number */
                          int64_t      num_df_to_get, /* Number of df's to read */
-                         void *       node_set_df    /* Distribution factors */
+                         void        *node_set_df    /* Distribution factors */
 )
 {
   return ex_get_partial_set_dist_fact(neid, EX_NODE_SET, node_set_id, start_num, num_df_to_get,
@@ -244,7 +244,7 @@ int ne_put_n_node_set_df(int          neid,          /* NetCDF/Exodus file ID */
                          ex_entity_id node_set_id,   /* Node-set ID */
                          int64_t      start_num,     /* Starting df number */
                          int64_t      num_df_to_get, /* Number of df's to write */
-                         void *       node_set_df    /* Distribution factors */
+                         void        *node_set_df    /* Distribution factors */
 )
 {
   return ex_put_partial_set_dist_fact(neid, EX_NODE_SET, node_set_id, start_num, num_df_to_get,
@@ -254,9 +254,9 @@ int ne_put_n_node_set_df(int          neid,          /* NetCDF/Exodus file ID */
 int ne_get_n_coord(int     neid,           /* NetCDF/Exodus file ID */
                    int64_t start_node_num, /* Starting position to read from */
                    int64_t num_nodes,      /* Number of coords to read */
-                   void *  x_coor,         /* Vector of X coordinates */
-                   void *  y_coor,         /* Vector of Y coordinates */
-                   void *  z_coor          /* Vector of Z coordinates */
+                   void   *x_coor,         /* Vector of X coordinates */
+                   void   *y_coor,         /* Vector of Y coordinates */
+                   void   *z_coor          /* Vector of Z coordinates */
 )
 {
   return ex_get_partial_coord(neid, start_node_num, num_nodes, x_coor, y_coor, z_coor);
@@ -265,9 +265,9 @@ int ne_get_n_coord(int     neid,           /* NetCDF/Exodus file ID */
 int ne_put_n_coord(int     neid,           /* NetCDF/Exodus file ID */
                    int64_t start_node_num, /* Starting position to write to */
                    int64_t num_nodes,      /* Number of coords to write */
-                   void *  x_coor,         /* Vector of X coordinates */
-                   void *  y_coor,         /* Vector of Y coordinates */
-                   void *  z_coor          /* Vector of Z coordinates */
+                   void   *x_coor,         /* Vector of X coordinates */
+                   void   *y_coor,         /* Vector of Y coordinates */
+                   void   *z_coor          /* Vector of Z coordinates */
 )
 {
   return ex_put_partial_coord(neid, start_node_num, num_nodes, x_coor, y_coor, z_coor);
@@ -277,7 +277,7 @@ int ne_get_n_elem_conn(int          neid,           /* NetCDF/Exodus file ID */
                        ex_entity_id elem_blk_id,    /* Element block ID */
                        int64_t      start_elem_num, /* Starting position to read from */
                        int64_t      num_elems,      /* Number of elements to read */
-                       void_int *   connect         /* Connectivity vector */
+                       void_int    *connect         /* Connectivity vector */
 )
 {
   return ex_get_partial_conn(neid, EX_ELEM_BLOCK, elem_blk_id, start_elem_num, num_elems, connect,
@@ -299,7 +299,7 @@ int ne_get_n_elem_attr(int          neid,           /* NetCDF/Exodus file ID */
                        ex_entity_id elem_blk_id,    /* Element block ID */
                        int64_t      start_elem_num, /* Starting position to read from */
                        int64_t      num_elems,      /* Number of elements to read */
-                       void *       attrib          /* Attribute */
+                       void        *attrib          /* Attribute */
 )
 {
   return ex_get_partial_attr(neid, EX_ELEM_BLOCK, elem_blk_id, start_elem_num, num_elems, attrib);
@@ -309,7 +309,7 @@ int ne_put_n_elem_attr(int          neid,           /* NetCDF/Exodus file ID */
                        ex_entity_id elem_blk_id,    /* Element block ID */
                        int64_t      start_elem_num, /* Starting position to write to */
                        int64_t      num_elems,      /* Number of elements to write */
-                       void *       attrib          /* Attribute */
+                       void        *attrib          /* Attribute */
 )
 {
   return ex_put_partial_attr(neid, EX_ELEM_BLOCK, elem_blk_id, start_elem_num, num_elems, attrib);
@@ -317,7 +317,7 @@ int ne_put_n_elem_attr(int          neid,           /* NetCDF/Exodus file ID */
 
 int ne_get_elem_type(int          neid,        /* NetCDF/Exodus file ID */
                      ex_entity_id elem_blk_id, /* Element block ID */
-                     char *       elem_type    /* The name of the element type */
+                     char        *elem_type    /* The name of the element type */
 )
 {
   return ex_get_elem_type(neid, elem_blk_id, elem_type);
@@ -333,7 +333,7 @@ int ne_get_n_elem_var(int          neid,              /* NetCDF/Exodus file ID *
                       int64_t      num_elem_this_blk, /* number of elements in block */
                       int64_t      start_elem_num,    /* Starting position for read */
                       int64_t      num_elem,          /* Number of elements to read */
-                      void *       elem_var_vals      /* variable values */
+                      void        *elem_var_vals      /* variable values */
 )
 {
   return ex_get_partial_var(neid, time_step, EX_ELEM_BLOCK, elem_var_index, elem_blk_id,
@@ -346,7 +346,7 @@ int ne_put_elem_var_slab(int          neid,           /* NetCDF/Exodus file ID *
                          ex_entity_id elem_blk_id,    /* elemental block id */
                          int64_t      start_pos,      /* Starting position to write to */
                          int64_t      num_vals,       /* Number of elements to write */
-                         void *       elem_var_vals   /* variable values */
+                         void        *elem_var_vals   /* variable values */
 )
 {
   return ex_put_partial_var(neid, time_step, EX_ELEM_BLOCK, elem_var_index, elem_blk_id, start_pos,
@@ -358,7 +358,7 @@ int ne_get_n_nodal_var(int     neid,            /* NetCDF/Exodus file ID */
                        int     nodal_var_index, /* index of desired nodal var */
                        int64_t start_node_num,  /* starting node number */
                        int64_t num_nodes,       /* number of nodes to read */
-                       void *  nodal_vars       /* array of nodal var values */
+                       void   *nodal_vars       /* array of nodal var values */
 )
 {
   return ex_get_partial_var(neid, time_step, EX_NODAL, nodal_var_index, 1, start_node_num,
@@ -370,7 +370,7 @@ int ne_put_nodal_var_slab(int     neid,            /* NetCDF/Exodus file ID */
                           int     nodal_var_index, /* Nodal variable index */
                           int64_t start_pos,       /* Start position for write */
                           int64_t num_vals,        /* Number of nodal variables */
-                          void *  nodal_var_vals   /* Nodal variable values */
+                          void   *nodal_var_vals   /* Nodal variable values */
 )
 {
   return ex_put_partial_var(neid, time_step, EX_NODAL, nodal_var_index, 1, start_pos, num_vals,
@@ -499,8 +499,8 @@ int ne_put_cmap_params_cc(int       neid,               /* NetCDF/Exodus file ID
 
 int ne_get_node_cmap(int          neid,     /* NetCDF/Exodus file ID */
                      ex_entity_id map_id,   /* Map ID */
-                     void_int *   node_ids, /* FEM node IDs */
-                     void_int *   proc_ids, /* Processor IDs */
+                     void_int    *node_ids, /* FEM node IDs */
+                     void_int    *proc_ids, /* Processor IDs */
                      int          processor /* This processor ID */
 )
 {
@@ -509,8 +509,8 @@ int ne_get_node_cmap(int          neid,     /* NetCDF/Exodus file ID */
 
 int ne_put_node_cmap(int          neid,     /* NetCDF/Exodus file ID */
                      ex_entity_id map_id,   /* Nodal comm map ID */
-                     void_int *   node_ids, /* FEM node IDs */
-                     void_int *   proc_ids, /* Processor IDs */
+                     void_int    *node_ids, /* FEM node IDs */
+                     void_int    *proc_ids, /* Processor IDs */
                      int          processor /* This processor ID */
 )
 {
@@ -519,9 +519,9 @@ int ne_put_node_cmap(int          neid,     /* NetCDF/Exodus file ID */
 
 int ne_get_elem_cmap(int          neid,     /* NetCDF/Exodus file ID */
                      ex_entity_id map_id,   /* Elemental comm map ID */
-                     void_int *   elem_ids, /* Element IDs */
-                     void_int *   side_ids, /* Element side IDs */
-                     void_int *   proc_ids, /* Processor IDs */
+                     void_int    *elem_ids, /* Element IDs */
+                     void_int    *side_ids, /* Element side IDs */
+                     void_int    *proc_ids, /* Processor IDs */
                      int          processor /* This processor ID */
 )
 {
@@ -530,9 +530,9 @@ int ne_get_elem_cmap(int          neid,     /* NetCDF/Exodus file ID */
 
 int ne_put_elem_cmap(int          neid,     /* NetCDF/Exodus file ID */
                      ex_entity_id map_id,   /* Elemental comm map ID */
-                     void_int *   elem_ids, /* Vector of element IDs */
-                     void_int *   side_ids, /* Vector of side IDs */
-                     void_int *   proc_ids, /* Vector of processor IDs */
+                     void_int    *elem_ids, /* Vector of element IDs */
+                     void_int    *side_ids, /* Vector of side IDs */
+                     void_int    *proc_ids, /* Vector of processor IDs */
                      int          processor /* This processor ID */
 )
 {
@@ -541,7 +541,7 @@ int ne_put_elem_cmap(int          neid,     /* NetCDF/Exodus file ID */
 
 int ne_get_idx(int         neid,        /* NetCDF/Exodus file ID */
                const char *ne_var_name, /* Nemesis index variable name */
-               int64_t *   index,       /* array of length 2 to hold results */
+               int64_t    *index,       /* array of length 2 to hold results */
                int         pos          /* position of this proc/cmap in index */
 )
 {


### PR DESCRIPTION
Several uses of reserved identifiers are present in IOSS and Exodus libraries.  These should be removed.

- One of the first steps is to eliminate any of these functions that are in the public section of the class.
- Change all uses of `ex__abdc` to some other convention.  The `ex__abdc` are internal functions meant to used only in the library itself (although there are some uses in come C++ Internals classes such as Ioex::Internals)
- Change all uses of the IOSS internal functions that end with double underscore to some other convention.  (These are internal functions that are called by the thread-safe wrapper functions that hold a mutex.  E.g `my_function` will hold a mutex and call `my_function__`
