### PR TITLE
IOSS: Catalyst API 2

### DIFF
--- a/packages/seacas/libraries/ioss/src/catalyst/Iocatalyst_DatabaseIO.C
+++ b/packages/seacas/libraries/ioss/src/catalyst/Iocatalyst_DatabaseIO.C
@@ -39,7 +39,6 @@
 #include <cstdlib>
 #include <fmt/ostream.h>
 #include <map>
-#include <cstdlib>
 
 #include <catalyst.hpp>
 #include <catalyst/Iocatalyst_DatabaseIO.h>
@@ -1249,13 +1248,20 @@ namespace Iocatalyst {
         if (pm.exists(detail::CATREADTIMESTEP)) {
           timestep = pm.get(detail::CATREADTIMESTEP).get_int();
         }
-        else if(const char* ts = std::getenv(detail::CATREADTIMESTEP.c_str())) {
+        else if (const char *ts = std::getenv(detail::CATREADTIMESTEP.c_str())) {
           timestep = std::stoi(std::string(ts));
         }
+
+        int proc_count = util().parallel_size();
+        int my_proc    = util().parallel_rank();
+        if (properties.exists("processor_count") && properties.exists("my_processor")) {
+          proc_count = properties.get("processor_count").get_int();
+          my_proc    = properties.get("my_processor").get_int();
+        }
+
         std::ostringstream path;
         path << get_catalyst_dump_dir() << detail::EXECUTE_INVC << timestep
-             << detail::PARAMS_CONDUIT_BIN << util().parallel_size() << detail::DOT
-             << util().parallel_rank();
+             << detail::PARAMS_CONDUIT_BIN << proc_count << detail::DOT << my_proc;
         auto &root  = this->Impl->root();
         auto &dbase = this->Impl->databaseNode();
         conduit_node_load(conduit_cpp::c_node(&root), path.str().c_str(), "conduit_bin");

--- a/packages/seacas/libraries/ioss/src/catalyst_tests/Iocatalyst_ConduitReadTest.C
+++ b/packages/seacas/libraries/ioss/src/catalyst_tests/Iocatalyst_ConduitReadTest.C
@@ -88,3 +88,13 @@ TEST_F(Iocatalyst_DatabaseIOTest, SetReaderTimeStepWithIOSSEnvVar)
   EXPECT_EQ(maxt.first, 1);
   EXPECT_DOUBLE_EQ(maxt.second, 0.0024000538978725672);
 }
+
+TEST_F(Iocatalyst_DatabaseIOTest, SetRankNumRanksSerialParallel)
+{
+  Ioss::PropertyManager iossProp;
+  iossProp.add(Ioss::Property("my_processor", 0));
+  iossProp.add(Ioss::Property("processor_count", 4));
+
+  auto db = getCatalystDatabaseFromConduitFiles("Iocatalyst_can_ex2_MPI_4", iossProp);
+  ASSERT_TRUE(db != nullptr);
+}

--- a/packages/seacas/libraries/ioss/src/catalyst_tests/Iocatalyst_ConduitReadTest.C
+++ b/packages/seacas/libraries/ioss/src/catalyst_tests/Iocatalyst_ConduitReadTest.C
@@ -93,8 +93,8 @@ TEST_F(Iocatalyst_DatabaseIOTest, SetRankNumRanksSerialParallel)
 {
   Ioss::PropertyManager iossProp;
   iossProp.add(Ioss::Property("my_processor", 0));
-  iossProp.add(Ioss::Property("processor_count", 4));
+  iossProp.add(Ioss::Property("processor_count", 1));
 
-  auto db = getCatalystDatabaseFromConduitFiles("Iocatalyst_can_ex2_MPI_4", iossProp);
+  auto db = getCatalystDatabaseFromConduitFiles("Iocatalyst_can_ex2_MPI_1", iossProp);
   ASSERT_TRUE(db != nullptr);
 }


### PR DESCRIPTION
Added support to database for using my_processor and processor_count IOSS properties when operating in
serial parallel mode and reading Conduit files.