### PR TITLE
Catalyst: Add support for Exodus IOSS Properties in Conduit Representation

### DIFF
--- a/packages/seacas/libraries/ioss/src/catalyst_tests/Iocatalyst_BlockMeshSet.C
+++ b/packages/seacas/libraries/ioss/src/catalyst_tests/Iocatalyst_BlockMeshSet.C
@@ -434,6 +434,7 @@ namespace Iocatalyst {
         values.push_back(itr->second + j*0.1);
       }
       elemBlock->put_field_data(itr->first, values);
+      values.clear();
     } 
   }
 
@@ -449,6 +450,7 @@ namespace Iocatalyst {
         values.push_back(itr->second + j*0.1);
       }
       nodeBlock->put_field_data(itr->first, values);
+      values.clear();
     } 
   }
 

--- a/packages/seacas/libraries/ioss/src/catalyst_tests/Iocatalyst_DatabaseIOTest.h
+++ b/packages/seacas/libraries/ioss/src/catalyst_tests/Iocatalyst_DatabaseIOTest.h
@@ -63,6 +63,7 @@ protected:
           void  *data;
           size_t dataSize;
           g->get_field_data(name, &data, &dataSize);
+          ASSERT_GT(dataSize, 0) << "DataSize is not greater than 0 for field "<<name<<std::endl;
           std::byte             *b = static_cast<std::byte *>(data);
           std::vector<std::byte> zcBuffer(b, b + field.get_size());
           EXPECT_EQ(dcBuffer, zcBuffer);

--- a/packages/seacas/libraries/ioss/src/catalyst_tests/Iocatalyst_ElementBlockTest.C
+++ b/packages/seacas/libraries/ioss/src/catalyst_tests/Iocatalyst_ElementBlockTest.C
@@ -109,6 +109,17 @@ TEST_F(Iocatalyst_DatabaseIOTest, Exodus_Prop_ENABLE_FIELD_RECOGNITION_ON)
   if(exo_foo_exists && cat_foo_exists) 
     EXPECT_TRUE(exo_elemBlock->get_field("foo") == cat_elemBlock->get_field("foo"));
   
+  //Check field data for equality
+  auto cat_field = cat_elemBlock->get_fieldref("foo");
+  std::vector<std::byte> dcBuffer(cat_field.get_size());
+  cat_elemBlock->get_field_data("foo", Data(dcBuffer), dcBuffer.size());
+
+  exo_reg.begin_state(1);
+  auto exo_field = exo_elemBlock->get_fieldref("foo");
+  std::vector<std::byte> deBuffer(exo_field.get_size());
+  exo_elemBlock->get_field_data("foo", Data(deBuffer), deBuffer.size());
+  EXPECT_EQ(dcBuffer, deBuffer);
+
   //Check foo_x doesn't exist
   bool exo_foo_x_exists = exo_elemBlock->field_exists("foo_x");
   bool cat_foo_x_exists = cat_elemBlock->field_exists("foo_x");
@@ -233,6 +244,17 @@ TEST_F(Iocatalyst_DatabaseIOTest, Exodus_Prop_IGNORE_REALN_FIELDS_OFF)
   if(exo_foo_exists && cat_foo_exists) 
     EXPECT_TRUE(exo_elemBlock->get_field("foo") == cat_elemBlock->get_field("foo"));
   
+  //Check field data for equality
+  auto cat_field = cat_elemBlock->get_fieldref("foo");
+  std::vector<std::byte> dcBuffer(cat_field.get_size());
+  cat_elemBlock->get_field_data("foo", Data(dcBuffer), dcBuffer.size());
+
+  exo_reg.begin_state(1);
+  auto exo_field = exo_elemBlock->get_fieldref("foo");
+  std::vector<std::byte> deBuffer(exo_field.get_size());
+  exo_elemBlock->get_field_data("foo", Data(deBuffer), deBuffer.size());
+  EXPECT_EQ(dcBuffer, deBuffer);
+  
 }
 
 TEST_F(Iocatalyst_DatabaseIOTest, Exodus_Prop_FIELD_SUFFIX_SEPARATOR)
@@ -282,6 +304,17 @@ TEST_F(Iocatalyst_DatabaseIOTest, Exodus_Prop_FIELD_SUFFIX_SEPARATOR)
   EXPECT_TRUE(cat_bar_exists);
   if(exo_bar_exists && cat_bar_exists) 
     EXPECT_TRUE(exo_elemBlock->get_field("bar") == cat_elemBlock->get_field("bar"));
+  
+  //Check bar field data for equality
+  auto cat_field = cat_elemBlock->get_fieldref("bar");
+  std::vector<std::byte> dcBuffer(cat_field.get_size());
+  cat_elemBlock->get_field_data("bar", Data(dcBuffer), dcBuffer.size());
+
+  exo_reg.begin_state(1);
+  auto exo_field = exo_elemBlock->get_fieldref("bar");
+  std::vector<std::byte> deBuffer(exo_field.get_size());
+  exo_elemBlock->get_field_data("bar", Data(deBuffer), deBuffer.size());
+  EXPECT_EQ(dcBuffer, deBuffer);
 
 }
 
@@ -322,6 +355,17 @@ TEST_F(Iocatalyst_DatabaseIOTest, Exodus_Prop_FIELD_STRIP_TRAILING_UNDERSCORE)
   EXPECT_TRUE(cat_foo_exists);
   if(exo_foo_exists && cat_foo_exists) 
     EXPECT_TRUE(exo_elemBlock->get_field("foo") == cat_elemBlock->get_field("foo"));
+  
+  //Check field data for equality
+  auto cat_field = cat_elemBlock->get_fieldref("foo");
+  std::vector<std::byte> dcBuffer(cat_field.get_size());
+  cat_elemBlock->get_field_data("foo", Data(dcBuffer), dcBuffer.size());
+
+  exo_reg.begin_state(1);
+  auto exo_field = exo_elemBlock->get_fieldref("foo");
+  std::vector<std::byte> deBuffer(exo_field.get_size());
+  exo_elemBlock->get_field_data("foo", Data(deBuffer), deBuffer.size());
+  EXPECT_EQ(dcBuffer, deBuffer);
 
 }
 


### PR DESCRIPTION
A sequel to the work done in #456 

Added it such that the changes made in our Catalyst Database from the Exodus Properties (on read) are also reflected/copied into the conduit representation, such that getting the field data (which accesses conduit) works as expected.