### PR TITLE
fix: include fmt/ranges.h in Ioss_Decomposition.C, Ioss_ParallelUtils.h (fmt-11)

### DIFF
--- a/packages/seacas/libraries/ioss/src/Ioss_Decomposition.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Decomposition.C
@@ -15,6 +15,7 @@
 #include <algorithm>
 #include <cassert>
 #include <fmt/ostream.h>
+#include <fmt/ranges.h>
 #include <numeric>
 
 #if !defined(NO_ZOLTAN_SUPPORT)

--- a/packages/seacas/libraries/ioss/src/Ioss_ParallelUtils.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_ParallelUtils.h
@@ -18,6 +18,7 @@
 #if IOSS_DEBUG_OUTPUT
 #include <fmt/format.h>
 #include <fmt/ostream.h>
+#include <fmt/ranges.h>
 #endif
 
 #ifdef SEACAS_HAVE_MPI


### PR DESCRIPTION
`fmt` v11 ([release notes](https://github.com/fmtlib/fmt/releases/tag/11.0.0)) "moved range and iterator overloads of fmt::join to fmt/ranges.h, next to other overloads."

This means the `fmt::join` in `Ioss_Decompoition.C` is not found: https://github.com/sandialabs/seacas/blob/049a054ee0e1c1107336d5996136314f57ddbe2a/packages/seacas/libraries/ioss/src/Ioss_Decomposition.C#L87

This PR adds the necessary `fmt/ranges.h` includes in that and one other place (behind a DEBUG define).

A possible other location that needs adapting (but I was unable to verify) is https://github.com/sandialabs/seacas/blob/049a054ee0e1c1107336d5996136314f57ddbe2a/packages/seacas/libraries/aprepro_lib/aprepro.ll#L154

This change should not have negative effects for older versions of `fmt`.