### PR TITLE
IOSS: Move transform factory from Iotr to Ioss

### DIFF
--- a/packages/seacas/applications/ejoin/EJoin.C
+++ b/packages/seacas/applications/ejoin/EJoin.C
@@ -31,7 +31,6 @@
 #include <Ioss_SmartAssert.h>
 #include <Ioss_SubSystem.h>
 #include <Ioss_Transform.h>
-#include <Ioss_TransformFactory.h>
 
 #include "EJ_CodeTypes.h"
 #include "EJ_SystemInterface.h"
@@ -228,7 +227,7 @@ int main(int argc, char *argv[])
       if (p > 0 && (offset.x != 0.0 || offset.y != 0.0 || offset.z != 0.0)) {
         Ioss::NodeBlock *nb        = part_mesh[p]->get_node_blocks()[0];
         Ioss::Field      coord     = nb->get_field("mesh_model_coordinates");
-        Ioss::Transform *transform = Ioss::TransformFactory::create("offset3D");
+        Ioss::Transform *transform = Ioss::create_transform("offset3D");
         assert(transform != nullptr);
         std::vector<double> values(3);
         values[0] = offset.x * p;

--- a/packages/seacas/applications/ejoin/EJoin.C
+++ b/packages/seacas/applications/ejoin/EJoin.C
@@ -31,7 +31,7 @@
 #include <Ioss_SmartAssert.h>
 #include <Ioss_SubSystem.h>
 #include <Ioss_Transform.h>
-#include <transform/Iotr_Factory.h>
+#include <Ioss_TransformFactory.h>
 
 #include "EJ_CodeTypes.h"
 #include "EJ_SystemInterface.h"
@@ -228,7 +228,7 @@ int main(int argc, char *argv[])
       if (p > 0 && (offset.x != 0.0 || offset.y != 0.0 || offset.z != 0.0)) {
         Ioss::NodeBlock *nb        = part_mesh[p]->get_node_blocks()[0];
         Ioss::Field      coord     = nb->get_field("mesh_model_coordinates");
-        Ioss::Transform *transform = Iotr::Factory::create("offset3D");
+        Ioss::Transform *transform = Ioss::TransformFactory::create("offset3D");
         assert(transform != nullptr);
         std::vector<double> values(3);
         values[0] = offset.x * p;

--- a/packages/seacas/applications/ejoin/EJoin.C
+++ b/packages/seacas/applications/ejoin/EJoin.C
@@ -227,7 +227,7 @@ int main(int argc, char *argv[])
       if (p > 0 && (offset.x != 0.0 || offset.y != 0.0 || offset.z != 0.0)) {
         Ioss::NodeBlock *nb        = part_mesh[p]->get_node_blocks()[0];
         Ioss::Field      coord     = nb->get_field("mesh_model_coordinates");
-        auto            *transform = Ioss::create_transform("offset3D");
+        auto            *transform = Ioss::Transform::create("offset3D");
         assert(transform != nullptr);
         std::vector<double> values(3);
         values[0] = offset.x * p;

--- a/packages/seacas/applications/ejoin/EJoin.C
+++ b/packages/seacas/applications/ejoin/EJoin.C
@@ -227,7 +227,7 @@ int main(int argc, char *argv[])
       if (p > 0 && (offset.x != 0.0 || offset.y != 0.0 || offset.z != 0.0)) {
         Ioss::NodeBlock *nb        = part_mesh[p]->get_node_blocks()[0];
         Ioss::Field      coord     = nb->get_field("mesh_model_coordinates");
-        Ioss::Transform *transform = Ioss::create_transform("offset3D");
+        auto            *transform = Ioss::create_transform("offset3D");
         assert(transform != nullptr);
         std::vector<double> values(3);
         values[0] = offset.x * p;

--- a/packages/seacas/libraries/ioss/src/Ioss_Transform.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Transform.C
@@ -1,15 +1,21 @@
-// Copyright(C) 1999-2020 National Technology & Engineering Solutions
+// Copyright(C) 1999-2020, 2024 National Technology & Engineering Solutions
 // of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
 // NTESS, the U.S. Government retains certain rights in this software.
 //
 // See packages/seacas/LICENSE for details
 
 #include "Ioss_Transform.h"
+#include "Ioss_TransformFactory.h"
 #include <vector>
 
 namespace Ioss {
 
   class Field;
+
+  Transform *create_transform(const std::string &transform)
+  {
+    return Ioss::TransformFactory::create(transform);
+  }
 
   bool Transform::execute(const Ioss::Field &field, void *data)
   {

--- a/packages/seacas/libraries/ioss/src/Ioss_Transform.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Transform.C
@@ -14,7 +14,7 @@ namespace Ioss {
 
   Transform *create_transform(const std::string &transform)
   {
-    return Ioss::TransformFactory::create(transform);
+    return TransformFactory::create(transform);
   }
 
   bool Transform::execute(const Ioss::Field &field, void *data)

--- a/packages/seacas/libraries/ioss/src/Ioss_Transform.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Transform.C
@@ -12,7 +12,7 @@ namespace Ioss {
 
   class Field;
 
-  Transform *create_transform(const std::string &transform)
+  Transform *Transform::create(const std::string &transform)
   {
     return TransformFactory::create(transform);
   }

--- a/packages/seacas/libraries/ioss/src/Ioss_Transform.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Transform.h
@@ -37,5 +37,5 @@ namespace Ioss {
     virtual bool internal_execute(const Ioss::Field &field, void *data) = 0;
   };
 
-  Transform *create_transform(const std::string &transform);
+  IOSS_EXPORT Transform *create_transform(const std::string &transform);
 } // namespace Ioss

--- a/packages/seacas/libraries/ioss/src/Ioss_Transform.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Transform.h
@@ -36,4 +36,5 @@ namespace Ioss {
 
     virtual bool internal_execute(const Ioss::Field &field, void *data) = 0;
   };
+
 } // namespace Ioss

--- a/packages/seacas/libraries/ioss/src/Ioss_Transform.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Transform.h
@@ -37,4 +37,5 @@ namespace Ioss {
     virtual bool internal_execute(const Ioss::Field &field, void *data) = 0;
   };
 
+  Transform *create_transform(const std::string &transform);
 } // namespace Ioss

--- a/packages/seacas/libraries/ioss/src/Ioss_Transform.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Transform.h
@@ -31,11 +31,11 @@ namespace Ioss {
     virtual void set_properties(const std::string &name, const std::vector<int> &values);
     virtual void set_properties(const std::string &name, const std::vector<double> &values);
 
+    static Transform *create(const std::string &transform);
+
   protected:
     Transform() = default;
 
     virtual bool internal_execute(const Ioss::Field &field, void *data) = 0;
   };
-
-  IOSS_EXPORT Transform *create_transform(const std::string &transform);
 } // namespace Ioss

--- a/packages/seacas/libraries/ioss/src/Ioss_TransformFactory.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_TransformFactory.C
@@ -1,11 +1,11 @@
-// Copyright(C) 1999-2021 National Technology & Engineering Solutions
+// Copyright(C) 1999-2021, 2024, 2024 National Technology & Engineering Solutions
 // of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
 // NTESS, the U.S. Government retains certain rights in this software.
 //
 // See packages/seacas/LICENSE for details
 
+#include "Ioss_TransformFactory.h"
 #include "Ioss_Utils.h"
-#include "transform/Iotr_Factory.h"
 #include <map>
 #include <ostream>
 #include <string>
@@ -14,11 +14,8 @@
 
 namespace Ioss {
   class Transform;
-} // namespace Ioss
 
-namespace Iotr {
-
-  Ioss::Transform *Factory::create(const std::string &type)
+  Ioss::Transform *TransformFactory::create(const std::string &type)
   {
     Ioss::Transform *transform = nullptr;
     auto             iter      = registry().find(type);
@@ -36,20 +33,20 @@ namespace Iotr {
       }
     }
     else {
-      Factory *factory = (*iter).second;
-      transform        = factory->make(type);
+      TransformFactory *factory = (*iter).second;
+      transform                 = factory->make(type);
     }
     return transform;
   }
 
-  Ioss::NameList Factory::describe()
+  Ioss::NameList TransformFactory::describe()
   {
     Ioss::NameList names;
     describe(&names);
     return names;
   }
 
-  int Factory::describe(Ioss::NameList *names)
+  int TransformFactory::describe(Ioss::NameList *names)
   {
     int count = 0;
     for (const auto &entry : registry()) {
@@ -59,18 +56,21 @@ namespace Iotr {
     return count;
   }
 
-  Factory::Factory(const std::string &type) { registry().insert(std::make_pair(type, this)); }
-
-  void Factory::alias(const std::string &base, const std::string &syn)
+  TransformFactory::TransformFactory(const std::string &type)
   {
-    Factory *factory = (*registry().find(base)).second;
+    registry().insert(std::make_pair(type, this));
+  }
+
+  void TransformFactory::alias(const std::string &base, const std::string &syn)
+  {
+    TransformFactory *factory = (*registry().find(base)).second;
     registry().insert(std::make_pair(syn, factory));
   }
 
-  FactoryMap &Factory::registry()
+  TransformFactoryMap &TransformFactory::registry()
   {
-    static FactoryMap registry_;
+    static TransformFactoryMap registry_;
     return registry_;
   }
 
-} // namespace Iotr
+} // namespace Ioss

--- a/packages/seacas/libraries/ioss/src/Ioss_TransformFactory.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_TransformFactory.h
@@ -1,4 +1,4 @@
-// Copyright(C) 2022, 2023 National Technology & Engineering Solutions
+// Copyright(C) 2022, 2023, 2024 National Technology & Engineering Solutions
 // of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
 // NTESS, the U.S. Government retains certain rights in this software.
 //
@@ -11,32 +11,30 @@
 #include <map>
 #include <string>
 
-#include "iotr_export.h"
+#include "ioss_export.h"
 
 namespace Ioss {
   class Transform;
-} // namespace Ioss
 
-namespace Iotr {
-  class Factory;
+  class TransformFactory;
 
-  using FactoryMap = std::map<std::string, Factory *, std::less<>>;
+  using TransformFactoryMap = std::map<std::string, TransformFactory *, std::less<>>;
 
-  class IOTR_EXPORT Factory
+  class IOSS_EXPORT TransformFactory
   {
   public:
-    virtual ~Factory() = default;
+    virtual ~TransformFactory() = default;
     static Ioss::Transform *create(const std::string &type);
 
     static int            describe(Ioss::NameList *names);
     static Ioss::NameList describe();
 
   protected:
-    explicit Factory(const std::string &type);
+    explicit TransformFactory(const std::string &type);
     virtual Ioss::Transform *make(const std::string &) const = 0;
     static void              alias(const std::string &base, const std::string &syn);
 
   private:
-    static FactoryMap &registry();
+    static TransformFactoryMap &registry();
   };
-} // namespace Iotr
+} // namespace Ioss

--- a/packages/seacas/libraries/ioss/src/main/io_shell_ts.C
+++ b/packages/seacas/libraries/ioss/src/main/io_shell_ts.C
@@ -948,11 +948,11 @@ namespace {
         Ioss::Field tr_field(out_field_name, field.get_type(), field.raw_storage(),
                              field.get_role(), field.raw_count());
 
-        Ioss::Transform *transform = Ioss::create_transform("vector magnitude");
+        auto *transform = Ioss::create_transform("vector magnitude");
         assert(transform != nullptr);
         tr_field.add_transform(transform);
 
-        Ioss::Transform *max_transform = Ioss::create_transform("absolute_maximum");
+        auto *max_transform = Ioss::create_transform("absolute_maximum");
         assert(max_transform != nullptr);
         tr_field.add_transform(max_transform);
 

--- a/packages/seacas/libraries/ioss/src/main/io_shell_ts.C
+++ b/packages/seacas/libraries/ioss/src/main/io_shell_ts.C
@@ -948,11 +948,11 @@ namespace {
         Ioss::Field tr_field(out_field_name, field.get_type(), field.raw_storage(),
                              field.get_role(), field.raw_count());
 
-        auto *transform = Ioss::create_transform("vector magnitude");
+        auto *transform = Ioss::Transform::create("vector magnitude");
         assert(transform != nullptr);
         tr_field.add_transform(transform);
 
-        auto *max_transform = Ioss::create_transform("absolute_maximum");
+        auto *max_transform = Ioss::Transform::create("absolute_maximum");
         assert(max_transform != nullptr);
         tr_field.add_transform(max_transform);
 

--- a/packages/seacas/libraries/ioss/src/main/io_shell_ts.C
+++ b/packages/seacas/libraries/ioss/src/main/io_shell_ts.C
@@ -1,4 +1,4 @@
-// Copyright(C) 1999-2023 National Technology & Engineering Solutions
+// Copyright(C) 1999-2024 National Technology & Engineering Solutions
 // of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
 // NTESS, the U.S. Government retains certain rights in this software.
 //
@@ -17,7 +17,6 @@
 #include "Ioss_SurfaceSplit.h"
 #include "Ioss_Transform.h"
 #include "Ioss_Utils.h"
-#include "transform/Iotr_Factory.h"
 #include <fmt/format.h>
 
 #include <algorithm>
@@ -949,11 +948,11 @@ namespace {
         Ioss::Field tr_field(out_field_name, field.get_type(), field.raw_storage(),
                              field.get_role(), field.raw_count());
 
-        Ioss::Transform *transform = Iotr::Factory::create("vector magnitude");
+        Ioss::Transform *transform = Ioss::create_transform("vector magnitude");
         assert(transform != nullptr);
         tr_field.add_transform(transform);
 
-        Ioss::Transform *max_transform = Iotr::Factory::create("absolute_maximum");
+        Ioss::Transform *max_transform = Ioss::create_transform("absolute_maximum");
         assert(max_transform != nullptr);
         tr_field.add_transform(max_transform);
 

--- a/packages/seacas/libraries/ioss/src/transform/Iotr_MinMax.C
+++ b/packages/seacas/libraries/ioss/src/transform/Iotr_MinMax.C
@@ -1,4 +1,4 @@
-// Copyright(C) 1999-2021, 2023 National Technology & Engineering Solutions
+// Copyright(C) 1999-2021, 2023, 2024 National Technology & Engineering Solutions
 // of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
 // NTESS, the U.S. Government retains certain rights in this software.
 //
@@ -13,7 +13,7 @@
 #include <string> // for operator==, string
 
 #include "Ioss_Transform.h" // for Factory, Transform
-#include "Iotr_Factory.h"
+#include "Ioss_TransformFactory.h"
 
 namespace Iotr {
 
@@ -23,12 +23,12 @@ namespace Iotr {
     return &registerThis;
   }
 
-  MinMax_Factory::MinMax_Factory() : Factory("generic_minmax")
+  MinMax_Factory::MinMax_Factory() : Ioss::TransformFactory("generic_minmax")
   {
-    Factory::alias("generic_minmax", "minimum");
-    Factory::alias("generic_minmax", "maximum");
-    Factory::alias("generic_minmax", "absolute_minimum");
-    Factory::alias("generic_minmax", "absolute_maximum");
+    Ioss::TransformFactory::alias("generic_minmax", "minimum");
+    Ioss::TransformFactory::alias("generic_minmax", "maximum");
+    Ioss::TransformFactory::alias("generic_minmax", "absolute_minimum");
+    Ioss::TransformFactory::alias("generic_minmax", "absolute_maximum");
   }
 
   Ioss::Transform *MinMax_Factory::make(const std::string &type) const { return new MinMax(type); }

--- a/packages/seacas/libraries/ioss/src/transform/Iotr_MinMax.h
+++ b/packages/seacas/libraries/ioss/src/transform/Iotr_MinMax.h
@@ -1,4 +1,4 @@
-// Copyright(C) 1999-2022 National Technology & Engineering Solutions
+// Copyright(C) 1999-2022, 2024 National Technology & Engineering Solutions
 // of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
 // NTESS, the U.S. Government retains certain rights in this software.
 //
@@ -6,9 +6,9 @@
 
 #pragma once
 
-#include "Ioss_Transform.h"    // for Transform, Factory
+#include "Ioss_Transform.h" // for Transform, Factory
+#include "Ioss_TransformFactory.h"
 #include "Ioss_VariableType.h" // for VariableType
-#include "transform/Iotr_Factory.h"
 #include <stddef.h>
 #include <string> // for string
 
@@ -20,7 +20,7 @@ namespace Ioss {
 
 namespace Iotr {
 
-  class IOTR_EXPORT MinMax_Factory : public Factory
+  class IOTR_EXPORT MinMax_Factory : public Ioss::TransformFactory
   {
   public:
     static const MinMax_Factory *factory();

--- a/packages/seacas/libraries/ioss/src/transform/Iotr_Offset.C
+++ b/packages/seacas/libraries/ioss/src/transform/Iotr_Offset.C
@@ -1,4 +1,4 @@
-// Copyright(C) 1999-2021, 2023 National Technology & Engineering Solutions
+// Copyright(C) 1999-2021, 2023, 2024 National Technology & Engineering Solutions
 // of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
 // NTESS, the U.S. Government retains certain rights in this software.
 //
@@ -11,7 +11,7 @@
 #include <stdint.h>
 
 #include "Ioss_Transform.h"
-#include "Iotr_Factory.h"
+#include "Ioss_TransformFactory.h"
 
 namespace Iotr {
 
@@ -21,7 +21,10 @@ namespace Iotr {
     return &registerThis;
   }
 
-  Offset_Factory::Offset_Factory() : Factory("offset") { Factory::alias("offset", "add"); }
+  Offset_Factory::Offset_Factory() : Ioss::TransformFactory("offset")
+  {
+    Ioss::TransformFactory::alias("offset", "add");
+  }
 
   Ioss::Transform *Offset_Factory::make(const std::string & /*unused*/) const
   {

--- a/packages/seacas/libraries/ioss/src/transform/Iotr_Offset.h
+++ b/packages/seacas/libraries/ioss/src/transform/Iotr_Offset.h
@@ -7,7 +7,7 @@
 #pragma once
 
 #include "Ioss_Transform.h" // for Transform, Factory
-#include "transform/Iotr_Factory.h"
+#include "Ioss_TransformFactory.h"
 #include <stddef.h>
 #include <string> // for string
 
@@ -20,7 +20,7 @@ namespace Ioss {
 
 namespace Iotr {
 
-  class IOTR_EXPORT Offset_Factory : public Factory
+  class IOTR_EXPORT Offset_Factory : public Ioss::TransformFactory
   {
   public:
     static const Offset_Factory *factory();

--- a/packages/seacas/libraries/ioss/src/transform/Iotr_Offset3D.C
+++ b/packages/seacas/libraries/ioss/src/transform/Iotr_Offset3D.C
@@ -1,4 +1,4 @@
-// Copyright(C) 1999-2021, 2023 National Technology & Engineering Solutions
+// Copyright(C) 1999-2021, 2023, 2024 National Technology & Engineering Solutions
 // of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
 // NTESS, the U.S. Government retains certain rights in this software.
 //
@@ -13,7 +13,7 @@
 #include <vector>
 
 #include "Ioss_Transform.h"
-#include "Iotr_Factory.h"
+#include "Ioss_TransformFactory.h"
 
 namespace Iotr {
 
@@ -23,9 +23,9 @@ namespace Iotr {
     return &registerThis;
   }
 
-  Offset3D_Factory::Offset3D_Factory() : Factory("offset3D")
+  Offset3D_Factory::Offset3D_Factory() : Ioss::TransformFactory("offset3D")
   {
-    Factory::alias("offset3D", "add3D");
+    Ioss::TransformFactory::alias("offset3D", "add3D");
   }
 
   Ioss::Transform *Offset3D_Factory::make(const std::string & /*unused*/) const

--- a/packages/seacas/libraries/ioss/src/transform/Iotr_Offset3D.h
+++ b/packages/seacas/libraries/ioss/src/transform/Iotr_Offset3D.h
@@ -6,9 +6,9 @@
 
 #pragma once
 
-#include "Ioss_Transform.h"    // for Transform, Factory
+#include "Ioss_Transform.h" // for Transform, Factory
+#include "Ioss_TransformFactory.h"
 #include "Ioss_VariableType.h" // for VariableType
-#include "transform/Iotr_Factory.h"
 #include <stddef.h>
 #include <string> // for string
 #include <vector> // for vector
@@ -21,7 +21,7 @@ namespace Ioss {
 
 namespace Iotr {
 
-  class IOTR_EXPORT Offset3D_Factory : public Factory
+  class IOTR_EXPORT Offset3D_Factory : public Ioss::TransformFactory
   {
   public:
     static const Offset3D_Factory *factory();

--- a/packages/seacas/libraries/ioss/src/transform/Iotr_Scale.C
+++ b/packages/seacas/libraries/ioss/src/transform/Iotr_Scale.C
@@ -1,4 +1,4 @@
-// Copyright(C) 1999-2021, 2023 National Technology & Engineering Solutions
+// Copyright(C) 1999-2021, 2023, 2024 National Technology & Engineering Solutions
 // of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
 // NTESS, the U.S. Government retains certain rights in this software.
 //
@@ -11,7 +11,7 @@
 #include <stdint.h>
 
 #include "Ioss_Transform.h"
-#include "Iotr_Factory.h"
+#include "Ioss_TransformFactory.h"
 
 namespace Iotr {
 
@@ -21,7 +21,10 @@ namespace Iotr {
     return &registerThis;
   }
 
-  Scale_Factory::Scale_Factory() : Factory("scale") { Factory::alias("scale", "multiply"); }
+  Scale_Factory::Scale_Factory() : Ioss::TransformFactory("scale")
+  {
+    Ioss::TransformFactory::alias("scale", "multiply");
+  }
 
   Ioss::Transform *Scale_Factory::make(const std::string & /*unused*/) const { return new Scale(); }
 

--- a/packages/seacas/libraries/ioss/src/transform/Iotr_Scale.h
+++ b/packages/seacas/libraries/ioss/src/transform/Iotr_Scale.h
@@ -7,8 +7,8 @@
 #pragma once
 
 #include "Ioss_Transform.h"
+#include "Ioss_TransformFactory.h"
 #include "Ioss_VariableType.h"
-#include "transform/Iotr_Factory.h"
 #include <stddef.h>
 #include <string>
 
@@ -20,7 +20,7 @@ namespace Ioss {
 
 namespace Iotr {
 
-  class IOTR_EXPORT Scale_Factory : public Factory
+  class IOTR_EXPORT Scale_Factory : public Ioss::TransformFactory
   {
   public:
     static const Scale_Factory *factory();

--- a/packages/seacas/libraries/ioss/src/transform/Iotr_Scale3D.C
+++ b/packages/seacas/libraries/ioss/src/transform/Iotr_Scale3D.C
@@ -1,4 +1,4 @@
-// Copyright(C) 1999-2021, 2023 National Technology & Engineering Solutions
+// Copyright(C) 1999-2021, 2023, 2024 National Technology & Engineering Solutions
 // of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
 // NTESS, the U.S. Government retains certain rights in this software.
 //
@@ -13,7 +13,7 @@
 #include <vector>
 
 #include "Ioss_Transform.h"
-#include "Iotr_Factory.h"
+#include "Ioss_TransformFactory.h"
 
 namespace Iotr {
 
@@ -23,9 +23,9 @@ namespace Iotr {
     return &registerThis;
   }
 
-  Scale3D_Factory::Scale3D_Factory() : Factory("scale3D")
+  Scale3D_Factory::Scale3D_Factory() : Ioss::TransformFactory("scale3D")
   {
-    Factory::alias("scale3D", "multiply3D");
+    Ioss::TransformFactory::alias("scale3D", "multiply3D");
   }
 
   Ioss::Transform *Scale3D_Factory::make(const std::string & /*unused*/) const

--- a/packages/seacas/libraries/ioss/src/transform/Iotr_Scale3D.h
+++ b/packages/seacas/libraries/ioss/src/transform/Iotr_Scale3D.h
@@ -6,9 +6,9 @@
 
 #pragma once
 
-#include "Ioss_Transform.h"    // for Transform, Factory
+#include "Ioss_Transform.h" // for Transform, Factory
+#include "Ioss_TransformFactory.h"
 #include "Ioss_VariableType.h" // for VariableType
-#include "transform/Iotr_Factory.h"
 #include <stddef.h>
 #include <string>
 #include <vector>
@@ -24,7 +24,7 @@ namespace Ioss {
 
 namespace Iotr {
 
-  class IOTR_EXPORT Scale3D_Factory : public Factory
+  class IOTR_EXPORT Scale3D_Factory : public Ioss::TransformFactory
   {
   public:
     static const Scale3D_Factory *factory();

--- a/packages/seacas/libraries/ioss/src/transform/Iotr_Tensor.C
+++ b/packages/seacas/libraries/ioss/src/transform/Iotr_Tensor.C
@@ -1,4 +1,4 @@
-// Copyright(C) 1999-2021 National Technology & Engineering Solutions
+// Copyright(C) 1999-2021, 2024 National Technology & Engineering Solutions
 // of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
 // NTESS, the U.S. Government retains certain rights in this software.
 //
@@ -12,7 +12,7 @@
 #include <string>
 
 #include "Ioss_Transform.h"
-#include "Iotr_Factory.h"
+#include "Ioss_TransformFactory.h"
 
 namespace Iotr {
 
@@ -22,16 +22,16 @@ namespace Iotr {
     return &registerThis;
   }
 
-  Tensor_Factory::Tensor_Factory() : Factory("generic_tensor")
+  Tensor_Factory::Tensor_Factory() : Ioss::TransformFactory("generic_tensor")
   {
-    Factory::alias("generic_tensor", "trace");      // scalar
-    Factory::alias("generic_tensor", "deviator");   // tensor
-    Factory::alias("generic_tensor", "spherical");  // tensor
-    Factory::alias("generic_tensor", "invariants"); // vector
-    Factory::alias("generic_tensor", "invariant1"); // scalar
-    Factory::alias("generic_tensor", "invariant2"); // scalar
-    Factory::alias("generic_tensor", "invariant3"); // scalar
-    Factory::alias("generic_tensor", "magnitude");  // scalar
+    Ioss::TransformFactory::alias("generic_tensor", "trace");      // scalar
+    Ioss::TransformFactory::alias("generic_tensor", "deviator");   // tensor
+    Ioss::TransformFactory::alias("generic_tensor", "spherical");  // tensor
+    Ioss::TransformFactory::alias("generic_tensor", "invariants"); // vector
+    Ioss::TransformFactory::alias("generic_tensor", "invariant1"); // scalar
+    Ioss::TransformFactory::alias("generic_tensor", "invariant2"); // scalar
+    Ioss::TransformFactory::alias("generic_tensor", "invariant3"); // scalar
+    Ioss::TransformFactory::alias("generic_tensor", "magnitude");  // scalar
   }
 
   Ioss::Transform *Tensor_Factory::make(const std::string &type) const { return new Tensor(type); }

--- a/packages/seacas/libraries/ioss/src/transform/Iotr_Tensor.h
+++ b/packages/seacas/libraries/ioss/src/transform/Iotr_Tensor.h
@@ -6,9 +6,9 @@
 
 #pragma once
 
-#include "Ioss_Transform.h"    // for Transform, Factory
+#include "Ioss_Transform.h" // for Transform, Factory
+#include "Ioss_TransformFactory.h"
 #include "Ioss_VariableType.h" // for VariableType
-#include "transform/Iotr_Factory.h"
 #include <stddef.h>
 #include <string> // for string
 
@@ -20,7 +20,7 @@ namespace Ioss {
 
 namespace Iotr {
 
-  class IOTR_EXPORT Tensor_Factory : public Factory
+  class IOTR_EXPORT Tensor_Factory : public Ioss::TransformFactory
   {
   public:
     static const Tensor_Factory *factory();

--- a/packages/seacas/libraries/ioss/src/transform/Iotr_VectorMagnitude.C
+++ b/packages/seacas/libraries/ioss/src/transform/Iotr_VectorMagnitude.C
@@ -1,4 +1,4 @@
-// Copyright(C) 1999-2021 National Technology & Engineering Solutions
+// Copyright(C) 1999-2021, 2024 National Technology & Engineering Solutions
 // of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
 // NTESS, the U.S. Government retains certain rights in this software.
 //
@@ -11,7 +11,7 @@
 #include <cstddef>
 
 #include "Ioss_Transform.h"
-#include "Iotr_Factory.h"
+#include "Ioss_TransformFactory.h"
 
 namespace Iotr {
 
@@ -21,9 +21,9 @@ namespace Iotr {
     return &registerThis;
   }
 
-  VM_Factory::VM_Factory() : Factory("vector magnitude")
+  VM_Factory::VM_Factory() : Ioss::TransformFactory("vector magnitude")
   {
-    Factory::alias("vector magnitude", "length");
+    Ioss::TransformFactory::alias("vector magnitude", "length");
   }
 
   Ioss::Transform *VM_Factory::make(const std::string & /*unused*/) const

--- a/packages/seacas/libraries/ioss/src/transform/Iotr_VectorMagnitude.h
+++ b/packages/seacas/libraries/ioss/src/transform/Iotr_VectorMagnitude.h
@@ -6,9 +6,9 @@
 
 #pragma once
 
-#include "Ioss_Transform.h"    // for Transform, Factory
+#include "Ioss_Transform.h" // for Transform, Factory
+#include "Ioss_TransformFactory.h"
 #include "Ioss_VariableType.h" // for VariableType
-#include "transform/Iotr_Factory.h"
 #include <stddef.h>
 #include <string> // for string
 
@@ -20,7 +20,7 @@ namespace Ioss {
 
 namespace Iotr {
 
-  class IOTR_EXPORT VM_Factory : public Factory
+  class IOTR_EXPORT VM_Factory : public Ioss::TransformFactory
   {
   public:
     static const VM_Factory *factory();


### PR DESCRIPTION
Move the Iotr::Factory to Ioss::TransformFactory to make it easier/clearer for clients on how to create and work with transforms.  No longer need to be concerned with the transform/ subdirectory.