### PR TITLE
Catalyst API 2

### DIFF
--- a/packages/seacas/libraries/ioss/src/catalyst_tests/CMakeLists.txt
+++ b/packages/seacas/libraries/ioss/src/catalyst_tests/CMakeLists.txt
@@ -113,11 +113,11 @@ TRIBITS_ADD_ADVANCED_TEST(${test_name}
      NOEXEPREFIX NOEXESUFFIX
      NUM_MPI_PROCS 1
    TEST_2 EXEC io_shell ARGS -out_type catalyst ${ioshell_output_file_name}
-          ${test_time_step}
+          catalyst.bin
      DIRECTORY ../main
      NOEXEPREFIX NOEXESUFFIX
      NUM_MPI_PROCS ${num_procs}
-   TEST_3 EXEC io_shell ARGS -in_type catalyst ${test_time_step}
+   TEST_3 EXEC io_shell ARGS -in_type catalyst catalyst.bin
           ${CATALYST_FNAME}
      DIRECTORY ../main
      NOEXEPREFIX NOEXESUFFIX
@@ -137,6 +137,7 @@ TRIBITS_ADD_ADVANCED_TEST(${test_name}
      NOEXEPREFIX NOEXESUFFIX
      NUM_MPI_PROCS 1
    ENVIRONMENT CATALYST_DATA_DUMP_DIRECTORY=${CMAKE_CURRENT_BINARY_DIR}/${test_name}
+     IOSS_PROPERTIES=CATALYST_READER_TIME_STEP=${test_time_step}
   )
 endfunction()
 
@@ -145,32 +146,32 @@ foreach(NUM_PROCS 1 4)
   catalyst_test_ioshell_generated(
     "Iocatalyst_10x10x10_hex_MPI_${NUM_PROCS}"
     "10x10x10+times:4+variables:element,2,nodal,3"
-    "ioshell_10x10x10.g" "3" "3" ${NUM_PROCS})
+    "ioshell_10x10x10.g" "3" 3 ${NUM_PROCS})
 
   catalyst_test_ioshell_generated(
     "Iocatalyst_10x10x10_tets_MPI_${NUM_PROCS}"
     "10x10x10+tets:+times:2+variables:element,2,nodal,3"
-    "ioshell_10x10x10_tets.g" "1" "1" ${NUM_PROCS})
+    "ioshell_10x10x10_tets.g" "1" 1 ${NUM_PROCS})
 
   catalyst_test_ioshell_generated(
     "Iocatalyst_10x10x10_pyramids_MPI_${NUM_PROCS}"
     "10x10x10+pyramids:+times:2+variables:element,2,nodal,3"
-    "ioshell_10x10x10_pyramids.g" "1" "1" ${NUM_PROCS})
+    "ioshell_10x10x10_pyramids.g" "1" 1 ${NUM_PROCS})
 
   catalyst_test_ioshell_generated(
     "Iocatalyst_10x10x10_shell_MPI_${NUM_PROCS}"
     "10x10x10+shell:xX:+times:2+variables:element,2,nodal,3"
-    "ioshell_10x10x10_shell.g" "1" "1" ${NUM_PROCS})
+    "ioshell_10x10x10_shell.g" "1" 1 ${NUM_PROCS})
 
   catalyst_test_ioshell_generated(
     "Iocatalyst_10x10x10_nodeset_MPI_${NUM_PROCS}"
     "10x10x10+nodeset:xX:+times:2+variables:element,2,nodal,3,nodeset,4"
-    "ioshell_10x10x10_nodeset.g" "1" "1" ${NUM_PROCS})
+    "ioshell_10x10x10_nodeset.g" "1" 1 ${NUM_PROCS})
 
   catalyst_test_ioshell_generated(
     "Iocatalyst_10x10x10_sideset_MPI_${NUM_PROCS}"
     "10x10x10+sideset:xX:+times:2+variables:element,2,nodal,3,sideset,4"
-    "ioshell_10x10x10_sideset.g" "1" "1" ${NUM_PROCS})
+    "ioshell_10x10x10_sideset.g" "1" 1 ${NUM_PROCS})
 
 endforeach()
 
