### PR TITLE
Add numBlob to the parameters for the ex_init_params method.

### DIFF
--- a/packages/seacas/scripts/exodus3.in.py
+++ b/packages/seacas/scripts/exodus3.in.py
@@ -164,13 +164,12 @@ class ex_options(Enum):
 if os.name == 'nt':
     so_prefix = ''
     so_suffix = 'dll'
+elif os.uname()[0] == 'Darwin':
+    so_prefix = 'lib'
+    so_suffix = 'dylib'
 else:
-    if os.uname()[0] == 'Darwin':
-        so_prefix = 'lib'
-        so_suffix = 'dylib'
-    else:
-        so_prefix = 'lib'
-        so_suffix = 'so'
+    so_prefix = 'lib'
+    so_suffix = 'so'
 pip_path = os.path.dirname(__file__)
 pip_so_path = os.path.join(pip_path, f"{so_prefix}exodus.{so_suffix}")
 try:
@@ -673,7 +672,7 @@ class exodus:
 
 
         >>> ex_pars = ex_init_params(num_dim=numDims, num_nodes=numNodes,
-        ...                          num_elem=numElems, num_elem_blk=numElemBlocks, num_assembly=numAssembly)
+        ...                          num_elem=numElems, num_elem_blk=numElemBlocks, num_assembly=numAssembly, num_blob=numBlob)
         >>> exo = exodus(file_name, mode=mode, title=title,
         ...             array_type=array_type, init_params=ex_pars)
         >>> with exodus(file_name, mode=mode, title=title,\
@@ -729,7 +728,10 @@ class exodus:
                     numElems = 0
                 if numBlocks is None:
                     numBlocks = 0
-
+                if numBlob is None:
+                    numBlob = 0
+                if numAssembly is None:
+                    numAssembly = 0
                 info = [title, numDims, numNodes, numElems, numBlocks,
                         numNodeSets, numSideSets]
                 if None not in info:
@@ -842,6 +844,7 @@ class exodus:
         self.numNodeSets = ctypes.c_longlong(p.num_node_sets)
         self.numSideSets = ctypes.c_longlong(p.num_side_sets)
         self.numAssembly = ctypes.c_longlong(p.num_assembly)
+        self.numBlob = ctypes.c_longlong(p.num_blob)
 
         EXODUS_LIB.ex_put_init_ext(self.fileId, ctypes.byref(p))
         return True

--- a/packages/seacas/scripts/tests/test_exodus3.py
+++ b/packages/seacas/scripts/tests/test_exodus3.py
@@ -17,6 +17,7 @@ from contextlib import contextmanager
 
 ACCESS = os.getenv("ACCESS", "@ACCESSDIR@")
 sys.path.append(os.path.join(ACCESS, "lib"))
+sys.path.append(os.path.join(ACCESS, "lib64"))
 import exodus as exo
 
 
@@ -58,6 +59,19 @@ class TestExodus(unittest.TestCase):
         with self.assertRaises(AssertionError):
             with exo.exodus(self.temp_exo_path, mode="r"):
                 self.assertFalse(True)
+
+    def test_ex_init_params(self):
+        ex_pars = exo.ex_init_params(
+            num_dim=2,
+            num_nodes=9,
+            num_elem=4,
+            num_elem_blk=1,
+            num_assembly=0,
+            num_blob=0,
+        )
+        new_temp_exo_path = os.path.join(self.tempdir.name, "newexodusfile.e")
+        with exo.exodus(new_temp_exo_path, mode="w+", init_params=ex_pars) as exo_file:
+            exo_file.summarize()
 
     def test_copy_opened_in_append_mode(self):
         new = exo.assembly(


### PR DESCRIPTION
This was needed to initialize a new exodus file from inside of exodus.py using the init_params argument of the exodus class.

Add a test to ensure this capability does not regress and that ex_init_params works if new arguments need to be initalized in the future.

Address the tests not running due to the test and exodus.py script being placed in lib64. This still needs work to ensure it finds the libexodus.so library because SEACAS_LIBDIR is left blank during the CMake configure step.