### PR TITLE
IOSS: Add guard for ARM/ARM64-specific include on Mac

### DIFF
--- a/packages/seacas/libraries/ioss/src/Ioss_MemoryUtils.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_MemoryUtils.C
@@ -14,8 +14,11 @@
 #include <sys/resource.h>
 #include <unistd.h>
 
-#if defined(__APPLE__) && defined(__MACH__)
+#if defined(__APPLE__) && defined(__MACH__) && (defined(__arm__) || defined(__arm64__))
 #include <mach/arm/kern_return.h>
+#endif
+
+#if defined(__APPLE__) && defined(__MACH__)
 #include <mach/kern_return.h>
 #include <mach/mach_init.h>
 #include <mach/message.h>


### PR DESCRIPTION
Hi @gsjaardema! 👋🏻 

I ran across an error building SEACAS / IOSS on Intel Mac (the Mac SDK was missing `mach/arm/kern_return.h`) that I hadn't on my Apple Silicon system. Guarding against using that include on Intel Mac platforms seemed to be the right fix, so I wanted to contribute it back to you. 

EDIT: Double-checking with INL the terms of the CLA. Thanks for your patience!