@@ -196,12 +197,12 @@ TRIBITS_ADD_ADVANCED_TEST(${test_name}
       NOEXEPREFIX NOEXESUFFIX
       NUM_MPI_PROCS 1
     TEST_1 EXEC io_shell ARGS -out_type catalyst
-           ${input_file} ${test_time_step}
+           ${input_file} catalyst.bin
       DIRECTORY ../main
       NOEXEPREFIX NOEXESUFFIX
       NUM_MPI_PROCS ${num_procs}
     TEST_2 EXEC io_shell ARGS -in_type catalyst
-           ${test_time_step} ${CATALYST_FNAME}
+           catalyst.bin ${CATALYST_FNAME}
       DIRECTORY ../main
       NOEXEPREFIX NOEXESUFFIX
       NUM_MPI_PROCS ${num_procs}
@@ -220,7 +221,13 @@ TRIBITS_ADD_ADVANCED_TEST(${test_name}
       NOEXEPREFIX NOEXESUFFIX
       NUM_MPI_PROCS 1
     ENVIRONMENT CATALYST_DATA_DUMP_DIRECTORY=${CMAKE_CURRENT_BINARY_DIR}/${test_name}
+      IOSS_PROPERTIES=CATALYST_READER_TIME_STEP=${test_time_step}
+    ADDED_TEST_NAME_OUT FileTestExodus
 )
+
+set_tests_properties(${FileTestExodus}
+   PROPERTIES FIXTURES_SETUP WriteTestConduit)
+
 endfunction()
 
 set(EXO_TEST_FILES
@@ -237,16 +244,16 @@ endforeach()
 foreach(NUM_PROCS 1 4)
   catalyst_test_ioshell_exodus_file(
     "Iocatalyst_cube_g_MPI_${NUM_PROCS}"
-    "cube.g" "1" "1" ${NUM_PROCS})
+    "cube.g" "1" 1 ${NUM_PROCS})
   catalyst_test_ioshell_exodus_file(
     "Iocatalyst_two_block_g_MPI_${NUM_PROCS}"
-    "two-block.g" "1" "1" ${NUM_PROCS})
+    "two-block.g" "1" 1 ${NUM_PROCS})
   catalyst_test_ioshell_exodus_file(
     "Iocatalyst_eight_block_g_MPI_${NUM_PROCS}"
-    "8-block.g" "0.05" "5" ${NUM_PROCS})
+    "8-block.g" "0.05" 5 ${NUM_PROCS})
   catalyst_test_ioshell_exodus_file(
     "Iocatalyst_can_ex2_MPI_${NUM_PROCS}"
-    "can.ex2" "0.00219992" "22" ${NUM_PROCS})
+    "can.ex2" "0.00219992" 22 ${NUM_PROCS})
 endforeach()
 
 if ( NETCDF_NCDUMP_BINARY )
