### PR TITLE
IOSS: Update TextMesh to handle extended shell ordinals to the edges

### DIFF
--- a/packages/seacas/libraries/ioss/src/Ioss_Utils.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Utils.C
@@ -940,11 +940,8 @@ void Ioss::Utils::calculate_sideblock_membership(IntVector             &face_is_
   }
 }
 
-int64_t Ioss::Utils::get_side_offset(const Ioss::SideBlock *sb)
+int64_t Ioss::Utils::get_side_offset(const Ioss::ElementTopology * parent_topo, const Ioss::ElementTopology * side_topo)
 {
-
-  const Ioss::ElementTopology *side_topo   = sb->topology();
-  const Ioss::ElementTopology *parent_topo = sb->parent_element_topology();
   int64_t                      side_offset = 0;
   if ((side_topo != nullptr) && (parent_topo != nullptr)) {
     int side_topo_dim = side_topo->parametric_dimension();
@@ -956,6 +953,13 @@ int64_t Ioss::Utils::get_side_offset(const Ioss::SideBlock *sb)
     }
   }
   return side_offset;
+}
+
+int64_t Ioss::Utils::get_side_offset(const Ioss::SideBlock *sb)
+{
+  const Ioss::ElementTopology *side_topo   = sb->topology();
+  const Ioss::ElementTopology *parent_topo = sb->parent_element_topology();
+  return get_side_offset(parent_topo, side_topo);
 }
 
 std::string Ioss::Utils::shape_to_string(const Ioss::ElementShape &shape)

