### PR TITLE
patches CGNS to use find_package(ZLIB)

### DIFF
--- a/TPL/cgns/CGNS-ZLIB.patch
+++ b/TPL/cgns/CGNS-ZLIB.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 8a400b8..48adcfd 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -345,6 +345,7 @@ if (CGNS_ENABLE_HDF5)
+ 
+   set(HDF5_NEED_ZLIB "OFF" CACHE BOOL "Does the HDF5 library require linking to zlib?")
+   if(HDF5_NEED_ZLIB)
++    find_package(ZLIB) # more recent versions of HDF5 require ZLIB::ZLIB
+     find_library(ZLIB_LIBRARY z)
+     mark_as_advanced(CLEAR ZLIB_LIBRARY)
+   else ()

--- a/install-tpl.sh
+++ b/install-tpl.sh
@@ -606,10 +606,15 @@ then
         then
             echo "${txtgrn}+++ Configuring, Building, and Installing...${txtrst}"
             cd CGNS || exit
-	    patch < ../CGNS-Allow-more-liberal-version-matching.patch
+            patch < ../CGNS-Allow-more-liberal-version-matching.patch
             if [[ $? != 0 ]]
             then
-		echo 1>&2 ${txtred}Problems applying CGNS Version patch. Continuing, but look here if errors building. Files written may not be readable by older libraries.${txtrst}
+                echo 1>&2 ${txtred}Problems applying CGNS Version patch. Continuing, but look here if errors building. Files written may not be readable by older libraries.${txtrst}
+            fi
+            patch < ../CGNS-ZLIB.patch
+            if [[ $? != 0 ]]
+            then
+                echo 1>&2 ${txtred}Problems applying CGNS ZLIB patch.${txtrst}
             fi
             rm -rf build
             mkdir build


### PR DESCRIPTION
- Patches CGNS to call `find_package(ZLIB)`
- Fixes error shown building static libraries as reported in https://github.com/sandialabs/seacas/issues/631