@@ -267,11 +274,11 @@ TRIBITS_ADD_ADVANCED_TEST(${test_name}
       DIRECTORY ../../../exodus/test
       NOEXEPREFIX NOEXESUFFIX
       NUM_MPI_PROCS 1
-    TEST_1 EXEC io_shell ARGS -out_type catalyst ${INPUT_FILE_PATH} ${test_time_step}
+    TEST_1 EXEC io_shell ARGS -out_type catalyst ${INPUT_FILE_PATH} catalyst.bin
       DIRECTORY ../main
       NOEXEPREFIX NOEXESUFFIX
       NUM_MPI_PROCS 1
-    TEST_2 EXEC io_shell ARGS -in_type catalyst ${test_time_step} ${CATALYST_FNAME}
+    TEST_2 EXEC io_shell ARGS -in_type catalyst catalyst.bin ${CATALYST_FNAME}
       DIRECTORY ../main
       NOEXEPREFIX NOEXESUFFIX
       NUM_MPI_PROCS 1
@@ -284,14 +291,16 @@ TRIBITS_ADD_ADVANCED_TEST(${test_name}
       NOEXEPREFIX NOEXESUFFIX
       NUM_MPI_PROCS 1
     ENVIRONMENT CATALYST_DATA_DUMP_DIRECTORY=${CMAKE_CURRENT_BINARY_DIR}/${test_name}
+      IOSS_PROPERTIES=CATALYST_READER_TIME_STEP=${test_time_step}
 )
+
 endfunction()
 
 catalyst_test_ioshell_generated_exodus_file("Iocatalyst_test_blob_exo_MPI_1"
-  "testwt-blob" "" "test-blob.exo" "0.02" "1")
+  "testwt-blob" "" "test-blob.exo" "0.02" 1)
 
 catalyst_test_ioshell_generated_exodus_file("Iocatalyst_test_seacas_exodus_exoIIC_MPI_1"
-  "SEACASExodus_ExoIICTests.exe" "CreateEdgeFace" "edgeFace.exo" "1" "0")
+  "SEACASExodus_ExoIICTests.exe" "CreateEdgeFace" "edgeFace.exo" "1" 0)
 
 endif()
 
@@ -325,11 +334,11 @@ set(IOSHELL_FNAME ioshell_time_${test_time_step}_${input_file})
 set(INPUT_FILE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../main/test/${input_file})
 
 TRIBITS_ADD_ADVANCED_TEST(${test_name}
-    TEST_0 EXEC io_shell ARGS -debug -out_type catalyst ${INPUT_FILE_PATH} ${test_time_step}
+    TEST_0 EXEC io_shell ARGS -debug -out_type catalyst ${INPUT_FILE_PATH} catalyst.bin
       DIRECTORY ../main
       NOEXEPREFIX NOEXESUFFIX
       NUM_MPI_PROCS 1
-    TEST_1 EXEC io_shell ARGS -in_type catalyst ${test_time_step} ${CATALYST_FNAME}
+    TEST_1 EXEC io_shell ARGS -in_type catalyst catalyst.bin ${CATALYST_FNAME}
       DIRECTORY ../main
       NOEXEPREFIX NOEXESUFFIX
       NUM_MPI_PROCS 1
@@ -341,11 +350,33 @@ TRIBITS_ADD_ADVANCED_TEST(${test_name}
       NOEXEPREFIX NOEXESUFFIX
       NUM_MPI_PROCS 1
     ENVIRONMENT CATALYST_DATA_DUMP_DIRECTORY=${CMAKE_CURRENT_BINARY_DIR}/${test_name}
+      IOSS_PROPERTIES=CATALYST_READER_TIME_STEP=${test_time_step}
+    ADDED_TEST_NAME_OUT FileTestCGNS
 )
+
+set_tests_properties(${FileTestCGNS}
+   PROPERTIES FIXTURES_SETUP WriteTestConduit)
+
 endfunction()
 
 catalyst_test_ioshell_cgns_file(
-  "Iocatalyst_sparc1_cgns_MPI_1" "sparc1.cgns" "15.992" "1")
+  "Iocatalyst_sparc1_cgns_MPI_1" "sparc1.cgns" "15.992" 1)
+
+TRIBITS_ADD_EXECUTABLE(
+    Iocatalyst_ConduitReadTest
+ SOURCES
+    Iocatalyst_ConduitReadTest.C
+)
+
+TRIBITS_ADD_TEST(
+	Iocatalyst_ConduitReadTest
+  NAME Iocatalyst_ConduitReadTest
+	NUM_MPI_PROCS 1
+  ADDED_TESTS_NAMES_OUT ConduitReadTest
+)
+
+set_tests_properties(${ConduitReadTest}
+  PROPERTIES FIXTURES_REQUIRED WriteTestConduit)
 
 endif()
 endif()

