### PR TITLE
TextMesh: Enable block and assembly omission/inclusion

### DIFF
--- a/packages/seacas/libraries/ioss/src/Ioss_DatabaseIO.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_DatabaseIO.C
@@ -887,6 +887,24 @@ namespace Ioss {
       IOSS_ERROR(errmsg);
     }
 
+    if (!assemblyOmissions.empty() && !inclusions.empty()) {
+      std::ostringstream errmsg;
+      fmt::print(errmsg,
+                 "ERROR: Only one of element block inclusion or assembly omission can be non-empty"
+                 "       [{}]\n",
+                 get_filename());
+      IOSS_ERROR(errmsg);
+    }
+
+    if (!assemblyInclusions.empty() && !omissions.empty()) {
+      std::ostringstream errmsg;
+      fmt::print(errmsg,
+                 "ERROR: Only one of element block omission or assembly inclusion can be non-empty"
+                 "       [{}]\n",
+                 get_filename());
+      IOSS_ERROR(errmsg);
+    }
+
     if (!omissions.empty()) {
       blockOmissions.assign(omissions.cbegin(), omissions.cend());
       Ioss::sort(blockOmissions.begin(), blockOmissions.end());
@@ -905,6 +923,24 @@ namespace Ioss {
       std::ostringstream errmsg;
       fmt::print(errmsg,
                  "ERROR: Only one of assembly omission or inclusion can be non-empty"
+                 "       [{}]\n",
+                 get_filename());
+      IOSS_ERROR(errmsg);
+    }
+
+    if (!blockOmissions.empty() && !inclusions.empty()) {
+      std::ostringstream errmsg;
+      fmt::print(errmsg,
+                 "ERROR: Only one of element block omission or assembly inclusion can be non-empty"
+                 "       [{}]\n",
+                 get_filename());
+      IOSS_ERROR(errmsg);
+    }
+
+    if (!blockInclusions.empty() && !omissions.empty()) {
+      std::ostringstream errmsg;
+      fmt::print(errmsg,
+                 "ERROR: Only one of element block inclusion or assembly omission can be non-empty"
                  "       [{}]\n",
                  get_filename());
       IOSS_ERROR(errmsg);

--- a/packages/seacas/libraries/ioss/src/Ioss_DatabaseIO.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_DatabaseIO.C
@@ -877,6 +877,16 @@ namespace Ioss {
   void DatabaseIO::set_block_omissions(const std::vector<std::string> &omissions,
                                        const std::vector<std::string> &inclusions)
   {
+    if (!omissions.empty() && !inclusions.empty()) {
+      // Only one can be non-empty
+      std::ostringstream errmsg;
+      fmt::print(errmsg,
+                 "ERROR: Only one of element block omission or inclusion can be non-empty"
+                 "       [{}]\n",
+                 get_filename());
+      IOSS_ERROR(errmsg);
+    }
+
     if (!omissions.empty()) {
       blockOmissions.assign(omissions.cbegin(), omissions.cend());
       Ioss::sort(blockOmissions.begin(), blockOmissions.end());

--- a/packages/seacas/libraries/ioss/src/Ioss_Utils.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Utils.h
@@ -532,6 +532,14 @@ namespace Ioss {
                               const std::string &header, const std::string &suffix = "\n\t",
                               bool print_empty = false);
 
+    static void insert_sort_and_unique(const std::vector<std::string> &src, std::vector<std::string> &dest)
+    {
+      dest.insert(dest.end(), src.begin(), src.end());
+      std::sort(dest.begin(), dest.end(), std::less<>());
+      auto endIter = std::unique(dest.begin(), dest.end());
+      dest.resize(endIter - dest.begin());
+    }
+
   private:
     // SEE: http://lemire.me/blog/2017/04/10/removing-duplicates-from-lists-quickly
     template <typename T> static size_t unique(std::vector<T> &out, bool skip_first)

--- a/packages/seacas/libraries/ioss/src/exodus/Ioex_BaseDatabaseIO.C
+++ b/packages/seacas/libraries/ioss/src/exodus/Ioex_BaseDatabaseIO.C
@@ -79,8 +79,6 @@ namespace {
   template <typename T>
   void write_attribute_names(int exoid, ex_entity_type type, const std::vector<T *> &entities);
 
-  void insert_sort_and_unique(const std::vector<std::string> &src, std::vector<std::string> &dest);
-
   class AssemblyTreeFilter
   {
   public:
@@ -730,8 +728,8 @@ namespace Ioex {
 
       cleanup_exodus_assembly_vector(assemblies);
 
-      insert_sort_and_unique(exclusions, blockOmissions);
-      insert_sort_and_unique(inclusions, blockInclusions);
+      Ioss::Utils::insert_sort_and_unique(exclusions, blockOmissions);
+      Ioss::Utils::insert_sort_and_unique(inclusions, blockInclusions);
     }
   }
 
@@ -3128,13 +3126,5 @@ namespace {
       throw x;
     }
 #endif
-  }
-
-  void insert_sort_and_unique(const std::vector<std::string> &src, std::vector<std::string> &dest)
-  {
-    dest.insert(dest.end(), src.begin(), src.end());
-    std::sort(dest.begin(), dest.end(), std::less<>());
-    auto endIter = std::unique(dest.begin(), dest.end());
-    dest.resize(endIter - dest.begin());
   }
 } // namespace

--- a/packages/seacas/libraries/ioss/src/exodus/Ioex_BaseDatabaseIO.C
+++ b/packages/seacas/libraries/ioss/src/exodus/Ioex_BaseDatabaseIO.C
@@ -689,14 +689,6 @@ namespace Ioex {
   {
     Ioss::SerializeIO serializeIO_(this);
 
-    if (!assemblyOmissions.empty()) {
-      assert(blockInclusions.empty());
-    }
-
-    if (!assemblyInclusions.empty()) {
-      assert(blockOmissions.empty());
-    }
-
     // Query number of assemblies...
     auto assemblies = get_exodus_assemblies(get_file_pointer());
     if (!assemblies.empty()) {

--- a/packages/seacas/libraries/ioss/src/text_mesh/Iotm_DatabaseIO.C
+++ b/packages/seacas/libraries/ioss/src/text_mesh/Iotm_DatabaseIO.C
@@ -643,6 +643,23 @@ namespace Iotm {
     }
   }
 
+  void DatabaseIO::update_block_omissions_from_assemblies()
+  {
+    Ioss::SerializeIO serializeIO_(this);
+
+    if (!assemblyOmissions.empty()) {
+      assert(blockInclusions.empty());
+    }
+
+    if (!assemblyInclusions.empty()) {
+      assert(blockOmissions.empty());
+    }
+
+    m_textMesh->update_block_omissions_from_assemblies(get_region(),
+                                                       assemblyOmissions, assemblyInclusions,
+                                                       blockOmissions, blockInclusions);
+  }
+
   void DatabaseIO::get_elemblocks()
   {
     // Attributes of an element block are:
@@ -674,6 +691,37 @@ namespace Iotm {
       add_transient_fields(block);
 
       order++;
+    }
+
+    if (!assemblyOmissions.empty() || !assemblyInclusions.empty()) {
+      update_block_omissions_from_assemblies();
+    }
+
+    assert(blockOmissions.empty() || blockInclusions.empty()); // Only one can be non-empty
+
+    // Handle all block omissions or inclusions...
+    if (!blockOmissions.empty()) {
+      for (const auto &name : blockOmissions) {
+        auto block = get_region()->get_element_block(name);
+        if (block != nullptr) {
+          block->property_add(Ioss::Property(std::string("omitted"), 1));
+        }
+      }
+    }
+
+    if (!blockInclusions.empty()) {
+      const auto &blocks = get_region()->get_element_blocks();
+      for (auto &block : blocks) {
+        block->property_add(Ioss::Property(std::string("omitted"), 1));
+      }
+
+      // Now, erase the property on any blocks in the inclusion list...
+      for (const auto &name : blockInclusions) {
+        auto block = get_region()->get_element_block(name);
+        if (block != nullptr) {
+          block->property_erase("omitted");
+        }
+      }
     }
   }
 

--- a/packages/seacas/libraries/ioss/src/text_mesh/Iotm_DatabaseIO.C
+++ b/packages/seacas/libraries/ioss/src/text_mesh/Iotm_DatabaseIO.C
@@ -645,14 +645,6 @@ namespace Iotm {
 
   void DatabaseIO::update_block_omissions_from_assemblies()
   {
-    if (!assemblyOmissions.empty()) {
-      assert(blockInclusions.empty());
-    }
-
-    if (!assemblyInclusions.empty()) {
-      assert(blockOmissions.empty());
-    }
-
     m_textMesh->update_block_omissions_from_assemblies(get_region(),
                                                        assemblyOmissions, assemblyInclusions,
                                                        blockOmissions, blockInclusions);

--- a/packages/seacas/libraries/ioss/src/text_mesh/Iotm_DatabaseIO.C
+++ b/packages/seacas/libraries/ioss/src/text_mesh/Iotm_DatabaseIO.C
@@ -645,8 +645,6 @@ namespace Iotm {
 
   void DatabaseIO::update_block_omissions_from_assemblies()
   {
-    Ioss::SerializeIO serializeIO_(this);
-
     if (!assemblyOmissions.empty()) {
       assert(blockInclusions.empty());
     }

--- a/packages/seacas/libraries/ioss/src/text_mesh/Iotm_DatabaseIO.h
+++ b/packages/seacas/libraries/ioss/src/text_mesh/Iotm_DatabaseIO.h
@@ -103,6 +103,8 @@ namespace Iotm {
     void get_commsets();
     void get_assemblies();
 
+    void update_block_omissions_from_assemblies();
+
     const Ioss::Map &get_node_map() const;
     const Ioss::Map &get_element_map() const;
 

--- a/packages/seacas/libraries/ioss/src/text_mesh/Iotm_TextMesh.h
+++ b/packages/seacas/libraries/ioss/src/text_mesh/Iotm_TextMesh.h
@@ -8,6 +8,7 @@
 
 #include "Ioss_CodeTypes.h"
 #include "Ioss_EntityType.h" // for EntityType
+#include "Ioss_Region.h"
 #include <cstddef>           // for size_t
 #include <cstdint>           // for int64_t
 #include <map>               // for map, etc
@@ -34,6 +35,7 @@ namespace Iotm {
   using ElementData    = text_mesh::ElementData<int64_t, Topology>;
   using SidesetData    = text_mesh::SidesetData<int64_t, Topology>;
   using NodesetData    = text_mesh::NodesetData<int64_t>;
+  using Assemblies     = text_mesh::Assemblies<int64_t>;
   using AssemblyData   = text_mesh::AssemblyData;
   using Coordinates    = text_mesh::Coordinates<int64_t>;
   using TextMeshParser = text_mesh::TextMeshParser<int64_t, IossTopologyMapping>;
@@ -283,7 +285,13 @@ namespace Iotm {
     Ioss::EntityType         get_assembly_type(const std::string &name) const;
     std::vector<std::string> get_assembly_members(const std::string &name) const;
 
-    Ioss::EntityType assembly_type_to_entity_type(const AssemblyType type) const;
+    static Ioss::EntityType assembly_type_to_entity_type(const AssemblyType type);
+
+    void update_block_omissions_from_assemblies(Ioss::Region *region,
+                                                std::vector<std::string>& assemblyOmissions,
+                                                std::vector<std::string>& assemblyInclusions,
+                                                std::vector<std::string>& blockOmissions,
+                                                std::vector<std::string>& blockInclusions) const;
 
     unsigned spatial_dimension() const;
 

--- a/packages/seacas/libraries/ioss/src/unit_tests/CMakeLists.txt
+++ b/packages/seacas/libraries/ioss/src/unit_tests/CMakeLists.txt
@@ -5,6 +5,11 @@ TRIBITS_ADD_EXECUTABLE(
 )
 
 TRIBITS_ADD_EXECUTABLE(
+ Utst_iotm
+ SOURCES unitMain.C UnitTestIotmDatabaseIO.C
+)
+
+TRIBITS_ADD_EXECUTABLE(
  Utst_blockbatchread
  SOURCES unitMain.C UnitTestElementBlockBatchRead.C
 )
@@ -49,6 +54,18 @@ TRIBITS_ADD_TEST(
         Utst_textmesh
         NAME Utst_textmesh
         NUM_MPI_PROCS 4
+)
+
+TRIBITS_ADD_TEST(
+        Utst_iotm
+        NAME Utst_iotm
+        NUM_MPI_PROCS 1
+)
+
+TRIBITS_ADD_TEST(
+        Utst_iotm
+        NAME Utst_iotm
+        NUM_MPI_PROCS 2
 )
 
 TRIBITS_INCLUDE_DIRECTORIES(

--- a/packages/seacas/libraries/ioss/src/unit_tests/UnitTestIotmDatabaseIO.C
+++ b/packages/seacas/libraries/ioss/src/unit_tests/UnitTestIotmDatabaseIO.C
@@ -1,0 +1,178 @@
+// Copyright(C) 1999-2020, 2022 National Technology & Engineering Solutions
+// of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
+// NTESS, the U.S. Government retains certain rights in this software.
+//
+// See packages/seacas/LICENSE for details
+
+#ifdef SEACAS_HAVE_MPI
+#include "mpi.h"
+#endif
+#include "gtest/gtest.h"
+
+#include "Ionit_Initializer.h"
+#include "Ioss_DBUsage.h"
+#include "Ioss_ElementBlock.h"
+#include "Ioss_ElementTopology.h"
+#include "Ioss_Hex8.h"
+#include "Ioss_NodeBlock.h"
+#include "Ioss_NodeSet.h"
+#include "Ioss_PropertyManager.h"
+#include "Ioss_Region.h"
+#include "Ioss_Shell4.h"
+#include "Ioss_SideBlock.h"
+#include "Ioss_SideSet.h"
+#include "text_mesh/Iotm_DatabaseIO.h"
+#include <fmt/core.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string>
+#include <vector>
+
+#include "Ioss_CodeTypes.h"
+#include "Ioss_Field.h"
+#include "Ioss_ParallelUtils.h"
+
+namespace {
+
+Iotm::DatabaseIO *create_input_db_io(const std::string &meshDesc)
+{
+  Ioss::Init::Initializer init_db;
+
+  Ioss::DatabaseUsage   db_usage = Ioss::READ_MODEL;
+  Ioss::PropertyManager properties;
+
+  properties.add(Ioss::Property("INTEGER_SIZE_DB", 8));
+  properties.add(Ioss::Property("INTEGER_SIZE_API", 8));
+
+  auto *db_io = new Iotm::DatabaseIO(nullptr, meshDesc, db_usage,
+                                     Ioss::ParallelUtils::comm_world(), properties);
+  return db_io;
+}
+
+Iotm::DatabaseIO *create_output_db_io(const std::string &filename)
+{
+  Ioss::Init::Initializer init_db;
+  Ioss::DatabaseUsage     db_usage = Ioss::WRITE_RESULTS;
+  Ioss::PropertyManager   properties;
+
+  properties.add(Ioss::Property("INTEGER_SIZE_DB", 8));
+  properties.add(Ioss::Property("INTEGER_SIZE_API", 8));
+
+  auto *db_io = new Iotm::DatabaseIO(nullptr, filename, db_usage,
+                                     Ioss::ParallelUtils::comm_world(), properties);
+  return db_io;
+}
+
+int get_parallel_size()
+{
+  return Ioss::ParallelUtils(Ioss::ParallelUtils::comm_world()).parallel_size();
+}
+
+int get_parallel_rank()
+{
+  return Ioss::ParallelUtils(Ioss::ParallelUtils::comm_world()).parallel_rank();
+}
+
+bool include_entity(const Ioss::GroupingEntity *entity)
+{
+  assert(entity);
+
+  // Check whether entity has "omitted" property...
+  bool omitted = (entity->property_exists("omitted")) &&
+                 (entity->get_property("omitted").get_int() == 1);
+
+  return !omitted;
+}
+
+TEST(TextMesh, twoHexesSerial)
+{
+  if (get_parallel_size() != 1) {
+    GTEST_SKIP();
+  }
+
+  std::string meshDesc = "0,1,HEX_8,1,2,3,4,5,6,7,8,block_1\n"
+                         "0,2,HEX_8,5,6,7,8,9,10,11,12,block_2";
+
+  Iotm::DatabaseIO *db_io = create_input_db_io(meshDesc);
+  db_io->set_surface_split_type(Ioss::SPLIT_BY_ELEMENT_BLOCK);
+
+  Ioss::Region region(db_io);
+
+  EXPECT_TRUE(nullptr != db_io);
+  EXPECT_TRUE(db_io->ok());
+  EXPECT_EQ("TextMesh", db_io->get_format());
+
+  const std::vector<Ioss::ElementBlock *> &element_blocks = region.get_element_blocks();
+  EXPECT_EQ(2u, element_blocks.size());
+
+  EXPECT_EQ(1u, element_blocks[0]->entity_count());
+  EXPECT_EQ(1u, element_blocks[1]->entity_count());
+
+  EXPECT_EQ(Ioss::Hex8::name, element_blocks[0]->topology()->name());
+  EXPECT_EQ(Ioss::Hex8::name, element_blocks[1]->topology()->name());
+}
+
+TEST(TextMesh, twoHexesParallel)
+{
+  if (get_parallel_size() != 2) {
+    GTEST_SKIP();
+  }
+
+  std::string meshDesc = "0,1,HEX_8,1,2,3,4,5,6,7,8,block_1\n"
+                         "1,2,HEX_8,5,6,7,8,9,10,11,12,block_2";
+
+  Iotm::DatabaseIO *db_io = create_input_db_io(meshDesc);
+  db_io->set_surface_split_type(Ioss::SPLIT_BY_ELEMENT_BLOCK);
+
+  Ioss::Region region(db_io);
+
+  EXPECT_TRUE(nullptr != db_io);
+  EXPECT_TRUE(db_io->ok());
+  EXPECT_EQ("TextMesh", db_io->get_format());
+
+  const std::vector<Ioss::ElementBlock *> &element_blocks = region.get_element_blocks();
+  EXPECT_EQ(2u, element_blocks.size());
+
+  if(get_parallel_rank() == 0) {
+    EXPECT_EQ(1u, element_blocks[0]->entity_count());
+    EXPECT_EQ(0u, element_blocks[1]->entity_count());
+  } else {
+    EXPECT_EQ(0u, element_blocks[0]->entity_count());
+    EXPECT_EQ(1u, element_blocks[1]->entity_count());
+  }
+
+  EXPECT_EQ(Ioss::Hex8::name, element_blocks[0]->topology()->name());
+  EXPECT_EQ(Ioss::Hex8::name, element_blocks[1]->topology()->name());
+}
+
+TEST(TextMesh, twoHexesParallel_skipBlock1)
+{
+  if (get_parallel_size() != 2) {
+    GTEST_SKIP();
+  }
+
+  std::string meshDesc = "0,1,HEX_8,1,2,3,4,5,6,7,8,block_1\n"
+                         "1,2,HEX_8,5,6,7,8,9,10,11,12,block_2";
+
+  const std::vector<std::string> omittedBlocks{"block_1"};
+
+  Iotm::DatabaseIO *db_io = create_input_db_io(meshDesc);
+  db_io->set_surface_split_type(Ioss::SPLIT_BY_ELEMENT_BLOCK);
+  db_io->set_block_omissions(omittedBlocks);
+
+  Ioss::Region region(db_io);
+
+  EXPECT_TRUE(nullptr != db_io);
+  EXPECT_TRUE(db_io->ok());
+  EXPECT_EQ("TextMesh", db_io->get_format());
+
+  const std::vector<Ioss::ElementBlock *> &element_blocks = region.get_element_blocks();
+  EXPECT_EQ(2u, element_blocks.size());
+
+  EXPECT_FALSE(include_entity(element_blocks[0]));
+  EXPECT_TRUE(include_entity(element_blocks[1]));
+}
+
+}
+
+


### PR DESCRIPTION
The text mesh database did not support omitted element blocks and assemblies . This is a fix to enable that oversight