### PR TITLE
IOSS: Catalyst API 2

### DIFF
--- a/packages/seacas/libraries/ioss/src/catalyst/Iocatalyst_DatabaseIO.C
+++ b/packages/seacas/libraries/ioss/src/catalyst/Iocatalyst_DatabaseIO.C
@@ -39,6 +39,7 @@
 #include <cstdlib>
 #include <fmt/ostream.h>
 #include <map>
+#include <cstdlib>
 
 #include <catalyst.hpp>
 #include <catalyst/Iocatalyst_DatabaseIO.h>
@@ -1244,9 +1245,12 @@ namespace Iocatalyst {
         this->Impl->setDatabaseNode(c_node_ptr);
       }
       else {
-        int timestep = 1;
+        int timestep = 0;
         if (pm.exists(detail::CATREADTIMESTEP)) {
           timestep = pm.get(detail::CATREADTIMESTEP).get_int();
+        }
+        else if(const char* ts = std::getenv(detail::CATREADTIMESTEP.c_str())) {
+          timestep = std::stoi(std::string(ts));
         }
         std::ostringstream path;
         path << get_catalyst_dump_dir() << detail::EXECUTE_INVC << timestep

--- a/packages/seacas/libraries/ioss/src/catalyst_tests/Iocatalyst_ConduitReadTest.C
+++ b/packages/seacas/libraries/ioss/src/catalyst_tests/Iocatalyst_ConduitReadTest.C
@@ -70,3 +70,21 @@ TEST_F(Iocatalyst_DatabaseIOTest, SetReaderTimeStepWithIOSSProp)
   EXPECT_EQ(maxt.first, 1);
   EXPECT_DOUBLE_EQ(maxt.second, 0.0011999331181868911);
 }
+
+TEST_F(Iocatalyst_DatabaseIOTest, SetReaderTimeStepWithIOSSEnvVar)
+{
+  setenv("CATALYST_READER_TIME_STEP", "24", 1);
+
+  auto db = getCatalystDatabaseFromConduitFiles("Iocatalyst_can_ex2_MPI_1");
+  ASSERT_TRUE(db != nullptr);
+
+  Ioss::Region reg(db);
+
+  auto mint = reg.get_min_time();
+  EXPECT_EQ(mint.first, 1);
+  EXPECT_DOUBLE_EQ(mint.second, 0.0024000538978725672);
+
+  auto maxt = reg.get_max_time();
+  EXPECT_EQ(maxt.first, 1);
+  EXPECT_DOUBLE_EQ(maxt.second, 0.0024000538978725672);
+}


### PR DESCRIPTION
Allow CATALYST_READER_TIME_STEP to be defined as an environment variable.

Changed default timestep to 0 for reading from Conduit files.