### PR TITLE
TextMesh: Enable block membership capability for sidesets and sideblocks

### DIFF
--- a/packages/seacas/libraries/ioss/src/text_mesh/Iotm_DatabaseIO.C
+++ b/packages/seacas/libraries/ioss/src/text_mesh/Iotm_DatabaseIO.C
@@ -856,4 +856,11 @@ namespace Iotm {
       entity->field_add(Ioss::Field(var_name, Ioss::Field::REAL, "scalar", Ioss::Field::TRANSIENT));
     }
   }
+
+  void DatabaseIO::compute_block_membership_nl(Ioss::SideBlock *efblock,
+                                               std::vector<std::string> &block_membership) const
+  {
+    m_textMesh->compute_block_membership(efblock->owner()->name(), efblock->name(), block_membership);
+  }
+
 } // namespace Iotm

--- a/packages/seacas/libraries/ioss/src/text_mesh/Iotm_DatabaseIO.h
+++ b/packages/seacas/libraries/ioss/src/text_mesh/Iotm_DatabaseIO.h
@@ -101,6 +101,9 @@ namespace Iotm {
     void get_commsets();
     void get_assemblies();
 
+    void compute_block_membership_nl(Ioss::SideBlock * efblock,
+                                     std::vector<std::string> & block_membership) const override;
+
     void update_block_omissions_from_assemblies();
 
     const Ioss::Map &get_node_map() const;

--- a/packages/seacas/libraries/ioss/src/text_mesh/Iotm_TextMesh.h
+++ b/packages/seacas/libraries/ioss/src/text_mesh/Iotm_TextMesh.h
@@ -30,29 +30,31 @@
 #include "iotm_export.h"
 
 namespace Iotm {
-  using Topology       = TopologyMapEntry;
-  using TextMeshData   = text_mesh::TextMeshData<int64_t, Topology>;
-  using ElementData    = text_mesh::ElementData<int64_t, Topology>;
-  using SidesetData    = text_mesh::SidesetData<int64_t, Topology>;
-  using NodesetData    = text_mesh::NodesetData<int64_t>;
-  using Assemblies     = text_mesh::Assemblies<int64_t>;
-  using AssemblyData   = text_mesh::AssemblyData;
-  using Coordinates    = text_mesh::Coordinates<int64_t>;
-  using TextMeshParser = text_mesh::TextMeshParser<int64_t, IossTopologyMapping>;
-  using ErrorHandler   = text_mesh::ErrorHandler;
-  using SideBlockInfo  = text_mesh::SideBlockInfo;
-  using SplitType      = text_mesh::SplitType;
-  using AssemblyType   = text_mesh::AssemblyType;
+  using EntityId        = int64_t;
+  using Topology        = TopologyMapEntry;
+  using TextMeshData    = text_mesh::TextMeshData<EntityId, Topology>;
+  using ElementData     = text_mesh::ElementData<EntityId, Topology>;
+  using ElementDataLess = text_mesh::ElementDataLess<EntityId, Topology>;
+  using SidesetData     = text_mesh::SidesetData<EntityId, Topology>;
+  using NodesetData     = text_mesh::NodesetData<EntityId>;
+  using Assemblies      = text_mesh::Assemblies<EntityId>;
+  using AssemblyData    = text_mesh::AssemblyData;
+  using Coordinates     = text_mesh::Coordinates<EntityId>;
+  using TextMeshParser  = text_mesh::TextMeshParser<EntityId, IossTopologyMapping>;
+  using ErrorHandler    = text_mesh::ErrorHandler;
+  using SideBlockInfo   = text_mesh::SideBlockInfo;
+  using SplitType       = text_mesh::SplitType;
+  using AssemblyType    = text_mesh::AssemblyType;
 
   struct IOTM_EXPORT BlockPartition
   {
-    size_t            offset;
-    std::string       name;
-    std::set<int64_t> elemIds;
+    size_t             offset;
+    std::string        name;
+    std::set<EntityId> elemIds;
 
     BlockPartition() : offset(0), name("") {}
 
-    BlockPartition(size_t offset_, const std::string &name_, const std::set<int64_t> &elemIds_)
+    BlockPartition(size_t offset_, const std::string &name_, const std::set<EntityId> &elemIds_)
         : offset(offset_), name(name_), elemIds(elemIds_)
     {
     }
@@ -93,12 +95,12 @@ namespace Iotm {
     /**
      * Return number of nodeset nodes on nodeset 'id'
      */
-    int64_t nodeset_node_count(int64_t id) const;
+    int64_t nodeset_node_count(EntityId id) const;
 
     /**
      * Return number of nodeset nodes on nodeset 'id' on the current processor
      */
-    virtual int64_t nodeset_node_count_proc(int64_t id) const;
+    virtual int64_t nodeset_node_count_proc(EntityId id) const;
 
     /**
      * Return number of sidesets in the entire model.
@@ -108,24 +110,24 @@ namespace Iotm {
     /**
      * Return number of sideset 'sides' on sideset 'id'
      */
-    int64_t sideset_side_count(int64_t id) const;
+    int64_t sideset_side_count(EntityId id) const;
 
     /**
      * Return number of sideset 'sides' on sideset 'id' on the current
      * processor.
      */
-    virtual int64_t sideset_side_count_proc(int64_t id) const;
+    virtual int64_t sideset_side_count_proc(EntityId id) const;
 
     /**
      * Return number of sideblock 'sides' on sideset 'id' and sideblock 'sideBlockName'
      */
-    int64_t sideblock_side_count(int64_t id, const std::string &sideBlockName) const;
+    int64_t sideblock_side_count(EntityId id, const std::string &sideBlockName) const;
 
     /**
      * Return number of sideset 'sides' on sideset 'id' and sideblock 'sideBlockName' on the current
      * processor.
      */
-    virtual int64_t sideblock_side_count_proc(int64_t id, const std::string &sideBlockName) const;
+    virtual int64_t sideblock_side_count_proc(EntityId id, const std::string &sideBlockName) const;
 
     /**
      * Return number of elements in all element blocks in the model.
@@ -142,13 +144,13 @@ namespace Iotm {
      * Return number of elements in the element block with id
      * 'block_number'.
      */
-    virtual int64_t element_count(int64_t block_number) const;
+    virtual int64_t element_count(EntityId block_number) const;
 
     /**
      * Return number of elements on this processor in the element
      * block with id 'block_number'.
      */
-    int64_t element_count_proc(int64_t block_number) const;
+    int64_t element_count_proc(EntityId block_number) const;
 
     /**
      * Return number of assemblies in the entire model.
@@ -160,11 +162,11 @@ namespace Iotm {
      * nodes / element". The topology type string will be "hex8" for
      * the hex element block and "shell4" for the shell element blocks.
      */
-    virtual std::pair<std::string, int> topology_type(int64_t block_number) const;
+    virtual std::pair<std::string, int> topology_type(EntityId block_number) const;
 
     virtual int64_t communication_node_count_proc() const;
     virtual void    node_communication_map(Ioss::Int64Vector &map, std::vector<int> &proc);
-    virtual void    owning_processor(int *owner, int64_t num_node);
+    virtual void    owning_processor(int *owner, EntityId num_node);
     /**
      * Fill the passed in 'map' argument with the node map
      * "map[local_position] = global_id" for the nodes on this
@@ -178,8 +180,8 @@ namespace Iotm {
      * "map[local_position] = global_id" for the elements on this
      * processor in block "block_number".
      */
-    virtual void element_map(int64_t block_number, Ioss::Int64Vector &map) const;
-    virtual void element_map(int64_t block_number, Ioss::IntVector &map) const;
+    virtual void element_map(EntityId block_number, Ioss::Int64Vector &map) const;
+    virtual void element_map(EntityId block_number, Ioss::IntVector &map) const;
 
     /**
      * Fill the passed in 'map' argument with the element map
@@ -199,10 +201,10 @@ namespace Iotm {
      * size required to contain the nodal connectivity for the
      * specified block; all information in 'connect' will be overwritten.
      */
-    void         connectivity(int64_t block_number, Ioss::Int64Vector &connect) const;
-    void         connectivity(int64_t block_number, Ioss::IntVector &connect) const;
-    void         connectivity(int64_t block_number, int64_t *connect) const;
-    virtual void connectivity(int64_t block_number, int *connect) const;
+    void         connectivity(EntityId block_number, Ioss::Int64Vector &connect) const;
+    void         connectivity(EntityId block_number, Ioss::IntVector &connect) const;
+    void         connectivity(EntityId block_number, EntityId *connect) const;
+    virtual void connectivity(EntityId block_number, int *connect) const;
 
     /**
      * Return the coordinates for all nodes on this processor.  The
@@ -240,7 +242,7 @@ namespace Iotm {
      * The 'nodes' vector will be resized to the size required to
      * contain the node list. The ids are global ids.
      */
-    virtual void nodeset_nodes(int64_t id, Ioss::Int64Vector &nodes) const;
+    virtual void nodeset_nodes(EntityId id, Ioss::Int64Vector &nodes) const;
 
     /**
      * Return the list of the face/ordinal pairs
@@ -251,11 +253,11 @@ namespace Iotm {
      * required to contain the list. The element ids are global ids,
      * the side ordinal is 0-based.
      */
-    virtual void sideset_elem_sides(int64_t id, Ioss::Int64Vector &elemSides) const;
-    virtual void sideblock_elem_sides(int64_t sidesetId, const std::string &sideBlockName,
+    virtual void sideset_elem_sides(EntityId id, Ioss::Int64Vector &elemSides) const;
+    virtual void sideblock_elem_sides(EntityId sidesetId, const std::string &sideBlockName,
                                       Ioss::Int64Vector &elemSides) const;
 
-    virtual std::vector<std::string> sideset_touching_blocks(int64_t set_id) const;
+    virtual std::vector<std::string> sideset_touching_blocks(EntityId set_id) const;
 
     size_t get_variable_count(Ioss::EntityType type) const
     {
@@ -266,22 +268,22 @@ namespace Iotm {
 
     // Element block query
     std::vector<std::string> get_part_names() const;
-    int64_t                  get_part_id(const std::string &name) const;
+    EntityId                 get_part_id(const std::string &name) const;
 
     // Nodeset query
     std::vector<std::string> get_nodeset_names() const;
-    std::string              get_nodeset_name(int64_t id) const;
-    int64_t                  get_nodeset_id(const std::string &name) const;
+    std::string              get_nodeset_name(EntityId id) const;
+    EntityId                 get_nodeset_id(const std::string &name) const;
 
     // Sideset query
     std::vector<std::string> get_sideset_names() const;
-    std::string              get_sideset_name(int64_t id) const;
-    int64_t                  get_sideset_id(const std::string &name) const;
+    std::string              get_sideset_name(EntityId id) const;
+    EntityId                 get_sideset_id(const std::string &name) const;
 
     // Assembly query
     std::vector<std::string> get_assembly_names() const;
-    std::string              get_assembly_name(int64_t id) const;
-    int64_t                  get_assembly_id(const std::string &name) const;
+    std::string              get_assembly_name(EntityId id) const;
+    EntityId                 get_assembly_id(const std::string &name) const;
     Ioss::EntityType         get_assembly_type(const std::string &name) const;
     std::vector<std::string> get_assembly_members(const std::string &name) const;
 
@@ -300,10 +302,14 @@ namespace Iotm {
                                                             const SideBlockInfo &info) const;
     SplitType                  get_sideset_split_type(const std::string &name) const;
 
+    void compute_block_membership(const std::string& sideSetName,
+                                  const std::string& sideBlockName,
+                                  std::vector<std::string> &block_membership) const;
+
   private:
-    template <typename INT> void raw_element_map(int64_t block_number, std::vector<INT> &map) const;
+    template <typename INT> void raw_element_map(EntityId block_number, std::vector<INT> &map) const;
     template <typename INT> void raw_element_map(std::vector<INT> &map) const;
-    template <typename INT> void raw_connectivity(int64_t block_number, INT *connect) const;
+    template <typename INT> void raw_connectivity(EntityId block_number, INT *connect) const;
     template <typename INT> void raw_node_map(std::vector<INT> &map) const;
 
     void set_variable_count(const std::string &type, size_t count);
@@ -314,14 +320,18 @@ namespace Iotm {
     void build_block_partition_map();
     void build_element_connectivity_map();
 
-    std::vector<int64_t> get_part_ids(const std::vector<std::string> &partNames);
-    std::vector<size_t>  get_part_offsets(const std::vector<int64_t> &partIds);
+    std::vector<EntityId> get_part_ids(const std::vector<std::string> &partNames);
+    std::vector<size_t>   get_part_offsets(const std::vector<EntityId> &partIds);
 
-    Topology get_topology_for_part(int64_t id) const;
+    Topology get_topology_for_part(EntityId id) const;
 
-    std::set<int64_t> get_local_element_ids_for_block(int64_t id) const;
+    std::set<EntityId> get_local_element_ids_for_block(EntityId id) const;
 
     std::set<std::string> get_blocks_touched_by_sideset(const SidesetData *sideset) const;
+
+    void compute_block_membership_impl(const SidesetData& sidesetData,
+                                       const SideBlockInfo& sideBlock,
+                                       std::vector<std::string>& sideBlockTouchingBlockParts) const;
 
     size_t m_myProcessor{0};
 
@@ -334,8 +344,8 @@ namespace Iotm {
 
     std::unordered_map<std::string, Topology> m_partToTopology;
 
-    std::unordered_map<int64_t, BlockPartition> m_blockPartition;
+    std::unordered_map<EntityId, BlockPartition> m_blockPartition;
 
-    std::unordered_map<int64_t, std::vector<int64_t>> m_elementConnectivity;
+    std::unordered_map<EntityId, std::vector<EntityId>> m_elementConnectivity;
   };
 } // namespace Iotm


### PR DESCRIPTION
Propagated consistent EntityId (int64_t) through code

Added unit tests for various forms of sideset/sideblock creation