--- a/packages/seacas/libraries/ioss/src/catalyst_tests/Iocatalyst_ConduitReadTest.C
+++ b/packages/seacas/libraries/ioss/src/catalyst_tests/Iocatalyst_ConduitReadTest.C
@@ -1,0 +1,72 @@
+// Copyright(C) 1999-2020 National Technology & Engineering Solutions
+// of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
+// NTESS, the U.S. Government retains certain rights in this software.
+//
+// See packages/seacas/LICENSE for details
+
+#include <Ioss_ElementBlock.h>
+#include <Ioss_NodeBlock.h>
+#include <Ioss_StructuredBlock.h>
+#include <catalyst/Iocatalyst_DatabaseIO.h>
+#include <catalyst_tests/Iocatalyst_DatabaseIOTest.h>
+
+TEST_F(Iocatalyst_DatabaseIOTest, ReadConduitCanExo)
+{
+  Ioss::PropertyManager iossProp;
+  iossProp.add(Ioss::Property("FIELD_SUFFIX_SEPARATOR", ""));
+
+  auto db = getCatalystDatabaseFromConduitFiles("Iocatalyst_can_ex2_MPI_1", iossProp);
+  ASSERT_TRUE(db != nullptr);
+  Ioss::Region reg(db);
+
+  auto eb = reg.get_element_block("block_1");
+  EXPECT_TRUE(eb->field_exists("eqps"));
+
+  auto nb = reg.get_node_block("nodeblock_1");
+  EXPECT_TRUE(nb->field_exists("accl"));
+  EXPECT_TRUE(nb->field_exists("vel"));
+  EXPECT_TRUE(nb->field_exists("displ"));
+}
+
+TEST_F(Iocatalyst_DatabaseIOTest, ReadConduitSPARCOneCGNS)
+{
+  Ioss::PropertyManager iossProp;
+  iossProp.add(Ioss::Property("FIELD_SUFFIX_SEPARATOR", ""));
+
+  auto db = getCatalystDatabaseFromConduitFiles("Iocatalyst_sparc1_cgns_MPI_1", iossProp);
+  ASSERT_TRUE(db != nullptr);
+  Ioss::Region reg(db);
+
+  auto sb = reg.get_structured_block("blk-1");
+  EXPECT_TRUE(sb != nullptr);
+  EXPECT_TRUE(sb->field_exists("Density1"));
+  EXPECT_TRUE(sb->field_exists("Temperature1"));
+  EXPECT_TRUE(sb->field_exists("Velocity"));
+
+  auto nb = sb->get_node_block();
+  EXPECT_TRUE(nb.field_exists("mesh_model_coordinates"));
+  EXPECT_TRUE(nb.field_exists("mesh_model_coordinates_x"));
+  EXPECT_TRUE(nb.field_exists("mesh_model_coordinates_y"));
+  EXPECT_TRUE(nb.field_exists("mesh_model_coordinates_z"));
+}
+
+TEST_F(Iocatalyst_DatabaseIOTest, SetReaderTimeStepWithIOSSProp)
+{
+  Ioss::PropertyManager iossProp;
+  iossProp.add(Ioss::Property("CATALYST_READER_TIME_STEP", 12));
+
+  auto db = getCatalystDatabaseFromConduitFiles("Iocatalyst_can_ex2_MPI_1", iossProp);
+  ASSERT_TRUE(db != nullptr);
+
+  Iocatalyst::DatabaseIO *catdb = static_cast<Iocatalyst::DatabaseIO *>(db);
+
+  Ioss::Region reg(db);
+
+  auto mint = reg.get_min_time();
+  EXPECT_EQ(mint.first, 1);
+  EXPECT_DOUBLE_EQ(mint.second, 0.0011999331181868911);
+
+  auto maxt = reg.get_max_time();
+  EXPECT_EQ(maxt.first, 1);
+  EXPECT_DOUBLE_EQ(maxt.second, 0.0011999331181868911);
+}

