### PR TITLE
Fix configure warning in Trilinos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,9 @@ if (${CMAKE_VERSION} GREATER_EQUAL "3.12")
      cmake_policy(SET CMP0074 NEW)
 endif()
 
+# This can be removed after the minimum CMake is set to >= 3.27
+cmake_policy(SET CMP0144 NEW)
+
 #
 # B) Pull in the TriBITS system and execute
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,10 +19,6 @@ CMAKE_MINIMUM_REQUIRED(VERSION ${TRIBITS_CMAKE_MINIMUM_REQUIRED} FATAL_ERROR)
 # not in an include file :-(
 PROJECT(${PROJECT_NAME} NONE)
 
-if (${CMAKE_VERSION} GREATER_EQUAL "3.12")
-     cmake_policy(SET CMP0074 NEW)
-endif()
-
 # This can be removed after the minimum CMake is set to >= 3.27
 cmake_policy(SET CMP0144 NEW)
 

--- a/cmake/TPLs/FindTPLMatio.cmake
+++ b/cmake/TPLs/FindTPLMatio.cmake
@@ -52,9 +52,6 @@
 #
 # ************************************************************************
 # @HEADER
-if (${CMAKE_VERSION} GREATER "3.13")
-     cmake_policy(SET CMP0074 NEW)
-endif()
 
 find_package(Matio REQUIRED)
 TRIBITS_TPL_FIND_INCLUDE_DIRS_AND_LIBRARIES( Matio


### PR DESCRIPTION
Some of the Trilinos CI builds set `<PACKAGENAME>_ROOT` in the environment, which triggers a CMake policy warning since the version of CMake is set at 3.22.  Use the new behavior explicitly until the minimum version is updated to >= 3.27, which silences the warning (and changes the behavior).

Also removes some (now) redundant policy settings.  I put a comment above the new one to help inform when it's safe to remove.