### PR TITLE
Revert "Fix configure warning in Trilinos"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,8 +19,9 @@ CMAKE_MINIMUM_REQUIRED(VERSION ${TRIBITS_CMAKE_MINIMUM_REQUIRED} FATAL_ERROR)
 # not in an include file :-(
 PROJECT(${PROJECT_NAME} NONE)
 
-# This can be removed after the minimum CMake is set to >= 3.27
-cmake_policy(SET CMP0144 NEW)
+if (${CMAKE_VERSION} GREATER_EQUAL "3.12")
+     cmake_policy(SET CMP0074 NEW)
+endif()
 
 #
 # B) Pull in the TriBITS system and execute

--- a/cmake/TPLs/FindTPLMatio.cmake
+++ b/cmake/TPLs/FindTPLMatio.cmake
@@ -52,6 +52,9 @@
 #
 # ************************************************************************
 # @HEADER
+if (${CMAKE_VERSION} GREATER "3.13")
+     cmake_policy(SET CMP0074 NEW)
+endif()
 
 find_package(Matio REQUIRED)
 TRIBITS_TPL_FIND_INCLUDE_DIRS_AND_LIBRARIES( Matio


### PR DESCRIPTION
Reverts sandialabs/seacas#600

Based on CMake documentation, this was introduced in CMake 3.27, so will need to be protected to only set if the version is 3.27 or later, but the comment says it can be removed once we move to that version, so is it even needed?

@sebrowne 

CMP0144
Added in version 3.27.

[find_package()](https://cmake.org/cmake/help/latest/command/find_package.html#command:find_package) uses upper-case <PACKAGENAME>_ROOT variables.

In CMake 3.27 and above the [find_package(<PackageName>)](https://cmake.org/cmake/help/latest/command/find_package.html#command:find_package) command now searches prefixes specified by the upper-case [<PACKAGENAME>_ROOT](https://cmake.org/cmake/help/latest/variable/PackageName_ROOT.html#variable:%3CPACKAGENAME%3E_ROOT) CMake variable and the [<PACKAGENAME>_ROOT](https://cmake.org/cmake/help/latest/envvar/PackageName_ROOT.html#envvar:%3CPACKAGENAME%3E_ROOT) environment variable in addition to the case-preserved [<PackageName>_ROOT](https://cmake.org/cmake/help/latest/variable/PackageName_ROOT.html#variable:%3CPackageName%3E_ROOT) and [<PackageName>_ROOT](https://cmake.org/cmake/help/latest/envvar/PackageName_ROOT.html#envvar:%3CPackageName%3E_ROOT) variables used since policy [CMP0074](https://cmake.org/cmake/help/latest/policy/CMP0074.html#policy:CMP0074). This policy provides compatibility with projects that have not been updated to avoid using <PACKAGENAME>_ROOT variables for other purposes.

The OLD behavior for this policy is to ignore <PACKAGENAME>_ROOT variables if the original <PackageName> has lower-case characters. The NEW behavior for this policy is to use <PACKAGENAME>_ROOT variables.

This policy was introduced in CMake version 3.27. It may be set by [cmake_policy()](https://cmake.org/cmake/help/latest/command/cmake_policy.html#command:cmake_policy) or [cmake_minimum_required()](https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html#command:cmake_minimum_required). If it is not set, CMake warns, and uses OLD behavior.