--- a/packages/seacas/libraries/ioss/src/Ioss_Utils.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Utils.h
@@ -500,6 +500,8 @@ namespace Ioss {
      *  \param[in] sb Compute the offset for element sides in this SideBlock
      *  \returns The offset.
      */
+    IOSS_NODISCARD static int64_t get_side_offset(const Ioss::ElementTopology * parent_topo, const Ioss::ElementTopology * side_topo);
+
     IOSS_NODISCARD static int64_t get_side_offset(const Ioss::SideBlock *sb);
 
     IOSS_NODISCARD static unsigned int hash(const std::string &name);

--- a/packages/seacas/libraries/ioss/src/text_mesh/Iotm_TextMesh.C
+++ b/packages/seacas/libraries/ioss/src/text_mesh/Iotm_TextMesh.C
@@ -880,6 +880,11 @@ namespace Iotm {
       return;
 
     SideBlockInfo       info = sideset->get_side_block_info(sideBlockName);
+    Ioss::ElementTopology* topology = Ioss::ElementTopology::factory(info.elementTopology, true);
+    Ioss::ElementTopology* side_topology = Ioss::ElementTopology::factory(info.sideTopology, true);
+
+    int sideOffset = Ioss::Utils::get_side_offset(topology, side_topology);
+
     std::vector<size_t> localSideIndex =
         sideset->get_sideblock_indices_local_to_proc(info, m_myProcessor);
     elemSides.resize(2 * localSideIndex.size());
@@ -892,7 +897,7 @@ namespace Iotm {
       int                          side         = elemSidePair.second;
 
       elemSides[count++] = elemId;
-      elemSides[count++] = side;
+      elemSides[count++] = side - sideOffset;
     }
   }
 

--- a/packages/seacas/libraries/ioss/src/text_mesh/Iotm_TextMeshAdjacencyGraph.h
+++ b/packages/seacas/libraries/ioss/src/text_mesh/Iotm_TextMeshAdjacencyGraph.h
@@ -364,7 +364,7 @@ namespace Iotm {
         std::vector<EntityId> sideNodes =
             get_sorted_side_nodes(adjacency.elementIndex, adjacency.side);
 
-        for (int otherSide = 1; otherSide <= get_element_topology(neighborElementIndex).num_sides();
+        for (int otherSide = 1; otherSide <= get_element_topology(neighborElementIndex).num_face_sides();
              ++otherSide) {
           std::vector<EntityId> otherSideNodes =
               get_sorted_side_nodes(neighborElementIndex, otherSide);
@@ -738,7 +738,7 @@ namespace Iotm {
         initialize_side_connectivity_graph(elementIndices);
 
         for (size_t elementIndex : elementIndices) {
-          int numSides = get_element_topology(elementIndex).num_sides();
+          int numSides = get_element_topology(elementIndex).num_face_sides();
           for (int side = 1; side <= numSides; ++side) {
             if (m_indexGraph[elementIndex].sideReference[side - 1] == 0) {
               CurrentAdjacency adjacency(elementIndex, side);
@@ -752,7 +752,7 @@ namespace Iotm {
       {
         for (size_t elementIndex : elementIndices) {
           m_indexGraph[elementIndex] =
-              FaceConnections(get_element_topology(elementIndex).num_sides());
+              FaceConnections(get_element_topology(elementIndex).num_face_sides());
         }
       }
 

--- a/packages/seacas/libraries/ioss/src/text_mesh/Iotm_TextMeshTopologyMapping.h
+++ b/packages/seacas/libraries/ioss/src/text_mesh/Iotm_TextMeshTopologyMapping.h
@@ -80,6 +80,18 @@ namespace Iotm {
 
     bool operator!=(const TopologyMapEntry &rhs) const { return !(*this == rhs); }
 
+    int num_face_sides() const
+    {
+      if (topology->is_shell()) {
+        // Only interested in face boundaries, not edges
+        if (topology->parametric_dimension() == 2) {
+          return topology->number_faces();
+        }
+      }
+
+      return topology->number_boundaries();
+    }
+
     int num_sides() const
     {
       return sideTopologies.size();

--- a/packages/seacas/libraries/ioss/src/text_mesh/Iotm_TextMeshTopologyMapping.h
+++ b/packages/seacas/libraries/ioss/src/text_mesh/Iotm_TextMeshTopologyMapping.h
@@ -82,14 +82,7 @@ namespace Iotm {
 
     int num_sides() const
     {
-      if (topology->is_shell()) {
-        // Only interested in face boundaries, not edges
-        if (topology->parametric_dimension() == 2) {
-          return topology->number_faces();
-        }
-      }
-
-      return topology->number_boundaries();
+      return sideTopologies.size();
     }
 
     // Side references are one-based
@@ -583,7 +576,7 @@ namespace Iotm {
 
       if (!entry.initialized) {
         entry.set_valid_spatial_dimensions({false, false, false, true});
-        entry.set_side_topologies({tri_3_factory(), tri_3_factory()});
+        entry.set_side_topologies({tri_3_factory(), tri_3_factory(), line_2_factory(), line_2_factory(), line_2_factory()});
         entry.initialized = true;
       }
 
@@ -596,7 +589,7 @@ namespace Iotm {
 
       if (!entry.initialized) {
         entry.set_valid_spatial_dimensions({false, false, false, true});
-        entry.set_side_topologies({tri_4_factory(), tri_4_factory()});
+        entry.set_side_topologies({tri_4_factory(), tri_4_factory(), line_2_factory(), line_2_factory(), line_2_factory()});
         entry.initialized = true;
       }
 
@@ -609,7 +602,7 @@ namespace Iotm {
 
       if (!entry.initialized) {
         entry.set_valid_spatial_dimensions({false, false, false, true});
-        entry.set_side_topologies({tri_6_factory(), tri_6_factory()});
+        entry.set_side_topologies({tri_6_factory(), tri_6_factory(), line_3_factory(), line_3_factory(), line_3_factory()});
         entry.initialized = true;
       }
 
@@ -627,7 +620,7 @@ namespace Iotm {
 
       if (!entry.initialized) {
         entry.set_valid_spatial_dimensions({false, false, false, true});
-        entry.set_side_topologies({quad_4_factory(), quad_4_factory()});
+        entry.set_side_topologies({quad_4_factory(), quad_4_factory(), line_2_factory(), line_2_factory(), line_2_factory(), line_2_factory()});
         entry.initialized = true;
       }
 
@@ -640,7 +633,7 @@ namespace Iotm {
 
       if (!entry.initialized) {
         entry.set_valid_spatial_dimensions({false, false, false, true});
-        entry.set_side_topologies({quad_8_factory(), quad_8_factory()});
+        entry.set_side_topologies({quad_8_factory(), quad_8_factory(), line_3_factory(), line_3_factory(), line_3_factory(), line_3_factory()});
         entry.initialized = true;
       }
 
@@ -653,7 +646,7 @@ namespace Iotm {
 
       if (!entry.initialized) {
         entry.set_valid_spatial_dimensions({false, false, false, true});
-        entry.set_side_topologies({quad_9_factory(), quad_9_factory()});
+        entry.set_side_topologies({quad_9_factory(), quad_9_factory(), line_3_factory(), line_3_factory(), line_3_factory(), line_3_factory()});
         entry.initialized = true;
       }
 


### PR DESCRIPTION
This is a request from STK to extend the ordinal indexing for shells in order to enable referencing the edges