--- a/packages/seacas/libraries/ioss/src/catalyst_tests/Iocatalyst_DatabaseIOTest.C
+++ b/packages/seacas/libraries/ioss/src/catalyst_tests/Iocatalyst_DatabaseIOTest.C
@@ -12,9 +12,10 @@
 #include <Ioss_MeshCopyOptions.h>
 #include <Ioss_NodeBlock.h>
 #include <Ioss_StructuredBlock.h>
+#include <catalyst/Iocatalyst_CatalystManager.h>
 #include <catalyst/Iocatalyst_DatabaseIO.h>
 #include <catalyst_tests/Iocatalyst_DatabaseIOTest.h>
-#include <catalyst/Iocatalyst_CatalystManager.h>
+#include <stdlib.h>
 
 Iocatalyst_DatabaseIOTest::Iocatalyst_DatabaseIOTest()
 {
@@ -92,30 +93,33 @@ void Iocatalyst_DatabaseIOTest::runUnstructuredTest(const std::string &testName)
   EXPECT_TRUE(regionsAreEqual(exodusFileName, catalystFileName, EXODUS_DATABASE_TYPE));
 }
 
-Ioss::DatabaseIO* Iocatalyst_DatabaseIOTest::writeAndGetExodusDatabaseOnRead(const std::string &testName,
-                                                                      Ioss::PropertyManager dbProps)
+Ioss::DatabaseIO *
+Iocatalyst_DatabaseIOTest::writeAndGetExodusDatabaseOnRead(const std::string    &testName,
+                                                           Ioss::PropertyManager dbProps)
 {
   std::string exodusFileName =
       testName + CATALYST_TEST_FILE_NP + std::to_string(part.size) + EXODUS_FILE_EXTENSION;
   Iocatalyst::BlockMeshSet::IOSSparams iop(exodusFileName, EXODUS_DATABASE_TYPE);
   bmSet.writeIOSSFile(iop);
-  Ioss::DatabaseIO* exo_db = getDatabaseOnReadFromFileName(exodusFileName, EXODUS_DATABASE_TYPE, dbProps);
-  if(exo_db == nullptr)
-  {
+  Ioss::DatabaseIO *exo_db =
+      getDatabaseOnReadFromFileName(exodusFileName, EXODUS_DATABASE_TYPE, dbProps);
+  if (exo_db == nullptr) {
     EXPECT_TRUE(false) << "Exodus db unable to initialize on read";
   }
   return exo_db;
 }
 
-Ioss::DatabaseIO* Iocatalyst_DatabaseIOTest::getExodusDatabaseFromFile(std::string &filename,
-                                                                       Ioss::PropertyManager dbProps) {
+Ioss::DatabaseIO *
+Iocatalyst_DatabaseIOTest::getExodusDatabaseFromFile(std::string          &filename,
+                                                     Ioss::PropertyManager dbProps)
+{
   Ioss::PropertyManager edbProps(dbProps);
-  
+
   std::string inputFileName = filename;
 
   Ioss::DatabaseIO *edbi =
-    Ioss::IOFactory::create(EXODUS_DATABASE_TYPE, inputFileName, Ioss::READ_RESTART,
-                            Ioss::ParallelUtils::comm_self(), edbProps);
+      Ioss::IOFactory::create(EXODUS_DATABASE_TYPE, inputFileName, Ioss::READ_RESTART,
+                              Ioss::ParallelUtils::comm_self(), edbProps);
   if (edbi == nullptr || !edbi->ok(true)) {
     return nullptr;
   }
@@ -123,7 +127,22 @@ Ioss::DatabaseIO* Iocatalyst_DatabaseIOTest::getExodusDatabaseFromFile(std::stri
   return edbi;
 }
 
-conduit_cpp::Node Iocatalyst_DatabaseIOTest::getConduitFromExodusFile(std::string &filename, 
+Ioss::DatabaseIO *
+Iocatalyst_DatabaseIOTest::getCatalystDatabaseFromConduitFiles(const std::string    &dirName,
+                                                               Ioss::PropertyManager dbProps)
+{
+  setenv("CATALYST_DATA_DUMP_DIRECTORY", dirName.c_str(), 1);
+  Ioss::DatabaseIO *cdbi =
+      Ioss::IOFactory::create(CATALYST_DATABASE_TYPE, "catalyst.bin", Ioss::READ_RESTART,
+                              Ioss::ParallelUtils::comm_self(), dbProps);
+  if (cdbi == nullptr || !cdbi->ok(true)) {
+    return nullptr;
+  }
+
+  return cdbi;
+}
+
+conduit_cpp::Node Iocatalyst_DatabaseIOTest::getConduitFromExodusFile(std::string &filename,
                                                                       Ioss::PropertyManager dbProps)
 {
   Iocatalyst::CatalystManager::getInstance().reset();
@@ -131,16 +150,16 @@ conduit_cpp::Node Iocatalyst_DatabaseIOTest::getConduitFromExodusFile(std::strin
   Ioss::PropertyManager edbProps;
   edbProps.add(Ioss::Property("SURFACE_SPLIT_TYPE", "TOPOLOGY"));
   Ioss::DatabaseIO *edbi = getExodusDatabaseFromFile(filename, edbProps);
-  
-  //Create Cat Db on write
+
+  // Create Cat Db on write
   Ioss::PropertyManager cdbwProps(edbi->get_property_manager());
-  Ioss::DatabaseIO *cdb_on_write =
+  Ioss::DatabaseIO     *cdb_on_write =
       Ioss::IOFactory::create(CATALYST_DATABASE_TYPE, CATALYST_DUMMY_DATABASE, Ioss::WRITE_RESULTS,
                               Ioss::ParallelUtils::comm_world(), cdbwProps);
   if (cdb_on_write == nullptr || !cdb_on_write->ok(true)) {
     return conduit_cpp::Node();
   }
-  
+
   Ioss::Region          cor(edbi);
   Ioss::Region          cir(cdb_on_write);
   Ioss::MeshCopyOptions options;
@@ -148,22 +167,22 @@ conduit_cpp::Node Iocatalyst_DatabaseIOTest::getConduitFromExodusFile(std::strin
   Ioss::copy_database(cor, cir, options);
 
   auto c_node = reinterpret_cast<conduit_node *>(
-        ((Iocatalyst::DatabaseIO *)cdb_on_write)->get_catalyst_conduit_node());
+      ((Iocatalyst::DatabaseIO *)cdb_on_write)->get_catalyst_conduit_node());
   conduit_cpp::Node conduitNode;
-  auto cpp_node = conduit_cpp::cpp_node(c_node);
+  auto              cpp_node = conduit_cpp::cpp_node(c_node);
   conduitNode.set(cpp_node);
   return conduitNode;
-
 }
 
-Ioss::DatabaseIO* Iocatalyst_DatabaseIOTest::getCatalystDatabaseFromConduit(conduit_cpp::Node &conduitNode, 
-                                                                                  Ioss::PropertyManager dbProps)
+Ioss::DatabaseIO *
+Iocatalyst_DatabaseIOTest::getCatalystDatabaseFromConduit(conduit_cpp::Node    &conduitNode,
+                                                          Ioss::PropertyManager dbProps)
 {
 
   Ioss::PropertyManager cdbrProps = Ioss::PropertyManager(dbProps);
   cdbrProps.add(Ioss::Property("CATALYST_CONDUIT_NODE", conduit_cpp::c_node(&conduitNode)));
-  
-  //Give to Cat Db on read
+
+  // Give to Cat Db on read
   Ioss::DatabaseIO *cdb_on_read =
       Ioss::IOFactory::create(CATALYST_DATABASE_TYPE, CATALYST_DUMMY_DATABASE, Ioss::READ_RESTART,
                               Ioss::ParallelUtils::comm_world(), cdbrProps);
@@ -174,16 +193,14 @@ Ioss::DatabaseIO* Iocatalyst_DatabaseIOTest::getCatalystDatabaseFromConduit(cond
   return cdb_on_read;
 }
 
-Ioss::DatabaseIO* Iocatalyst_DatabaseIOTest::getDatabaseOnReadFromFileName(const std::string &fileName,
-                                                                        const std::string &iossDatabaseType,
-                                                                        Ioss::PropertyManager dbProps)
+Ioss::DatabaseIO *Iocatalyst_DatabaseIOTest::getDatabaseOnReadFromFileName(
+    const std::string &fileName, const std::string &iossDatabaseType, Ioss::PropertyManager dbProps)
 {
   Ioss::PropertyManager dbaseProps = Ioss::PropertyManager(dbProps);
-  //dbProps.add(Ioss::Property("ENABLE_FIELD_RECOGNITION", "OFF"));
-  auto                  inputFileName         = fileName;
-  Ioss::ParallelUtils   pu;
-  int                   numRanks = pu.parallel_size();
-  int                   rank     = pu.parallel_rank();
+  auto                inputFileName = fileName;
+  Ioss::ParallelUtils pu;
+  int                 numRanks = pu.parallel_size();
+  int                 rank     = pu.parallel_rank();
   if (iossDatabaseType == EXODUS_DATABASE_TYPE && numRanks > 1) {
     inputFileName += "." + std::to_string(numRanks) + "." + std::to_string(rank);
   }
@@ -195,26 +212,6 @@ Ioss::DatabaseIO* Iocatalyst_DatabaseIOTest::getDatabaseOnReadFromFileName(const
   }
   return dbi;
 }
-
-/*Ioss::DatabaseIO* Iocatalyst_DatabaseIOTest::writeAndGetCatalystDatabaseOnRead(Ioss::PropertyManager dbProps)
-{
-  std::string exodusFileName =
-      "test_eb_1_enable_field_recog" + CATALYST_TEST_FILE_NP + std::to_string(part.size) + EXODUS_FILE_EXTENSION;
-  Iocatalyst::BlockMeshSet::IOSSparams iop(exodusFileName, EXODUS_DATABASE_TYPE);
-
-  Ioss::DatabaseIO *cat_d = bmSet.getCatalystDatabase(iop);
-
-  //Ioss::Region          cir(cat_d);
-  //std::cout<<"Done Region!"<<std::endl;
-  if(cat_d == nullptr)
-  {
-    EXPECT_TRUE(false) << "Catalyst db unable to initialize on read";
-  }
-  checkZeroCopyFields(iop);
-  //Ioss::Region          cir(cat_d);
-  //std::cout<<"Done Region!"<<std::endl;
-  return cat_d;
-}*/
 
 void Iocatalyst_DatabaseIOTest::checkZeroCopyFields(Iocatalyst::BlockMeshSet::IOSSparams &iop)
 {

--- a/packages/seacas/libraries/ioss/src/catalyst_tests/Iocatalyst_DatabaseIOTest.h
+++ b/packages/seacas/libraries/ioss/src/catalyst_tests/Iocatalyst_DatabaseIOTest.h
@@ -25,27 +25,29 @@ protected:
 
   bool regionsAreEqual(const std::string &fileName, const std::string &catFileName,
                        const std::string &iossDatabaseType);
-  
-  bool regionsAreEqualCatalystAndIoss(const std::string &fileName,
-                                      Ioss::DatabaseIO &cat_d,
+
+  bool regionsAreEqualCatalystAndIoss(const std::string &fileName, Ioss::DatabaseIO &cat_d,
                                       const std::string &iossDatabaseType);
 
   void runStructuredTest(const std::string &testName);
 
   void runUnstructuredTest(const std::string &testName);
 
-  Ioss::DatabaseIO* writeAndGetExodusDatabaseOnRead(const std::string &testName,
+  Ioss::DatabaseIO *writeAndGetExodusDatabaseOnRead(const std::string    &testName,
                                                     Ioss::PropertyManager dbProps = {});
-  
-  Ioss::DatabaseIO* getExodusDatabaseFromFile(std::string &filename, 
-                                              Ioss::PropertyManager dbProps = {});
-  conduit_cpp::Node getConduitFromExodusFile(std::string &filename, 
-                                             Ioss::PropertyManager dbProps = {});
-  Ioss::DatabaseIO* getCatalystDatabaseFromConduit(conduit_cpp::Node &conduitNode, 
-                                                            Ioss::PropertyManager dbProps = {});
 
-  Ioss::DatabaseIO* getDatabaseOnReadFromFileName(const std::string &fileName,
-                                                        const std::string &iossDatabaseType, 
+  Ioss::DatabaseIO *getExodusDatabaseFromFile(std::string          &filename,
+                                              Ioss::PropertyManager dbProps = {});
+  conduit_cpp::Node getConduitFromExodusFile(std::string          &filename,
+                                             Ioss::PropertyManager dbProps = {});
+  Ioss::DatabaseIO *getCatalystDatabaseFromConduit(conduit_cpp::Node    &conduitNode,
+                                                   Ioss::PropertyManager dbProps = {});
+
+  Ioss::DatabaseIO *getDatabaseOnReadFromFileName(const std::string    &fileName,
+                                                  const std::string    &iossDatabaseType,
+                                                  Ioss::PropertyManager dbProps = {});
+
+  Ioss::DatabaseIO *getCatalystDatabaseFromConduitFiles(const std::string    &dirName,
                                                         Ioss::PropertyManager dbProps = {});
 
   void checkZeroCopyFields(Iocatalyst::BlockMeshSet::IOSSparams &iop);
@@ -63,7 +65,8 @@ protected:
           void  *data;
           size_t dataSize;
           g->get_field_data(name, &data, &dataSize);
-          ASSERT_GT(dataSize, 0) << "DataSize is not greater than 0 for field "<<name<<std::endl;
+          ASSERT_GT(dataSize, 0) << "DataSize is not greater than 0 for field " << name
+                                 << std::endl;
           std::byte             *b = static_cast<std::byte *>(data);
           std::vector<std::byte> zcBuffer(b, b + field.get_size());
           EXPECT_EQ(dcBuffer, zcBuffer);
@@ -76,12 +79,12 @@ protected:
   void setOrigin(unsigned int i, unsigned int j, unsigned int k);
   void addBlockMesh(Iocatalyst::BlockMesh &blockMesh);
 
-  const std::string CGNS_DATABASE_TYPE        = "cgns";
-  const std::string CGNS_FILE_EXTENSION       = ".cgns";
-  const std::string EXODUS_DATABASE_TYPE      = "exodus";
-  const std::string EXODUS_FILE_EXTENSION     = ".ex2";
-  const std::string CATALYST_TEST_FILE_PREFIX = "catalyst_";
-  const std::string CATALYST_TEST_FILE_NP     = "_np_";
-  inline static const std::string CATALYST_DATABASE_TYPE  = "catalyst";
-  inline static const std::string CATALYST_DUMMY_DATABASE = "dummy.db";
+  const std::string               CGNS_DATABASE_TYPE        = "cgns";
+  const std::string               CGNS_FILE_EXTENSION       = ".cgns";
+  const std::string               EXODUS_DATABASE_TYPE      = "exodus";
+  const std::string               EXODUS_FILE_EXTENSION     = ".ex2";
+  const std::string               CATALYST_TEST_FILE_PREFIX = "catalyst_";
+  const std::string               CATALYST_TEST_FILE_NP     = "_np_";
+  inline static const std::string CATALYST_DATABASE_TYPE    = "catalyst";
+  inline static const std::string CATALYST_DUMMY_DATABASE   = "dummy.db";
 };


### PR DESCRIPTION
Fixed crash bug when IOSS field suffix separator is empty.

Added tests for case when reading from Conduit files written by Catalyst IOSS database.

Changed time step selection when reading from Conduit files to use the IOSS integer property CATALYST_READER_TIME_STEP instead of IOSS database filename.