### PR TITLE
EXODUS_FOR: Refactor to avoid fortran malloc free

### DIFF
--- a/packages/seacas/cmake/FortranSettings.cmake
+++ b/packages/seacas/cmake/FortranSettings.cmake
@@ -8,7 +8,7 @@ IF (${PROJECT_NAME}_ENABLE_Fortran)
 ENDIF()
 
 IF ("${CMAKE_Fortran_COMPILER_ID}" MATCHES "GNU")
-  SET(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fcray-pointer -fdefault-real-8 -fdefault-integer-8 -fno-range-check")
+  SET(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fdefault-real-8 -fdefault-integer-8 -fno-range-check")
 ELSEIF ("${CMAKE_Fortran_COMPILER_ID}" MATCHES "LLVMFlang")
   SET(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fdefault-real-8 -fdefault-integer-8")
 ELSEIF ("${CMAKE_Fortran_COMPILER_ID}" MATCHES "XL")

--- a/packages/seacas/libraries/exodus_for/src/addrwrap.F
+++ b/packages/seacas/libraries/exodus_for/src/addrwrap.F
@@ -187,21 +187,14 @@ C       READ COORDINATE FRAMES
 
         INTEGER*4 IDEXO4        ! (R)
         integer*4 nframe4       ! (R)
-        integer*4 itags4(1)     ! (W)
         INTEGER*4 IERR4         ! (W)
-
-        POINTER (PITAGS4, ITAGS4)
 
         idexo4 = idexo
 
         NFRAME = EXINQI (IDEXO, EXNCF)
         NFRAME4 = NFRAME
 
-        CALL I4ALLOC (NFRAME, PITAGS4)
-
-        call exgfrm4(idexo4, nframe4, idscf, coord, itags4, ierr4)
-
-        CALL I4I8 (NFRAME, PITAGS4, ITAGS)
+        call exgfrm4(idexo4, nframe4, idscf, coord, itags, ierr4)
         ierr = ierr4
 
         END
@@ -224,19 +217,12 @@ C       DEFINE/WRITE COORDINATE FRAMES
 
         INTEGER*4 IDEXO4        ! (R)
         integer*4 nframe4       ! (R)
-        integer*4 itags4(1)     ! (R)
         INTEGER*4 IERR4         ! (W)
-
-        POINTER (PITAGS4, ITAGS4)
 
         idexo4 = idexo
         NFRAME4 = NFRAME
 
-        CALL I8I4 (NFRAME, ITAGS, PITAGS4)
-
-        call expfrm4(idexo4, nframe4, idscf, coord, itags4, ierr4)
-
-        CALL I4FREE (PITAGS4)
+        call expfrm4(idexo4, nframe4, idscf, coord, itags, ierr4)
         ierr = ierr4
 
         END
@@ -463,24 +449,11 @@ C>       READ ENTITY_COUNT-PER-POLYHEDRA
 
         INTEGER*4 IDEXO4        ! (R)
         INTEGER*4 ITYPE4        ! (R)
-        INTEGER*4 COUNTS4 (1)   ! (NUMELB) ! (W)
-        POINTER (PCOUNTS4, COUNTS4)
         INTEGER*4 IERR4         ! (W)
-
-        CHARACTER* (MXSTLN) NAMELB
-
-        INTEGER NUMELB
-        INTEGER NUMATR
-        INTEGER NUMLNK
 
         IDEXO4 = IDEXO
         ITYPE4 = ITYPE
-        CALL EXGELB4 (IDEXO4, IDELB, NAMELB, NUMELB, NUMLNK,
-     &          NUMATR, IERR4)
-
-        CALL I4ALLOC (NUMELB, PCOUNTS4)
-        CALL EXGECPP4 (IDEXO4, ITYPE4, IDELB, COUNTS4, IERR4)
-        CALL I4I8 (NUMELB, PCOUNTS4, COUNTS)
+        CALL EXGECPP4 (IDEXO4, ITYPE4, IDELB, COUNTS, IERR4)
         IERR = IERR4
         END
 
@@ -1226,21 +1199,12 @@ C>       READ SIDE SET NODE LIST COUNT
         INTEGER IERR            ! (W)
 
         INTEGER*4 IDEXO4        ! (R)
-        INTEGER*4 INCNT4 (1)    ! (W)
-        POINTER (PINCNT4, INCNT4)
         INTEGER*4 IERR4         ! (W)
 
-        INTEGER   NDESS
-        INTEGER   NINCNT
-
         IDEXO4 = IDEXO
-        CALL EXGSP4 (IDEXO4, IDESS, NINCNT, NDESS, IERR4)
-        CALL I4ALLOC (NINCNT, PINCNT4)
-
-        CALL EXGSSC4 (IDEXO4, IDESS, INCNT4, IERR4)
-
-        CALL I4I8 (NINCNT, PINCNT4, INCNT)
+        CALL EXGSSC4 (IDEXO4, IDESS, INCNT, IERR4)
         IERR = IERR4
+        
         END
 
         SUBROUTINE EXGCSSC (IDEXO, INCNT, IERR)
@@ -1256,20 +1220,10 @@ C>       (nodes/face for all faces)
         INTEGER IERR            ! (W)
 
         INTEGER*4 IDEXO4        ! (R)
-        INTEGER*4 INCNT4 (1)    ! (W)
-        POINTER (PINCNT4, INCNT4)
         INTEGER*4 IERR4         ! (W)
 
-        INTEGER   NINCNT
-
         IDEXO4 = IDEXO
-        NINCNT = EXINQI (IDEXO, EXSSEL)
-
-        CALL I4ALLOC (NINCNT, PINCNT4)
-
-        CALL EXGCSSC4 (IDEXO4, INCNT4, IERR4)
-
-        CALL I4I8 (NINCNT, PINCNT4, INCNT)
+        CALL EXGCSSC4 (IDEXO4, INCNT, IERR4)
         IERR = IERR4
         END
 
@@ -1402,16 +1356,12 @@ C>       READ ELEMENT VARIABLE TRUTH TABLE
         INTEGER*4 IDEXO4        ! (R)
         INTEGER*4 NELBLK4       ! (R)
         INTEGER*4 NVAREL4       ! (R)
-        INTEGER*4 ISEVOK4(1)    ! (NVAREL,NELBLK) (W)
-        POINTER (PISEVOK4, ISEVOK4)
         INTEGER*4 IERR4         ! (W)
 
         IDEXO4 = IDEXO
         NELBLK4 = NELBLK
         NVAREL4 = NVAREL
-        CALL I4ALLOC (NVAREL*NELBLK, PISEVOK4)
-        CALL EXGVTT4 (IDEXO4, NELBLK4, NVAREL4, ISEVOK4, IERR4)
-        CALL I4I8 (NVAREL*NELBLK, PISEVOK4, ISEVOK)
+        CALL EXGVTT4 (IDEXO4, NELBLK4, NVAREL4, ISEVOK, IERR4)
         IERR = IERR4
         END
 
@@ -1431,16 +1381,12 @@ C>       READ NODESET VARIABLE TRUTH TABLE
         INTEGER*4 IDEXO4        ! (R)
         INTEGER*4 NBLK4         ! (R)
         INTEGER*4 NVAR4         ! (R)
-        INTEGER*4 ISVOK4(1)     ! (NVAR,NBLK) (W)
-        POINTER (PISVOK4, ISVOK4)
         INTEGER*4 IERR4         ! (W)
 
         IDEXO4 = IDEXO
         NBLK4  = NBLK
         NVAR4  = NVAR
-        CALL I4ALLOC (NVAR*NBLK, PISVOK4)
-        CALL EXGNSTT4 (IDEXO4, NBLK4, NVAR4, ISVOK4, IERR4)
-        CALL I4I8 (NVAR*NBLK, PISVOK4, ISVOK)
+        CALL EXGNSTT4 (IDEXO4, NBLK4, NVAR4, ISVOK, IERR4)
         IERR = IERR4
         END
 
@@ -1460,16 +1406,12 @@ C>       READ SIDESET VARIABLE TRUTH TABLE
         INTEGER*4 IDEXO4        ! (R)
         INTEGER*4 NBLK4         ! (R)
         INTEGER*4 NVAR4         ! (R)
-        INTEGER*4 ISVOK4(1)     ! (NVAR,NBLK) (W)
-        POINTER (PISVOK4, ISVOK4)
         INTEGER*4 IERR4         ! (W)
 
         IDEXO4 = IDEXO
         NBLK4  = NBLK
         NVAR4  = NVAR
-        CALL I4ALLOC (NVAR*NBLK, PISVOK4)
-        CALL EXGSSTT4 (IDEXO4, NBLK4, NVAR4, ISVOK4, IERR4)
-        CALL I4I8 (NVAR*NBLK, PISVOK4, ISVOK)
+        CALL EXGSSTT4 (IDEXO4, NBLK4, NVAR4, ISVOK, IERR4)
         IERR = IERR4
         END
 
@@ -1900,25 +1842,12 @@ C>       WRITE ELEMENT BLOCK ELEMENT COUNT PER POLYHEDRA
 
         INTEGER*4 IDEXO4        ! (R)
         INTEGER*4 ITYPE4        ! (R)
-        INTEGER*4 COUNTS4 (1)   ! (NUMELB) ! (R)
-        POINTER (PCOUNTS4, COUNTS4)
         INTEGER*4 IERR4         ! (W)
-
-        CHARACTER* (MXSTLN) NAMELB
-
-        INTEGER   NUMELB
-        INTEGER   NUMLNK
-        INTEGER   NUMATR
 
         IDEXO4 = IDEXO
         ITYPE4 = ITYPE
 
-        CALL EXGELB4 (IDEXO4, IDELB, NAMELB, NUMELB, NUMLNK,
-     &    NUMATR, IERR4)
-
-        CALL I8I4 (NUMELB, COUNTS, PCOUNTS4)
-        CALL EXPECPP4 (IDEXO4, ITYPE4, IDELB, COUNTS4, IERR4)
-        CALL I4FREE (PCOUNTS4)
+        CALL EXPECPP4 (IDEXO4, ITYPE4, IDELB, COUNTS, IERR4)
         IERR = IERR4
         END
 
@@ -2526,16 +2455,12 @@ C>       WRITE ELEMENT VARIABLE TRUTH TABLE
         INTEGER*4 IDEXO4        ! (R)
         INTEGER*4 NELBLK4       ! (R)
         INTEGER*4 NVAREL4       ! (R)
-        INTEGER*4 ISEVOK4 (1)   ! (NVAREL,NELBLK) (R)
-        POINTER (PISEVOK4, ISEVOK4)
         INTEGER*4 IERR4         ! (W)
 
         IDEXO4 = IDEXO
         NELBLK4 = NELBLK
         NVAREL4 = NVAREL
-        CALL I8I4 (NVAREL*NELBLK, ISEVOK, PISEVOK4)
-        CALL EXPVTT4 (IDEXO4, NELBLK4, NVAREL4, ISEVOK4, IERR4)
-        CALL I4FREE (PISEVOK4)
+        CALL EXPVTT4 (IDEXO4, NELBLK4, NVAREL4, ISEVOK, IERR4)
         IERR = IERR4
         END
 
@@ -2555,16 +2480,12 @@ C>       WRITE NODESET VARIABLE TRUTH TABLE
         INTEGER*4 IDEXO4        ! (R)
         INTEGER*4 NBLK4 ! (R)
         INTEGER*4 NVAR4 ! (R)
-        INTEGER*4 ISVOK4 (1)    ! (NVAR,NBLK) (R)
-        POINTER (PISVOK4, ISVOK4)
         INTEGER*4 IERR4         ! (W)
 
         IDEXO4 = IDEXO
         NBLK4 = NBLK
         NVAR4 = NVAR
-        CALL I8I4 (NVAR*NBLK, ISVOK, PISVOK4)
-        CALL EXPNSTT4 (IDEXO4, NBLK4, NVAR4, ISVOK4, IERR4)
-        CALL I4FREE (PISVOK4)
+        CALL EXPNSTT4 (IDEXO4, NBLK4, NVAR4, ISVOK, IERR4)
         IERR = IERR4
         END
 
@@ -2584,16 +2505,12 @@ C>       WRITE SIDESET VARIABLE TRUTH TABLE
         INTEGER*4 IDEXO4        ! (R)
         INTEGER*4 NBLK4 ! (R)
         INTEGER*4 NVAR4 ! (R)
-        INTEGER*4 ISVOK4 (1)    ! (NVAR,NBLK) (R)
-        POINTER (PISVOK4, ISVOK4)
         INTEGER*4 IERR4         ! (W)
 
         IDEXO4 = IDEXO
         NBLK4 = NBLK
         NVAR4 = NVAR
-        CALL I8I4 (NVAR*NBLK, ISVOK, PISVOK4)
-        CALL EXPSSTT4 (IDEXO4, NBLK4, NVAR4, ISVOK4, IERR4)
-        CALL I4FREE (PISVOK4)
+        CALL EXPSSTT4 (IDEXO4, NBLK4, NVAR4, ISVOK, IERR4)
         IERR = IERR4
         END
 
@@ -4088,78 +4005,4 @@ C> writes the values of a single variable for a partial block at one time
 
 C-----------------------------------------------------------------------
 
-        SUBROUTINE I8I4 (N, I8, PI4)
-
-C       CREATE I4 ARRAY AND COPY I8 ARRAY CONTENTS TO I4
-
-        IMPLICIT NONE
-        INTEGER N
-        INTEGER I8 (*)
-        INTEGER*4 I4 (1)
-        POINTER (PI4, I4)
-        INTEGER I
-
-        CALL I4ALLOC (N, PI4)
-        DO I = 1, N
-                I4 (I) = I8 (I)
-        END DO
-        END
-
-        SUBROUTINE I4I8 (N, PI4, I8)
-
-C       COPY I4 ARRAY CONTENTS TO I8 AND FREE I4 ARRAY
-
-        IMPLICIT NONE
-        INTEGER   N
-        INTEGER*4 I4 (1)
-        POINTER (PI4, I4)
-        INTEGER I8 (*)
-        INTEGER I
-
-        DO I = 1, N
-                I8 (I) = I4 (I)
-        END DO
-        CALL I4FREE (PI4)
-        END
-
-        SUBROUTINE I4ALLOC (N, PI4)
-
-C       ALLOCATE DYNAMIC I4 ARRAY N ELEMENTS IN SIZE
-
-        IMPLICIT NONE
-        INTEGER N
-        INTEGER*4 I4 (1)
-        POINTER (PI4, I4)
-        INTEGER MALLOC
-        INTEGER*4 NB
-
-        PI4 = 0
-        IF (N .EQ. 0) RETURN
-        NB = N * 4
-#if defined(__XLF__)
-        PI4 = MALLOC (%val(NB))
-#else
-        PI4 = MALLOC (NB)
-#endif
-        if (PI4 .EQ. 0) then
-          write (*,*)
-     *      'ERROR: Unable to allocate array of size ',N,' in I4ALLOC'
-          stop 'Exodus Memory Allocation Error'
-        end if
-        END
-
-        SUBROUTINE I4FREE (PI4)
-
-C       FREE DYNAMIC MEMORY ASSOCIATED WITH I4 ARRAY REFERENCED BY PI4
-
-        IMPLICIT NONE
-        INTEGER*4 I4 (1)
-        POINTER (PI4, I4)
-
-        IF (PI4 .EQ. 0) RETURN
-#if !defined(__XLF__)
-        CALL FREE(PI4)
-#endif
-        PI4 = 0
-        END
 #endif

--- a/packages/seacas/libraries/exodus_for/src/exo_jack.c
+++ b/packages/seacas/libraries/exodus_for/src/exo_jack.c
@@ -75,6 +75,24 @@
 
 #endif /* 64 vs 32 bit build */
 
+#if defined(Build64)
+static int *i8i4(int64_t size, const int64_t *i8) 
+{
+  int *i4 = malloc(size * sizeof(int));
+  for (int64_t i = 0; i < size; i++) {
+    i4[i] = i8[i];
+  }
+  return i4;
+}
+
+static void i4i8(int64_t size, const int *i4, int64_t *i8) 
+{
+  for (int64_t i = 0; i < size; i++) {
+    i8[i] = i4[i];
+  }
+}
+#endif
+
 /* blank fill C string to make FORTRAN string */
 static void ex_fcdcpy(char *fstring, /* output string to be blank-filled */
                       int   fslen,   /* length of output string */
@@ -836,23 +854,61 @@ void F2C(exgelc, EXGELC)(int *idexo, entity_id *elem_blk_id, void_int *connect, 
  * write entity count-per-polyhedra information for nsided block
  * \sa ex_put_entity_count_per_polyhedra()
  */
+#if Build64
+void F2C(expecpp, EXPECPP)(int *idexo, int *obj_type, entity_id *elem_blk_id, int64_t *counts,
+                           int *ierr)
+{
+  ex_block block;
+  block.id = *elem_blk_id;
+  block.type = *obj_type;
+  if (ex_get_block_param(*idexo, &block) == EX_FATAL) {
+    *ierr = EX_FATAL;
+    return;
+  }
+  int *counts4 = i8i4(block.num_entry, counts);
+  *ierr =
+      ex_put_entity_count_per_polyhedra(*idexo, (ex_entity_type)*obj_type, *elem_blk_id, counts4);
+  free(counts4);
+}
+#else
 void F2C(expecpp, EXPECPP)(int *idexo, int *obj_type, entity_id *elem_blk_id, int *counts,
                            int *ierr)
 {
   *ierr =
       ex_put_entity_count_per_polyhedra(*idexo, (ex_entity_type)*obj_type, *elem_blk_id, counts);
 }
+#endif
 
 /*!
  * read entity count-per-polyhedra information for nsided block
  * \sa ex_get_entity_count_per_polyhedra()
  */
+#if Build64
+void F2C(exgecpp, EXGECPP)(int *idexo, int *obj_type, entity_id *elem_blk_id, int64_t *counts,
+                           int *ierr)
+{
+  ex_block block;
+  block.id = *elem_blk_id;
+  block.type = *obj_type;
+  if (ex_get_block_param(*idexo, &block) == EX_FATAL) {
+    *ierr = EX_FATAL;
+    return;
+  }
+  int64_t num_elem_this_blk = block.num_entry;
+  int *counts4 = malloc(num_elem_this_blk * sizeof(int));
+  *ierr =
+      ex_get_entity_count_per_polyhedra(*idexo, (ex_entity_type)*obj_type, *elem_blk_id, counts4);
+  i4i8(num_elem_this_blk, counts4, counts);
+  free(counts4);
+}
+#else
 void F2C(exgecpp, EXGECPP)(int *idexo, int *obj_type, entity_id *elem_blk_id, int *counts,
                            int *ierr)
 {
   *ierr =
       ex_get_entity_count_per_polyhedra(*idexo, (ex_entity_type)*obj_type, *elem_blk_id, counts);
 }
+#endif
 
 /*!
  * write element block attributes
@@ -1980,58 +2036,116 @@ void F2C(exgvan, EXGVAN)(int *idexo, char *var_type, int *num_vars, char *var_na
  * write element variable truth table
  * \sa ex_put_truth_table()
  */
-void F2C(expvtt, EXPVTT)(int *idexo, int *num_elem_blk, int *num_elem_var, int *elem_var_tab,
+#if Build64
+void F2C(expvtt, EXPVTT)(int *idexo, int *num_entity, int *num_var, int64_t *var_tab,
                          int *ierr)
 {
-  *ierr = ex_put_truth_table(*idexo, EX_ELEM_BLOCK, *num_elem_blk, *num_elem_var, elem_var_tab);
+  int *var_tab4 = i8i4(*num_entity * *num_var, var_tab);
+  *ierr = ex_put_truth_table(*idexo, EX_ELEM_BLOCK, *num_entity, *num_var, var_tab4);
+  free(var_tab4);
 }
+#else
+void F2C(expvtt, EXPVTT)(int *idexo, int *num_entity, int *num_var, int *var_tab,
+                         int *ierr)
+{
+  *ierr = ex_put_truth_table(*idexo, EX_ELEM_BLOCK, *num_entity, *num_var, var_tab);
+}
+#endif
 
 /*!
  * write nodeset variable truth table
  * \sa ex_put_truth_table()
  */
+#if Build64
+void F2C(expnstt, EXPNSTT)(int *idexo, int *num_entity, int *num_var, int64_t *var_tab, int *ierr)
+{
+  int *var_tab4 = i8i4(*num_entity * *num_var, var_tab);
+  *ierr = ex_put_truth_table(*idexo, EX_NODE_SET, *num_entity, *num_var, var_tab4);
+  free(var_tab4);
+}
+#else
 void F2C(expnstt, EXPNSTT)(int *idexo, int *num_entity, int *num_var, int *var_tab, int *ierr)
 {
   *ierr = ex_put_truth_table(*idexo, EX_NODE_SET, *num_entity, *num_var, var_tab);
 }
+#endif
 
 /*!
  * write sideset variable truth table
  * \sa ex_put_truth_table()
  */
+#if Build64
+void F2C(expsstt, EXPSSTT)(int *idexo, int *num_entity, int *num_var, int64_t *var_tab, int *ierr)
+{
+  int *var_tab4 = i8i4(*num_entity * *num_var, var_tab);
+  *ierr = ex_put_truth_table(*idexo, EX_SIDE_SET, *num_entity, *num_var, var_tab4);
+  free(var_tab4);
+}
+#else
 void F2C(expsstt, EXPSSTT)(int *idexo, int *num_entity, int *num_var, int *var_tab, int *ierr)
 {
   *ierr = ex_put_truth_table(*idexo, EX_SIDE_SET, *num_entity, *num_var, var_tab);
 }
+#endif
 
 /*!
  * read element variable truth table
  * \sa ex_get_truth_table()
  */
-void F2C(exgvtt, EXGVTT)(int *idexo, int *num_elem_blk, int *num_elem_var, int *elem_var_tab,
+#if Build64
+void F2C(exgvtt, EXGVTT)(int *idexo, int *num_entity, int *num_var, int64_t *var_tab,
                          int *ierr)
 {
-  *ierr = ex_get_truth_table(*idexo, EX_ELEM_BLOCK, *num_elem_blk, *num_elem_var, elem_var_tab);
+  int *var_tab4 = malloc(*num_entity * *num_var * sizeof(int));
+  *ierr = ex_get_truth_table(*idexo, EX_ELEM_BLOCK, *num_entity, *num_var, var_tab4);
+  i4i8(*num_entity * *num_var, var_tab4, var_tab);
+  free(var_tab4);
+#else
+void F2C(exgvtt, EXGVTT)(int *idexo, int *num_entity, int *num_var, int *var_tab,
+                         int *ierr)
+{
+  *ierr = ex_get_truth_table(*idexo, EX_ELEM_BLOCK, *num_entity, *num_var, var_tab);
+#endif
 }
 
 /*!
  * read nodeset variable truth table
  * \sa ex_get_truth_table()
  */
-void F2C(exgnstt, EXGNSTT)(int *idexo, int *num_entity, int *num_var, int *var_tab, int *ierr)
+#if Build64
+void F2C(exgnstt, EXGNSTT)(int *idexo, int *num_entity, int *num_var, int64_t *var_tab, int *ierr)
+{
+  int *var_tab4 = malloc(*num_entity * *num_var * sizeof(int));
+  *ierr = ex_get_truth_table(*idexo, EX_NODE_SET, *num_entity, *num_var, var_tab4);
+  i4i8(*num_entity * *num_var, var_tab4, var_tab);
+  free(var_tab4);
+}
+#else
+ void F2C(exgnstt, EXGNSTT)(int *idexo, int *num_entity, int *num_var, int *var_tab, int *ierr)
 {
   *ierr = ex_get_truth_table(*idexo, EX_NODE_SET, *num_entity, *num_var, var_tab);
 }
-
+#endif
+ 
 /*!
  * read sideset variable truth table
  * \sa ex_get_truth_table()
  */
-void F2C(exgsstt, EXGSSTT)(int *idexo, int *num_entity, int *num_var, int *var_tab, int *ierr)
+#if Build64
+void F2C(exgsstt, EXGSSTT)(int *idexo, int *num_entity, int *num_var, int64_t *var_tab, int *ierr)
+{
+  int *var_tab4 = malloc(*num_entity * *num_var * sizeof(int));
+  *ierr = ex_get_truth_table(*idexo, EX_SIDE_SET, *num_entity, *num_var, var_tab4);
+  i4i8(*num_entity * *num_var, var_tab4, var_tab);
+  free(var_tab4);
+}
+#else
+ void F2C(exgsstt, EXGSSTT)(int *idexo, int *num_entity, int *num_var, int *var_tab, int *ierr)
 {
   *ierr = ex_get_truth_table(*idexo, EX_SIDE_SET, *num_entity, *num_var, var_tab);
 }
-
+#endif
+ 
 /*!
  * write global variable values at time step
  * \sa ex_put_var()
@@ -2325,26 +2439,59 @@ void F2C(exgssn, EXGSSN)(int *idexo, entity_id *side_set_id, int *side_set_node_
  * read side set node count
  * \sa ex_get_side_set_node_count()
  */
+#if Build64
+void F2C(exgssc, EXGSSC)(int *idexo, entity_id *side_set_id, int64_t *side_set_node_cnt_list, int *ierr)
+{
+  int num_sides_in_set = 0;
+  int num_df_in_set = 0;
+  ex_get_set_param(*idexo, EX_SIDE_SET, *side_set_id, &num_sides_in_set, &num_df_in_set);
+  int *cnt_list = malloc(num_sides_in_set * sizeof(int));
+
+  *ierr = ex_get_side_set_node_count(*idexo, *side_set_id, cnt_list);
+
+  i4i8(num_sides_in_set, cnt_list, side_set_node_cnt_list);
+  free(cnt_list);
+}
+#else
 void F2C(exgssc, EXGSSC)(int *idexo, entity_id *side_set_id, int *side_set_node_cnt_list, int *ierr)
 {
   *ierr = ex_get_side_set_node_count(*idexo, *side_set_id, side_set_node_cnt_list);
 }
+#endif
 
 /*!
  * read concatenated side set node count
  * \sa ex_get_concat_side_set_node_count()
  */
+#if Build64
+void F2C(exgcssc, EXGCSSC)(int *idexo, int64_t *side_set_node_cnt_list, int *ierr)
+{
+  int count = ex_inquire_int(*idexo, EX_INQ_SS_ELEM_LEN);
+  int *cnt_list = malloc(count * sizeof(int));
+
+  *ierr = ex_get_concat_side_set_node_count(*idexo, cnt_list);
+
+  i4i8(count, cnt_list, side_set_node_cnt_list);
+  free(cnt_list);
+}
+#else
 void F2C(exgcssc, EXGCSSC)(int *idexo, int *side_set_node_cnt_list, int *ierr)
 {
   *ierr = ex_get_concat_side_set_node_count(*idexo, side_set_node_cnt_list);
 }
+#endif
 
 /*!
  *  ex_get_coordinate_frames -- read coordinate frames
  * \sa ex_get_coordinate_frames()
  */
+#if Build64
+void F2C(exgfrm, EXGFRM)(int *idexo, int *nframeo, void_int *cfids, real *coord, int64_t *tags,
+                         int *ierr)
+#else
 void F2C(exgfrm, EXGFRM)(int *idexo, int *nframeo, void_int *cfids, real *coord, int *tags,
                          int *ierr)
+#endif
 {
   /* Determine number of coordinate frames stored in file */
   int nframe = ex_inquire_int(*idexo, EX_INQ_COORD_FRAMES);
@@ -2390,8 +2537,13 @@ void F2C(exgfrm, EXGFRM)(int *idexo, int *nframeo, void_int *cfids, real *coord,
  *  ex_put_coordinate_frames -- define/write coordinate frames
  * \sa ex_put_coordinate_frames()
  */
+#if Build64
+void F2C(expfrm, EXPFRM)(int *idexo, int *nframe, void_int *cfids, real *coord, int64_t *tags,
+                         int *ierr)
+#else
 void F2C(expfrm, EXPFRM)(int *idexo, int *nframe, void_int *cfids, real *coord, int *tags,
                          int *ierr)
+#endif
 {
   /* Create array of characters to store tags... */
   if (*nframe > 0) {
@@ -3878,4 +4030,15 @@ void F2C(exppcc, EXPPCC)(int *exoid, void_int *start_node_num, void_int *num_nod
              "Error: failed to write coordinate component  slab to file id %d", *exoid);
     ex_err_fn(*exoid, __func__, errmsg, EX_MSG);
   }
+}
+
+void F2C(cmalloc, CMALLOC)(int *size, int64_t* pointer)
+{
+  int64_t *tmp = malloc(*size);
+  *pointer = *tmp;
+}
+
+void F2C(cfree, CFREE)(int *pointer)
+{
+  //  free(pointer);
 }

--- a/packages/seacas/libraries/exodus_for/src/exo_jack.c
+++ b/packages/seacas/libraries/exodus_for/src/exo_jack.c
@@ -4032,13 +4032,3 @@ void F2C(exppcc, EXPPCC)(int *exoid, void_int *start_node_num, void_int *num_nod
   }
 }
 
-void F2C(cmalloc, CMALLOC)(int *size, int64_t* pointer)
-{
-  int64_t *tmp = malloc(*size);
-  *pointer = *tmp;
-}
-
-void F2C(cfree, CFREE)(int *pointer)
-{
-  //  free(pointer);
-}

--- a/packages/seacas/libraries/exodus_for/src/exo_jack.c
+++ b/packages/seacas/libraries/exodus_for/src/exo_jack.c
@@ -2428,7 +2428,7 @@ void F2C(excn2s, EXCN2S)(int *idexo, void_int *num_elem_per_set, void_int *num_n
  * read side set node list
  * \sa ex_get_side_set_node_list()
  */
-void F2C(exgssn, EXGSSN)(int *idexo, entity_id *side_set_id, int *side_set_node_cnt_list,
+void F2C(exgssn, EXGSSN)(int *idexo, entity_id *side_set_id, void_int *side_set_node_cnt_list,
                          void_int *side_set_node_list, int *ierr)
 {
   *ierr =

--- a/packages/seacas/libraries/exodus_for/src/exo_jack.c
+++ b/packages/seacas/libraries/exodus_for/src/exo_jack.c
@@ -2442,8 +2442,8 @@ void F2C(exgssn, EXGSSN)(int *idexo, entity_id *side_set_id, void_int *side_set_
 #if Build64
 void F2C(exgssc, EXGSSC)(int *idexo, entity_id *side_set_id, int64_t *side_set_node_cnt_list, int *ierr)
 {
-  int num_sides_in_set = 0;
-  int num_df_in_set = 0;
+  int64_t num_sides_in_set = 0;
+  int64_t num_df_in_set = 0;
   ex_get_set_param(*idexo, EX_SIDE_SET, *side_set_id, &num_sides_in_set, &num_df_in_set);
   int *cnt_list = malloc(num_sides_in_set * sizeof(int));
 


### PR DESCRIPTION
The flang-new compiler did not have the gnu fortran extensions of MALLOC and FREE. Rewrote addrwrap.F and exo_jack.c to not require the fortran malloc/free -- now any integer conversions are done in exo_jack.c.

Need to see if can reduce code duplication in exo_jack.c, but addrwrap.F is much cleaner...