### PR TITLE
DTIO: Fix app-side memory leak

### DIFF
--- a/packages/seacas/libraries/ioss/src/Ioss_DynamicTopologyObserver.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_DynamicTopologyObserver.C
@@ -212,4 +212,11 @@ namespace Ioss {
 
   void DynamicTopologyObserver::define_transient() {}
 
+  void DynamicTopologyObserver::initialize_region()
+  {
+    if (nullptr != m_region) {
+      m_region->reset_region();
+    }
+  }
+
 } // namespace Ioss

--- a/packages/seacas/libraries/ioss/src/Ioss_DynamicTopologyObserver.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_DynamicTopologyObserver.h
@@ -70,6 +70,8 @@ namespace Ioss {
 
     virtual bool needs_new_output_file() const;
 
+    virtual void initialize_region();
+
   protected:
     Region      *m_region{nullptr};
     unsigned int m_topologyModification{TOPOLOGY_SAME};

--- a/packages/seacas/libraries/ioss/src/Ioss_Region.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Region.C
@@ -2897,7 +2897,8 @@ namespace Ioss {
 
       state++; // For the state we are going to write.
 
-      reset_region();
+      topologyObserver->initialize_region();
+
       DynamicTopologyFileControl fileControl(this);
       fileControl.add_output_database_change_set(state);
 
@@ -2939,7 +2940,8 @@ namespace Ioss {
 
       state++; // For the state we are going to write.
 
-      reset_region();
+      topologyObserver->initialize_region();
+
       DynamicTopologyFileControl fileControl(this);
       fileControl.clone_and_replace_output_database(state);
 
@@ -2982,7 +2984,12 @@ namespace Ioss {
     if (!iodatabase->open_internal_change_set(set_name))
       return false;
 
-    reset_region();
+    if(topologyObserver) {
+      topologyObserver->initialize_region();
+    } else {
+      reset_region();
+    }
+
     iodatabase->release_memory();
 
     Region::set_state(STATE_CLOSED);
@@ -3012,7 +3019,12 @@ namespace Ioss {
     if (!iodatabase->open_internal_change_set(child_group_index))
       return false;
 
-    reset_region();
+    if(topologyObserver) {
+      topologyObserver->initialize_region();
+    } else {
+      reset_region();
+    }
+
     iodatabase->release_memory();
 
     Region::set_state(STATE_CLOSED);

--- a/packages/seacas/libraries/ioss/src/Ioss_Region.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Region.C
@@ -2984,9 +2984,10 @@ namespace Ioss {
     if (!iodatabase->open_internal_change_set(set_name))
       return false;
 
-    if(topologyObserver) {
+    if (topologyObserver) {
       topologyObserver->initialize_region();
-    } else {
+    }
+    else {
       reset_region();
     }
 
@@ -3019,9 +3020,10 @@ namespace Ioss {
     if (!iodatabase->open_internal_change_set(child_group_index))
       return false;
 
-    if(topologyObserver) {
+    if (topologyObserver) {
       topologyObserver->initialize_region();
-    } else {
+    }
+    else {
       reset_region();
     }
 

--- a/packages/seacas/libraries/ioss/src/Ioss_Region.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Region.h
@@ -328,6 +328,7 @@ namespace Ioss {
 
     IOSS_NODISCARD std::tuple<std::string, int, double> locate_db_state(double targetTime) const;
 
+    // Reinitialize region data structures
     void reset_region();
 
   protected:


### PR DESCRIPTION
Update to allow app the opportunity to clean up any data associated with a Region to prevent memory leaks

This happens when the Region is reset on a topology change