### PR TITLE
Modifications to exomerge field name sorting

### DIFF
--- a/packages/seacas/scripts/exomerge3.py
+++ b/packages/seacas/scripts/exomerge3.py
@@ -493,13 +493,7 @@ class ExodusModel(object):
 
     # Regular expression used to parse field names. It splits the name into three named groups: base_name, component, and integration_point.
     # See "_sort_field_names" method for details.
-    _FIELD_NAME_REGEX = re.compile(fr"^(?P<base_name>.*?)(?:[_]?)(?P<component>{'|'.join(_FIELD_NAME_SUBSCRIPT_ORDER.keys())})?(?:[_]?(?P<integration_point>\d+))?$")
-
-    # Regular expression used to parse field names. It tries to split the name into three named groups: base_name, ip1, ip2.
-    # `ip1` and `ip2` are "integration_point which is a number from 1 or 01 or 001 to number of integration points.
-    # For example `state_dsa_29_8`
-    # See "_sort_field_names" method for details.
-    _FIELD_NAME_IP_IP_REGEX = re.compile(r"^(?P<base_name>.*?)_(?P<ip1>\d+)_(?P<ip2>\d+)$")
+    _FIELD_NAME_REGEX = re.compile(fr"^(?P<base_name>.*?)(?:[_]?)(?P<component>{'|'.join(_FIELD_NAME_SUBSCRIPT_ORDER.keys())})?(?:[_]?(?P<integration_point_1>\d+))?(?:[_]?(?P<integration_point_2>\d+))?$")
 
     def __init__(self):
         """Initialize the model."""
@@ -6953,26 +6947,16 @@ class ExodusModel(object):
             into another element that will be used for sorting purposes
             """
 
-            # See if matches "name_ip1_ip2" first.  If so, reverse
-            # order of ip1 and ip2 in the field name so it is sorted
-            # correctly.
-            match1 = self._FIELD_NAME_IP_IP_REGEX.match(elem.lower())  # type: ignore
-            if match1 is not None and match1["ip1"] is not None and match1["ip2"] is not None:
-                print(elem, match1)
-                base_name = str(match1["base_name"])
-                ip1 = int(match1["ip1"])
-                ip2 = int(match1["ip2"])
-                return (base_name, ip2, ip1)
-
             match = self._FIELD_NAME_REGEX.match(elem.lower()).groupdict()  # type: ignore
 
             base_name = str(match["base_name"])
-            integration_point = int(match["integration_point"]) if match["integration_point"] is not None else 0
+            integration_point_1 = int(match["integration_point_1"]) if match["integration_point_1"] is not None else 0
+            integration_point_2 = int(match["integration_point_2"]) if match["integration_point_2"] is not None else 0
 
             # Transform the component to a letter according to the _FIELD_NAME_SUBSCRIPT_ORDER
             component = self._FIELD_NAME_SUBSCRIPT_ORDER[match["component"]] if match["component"] is not None else 0
 
-            return (base_name, integration_point, component)
+            return (base_name, integration_point_2, integration_point_1, component)
 
         original_field_names.sort(key=_sorting_key)
         return original_field_names

--- a/packages/seacas/scripts/exomerge3.py
+++ b/packages/seacas/scripts/exomerge3.py
@@ -56,7 +56,7 @@ if sys.version_info[0] < 3:
 import exodus3 as exodus
 
 # informal version number of this module
-__version__ = "8.6.2"
+__version__ = "8.7.0"
 VERSION = __version__
 
 # contact person for issues
@@ -487,6 +487,8 @@ class ExodusModel(object):
         "x": 10,
         "y": 11,
         "z": 12,
+        "s": 13,
+        "q": 14
     }
 
     # Regular expression used to parse field names. It splits the name into three named groups: base_name, component, and integration_point.

--- a/packages/seacas/scripts/exomerge3.py
+++ b/packages/seacas/scripts/exomerge3.py
@@ -42,7 +42,6 @@ import datetime
 import itertools
 import math
 import struct
-import bisect
 import colorsys
 import difflib
 import operator
@@ -476,19 +475,19 @@ class ExodusModel(object):
     # A dictionary defining the order of components in multi-component fields.
     # See "_sort_field_names" method for details.
     _FIELD_NAME_SUBSCRIPT_ORDER = {
-                    "xx": 1,
-                    "yy": 2,
-                    "zz": 3,
-                    "xy": 4,
-                    "yz": 5,
-                    "zx": 6,
-                    "yx": 7,
-                    "zy": 8,
-                    "xz": 9,
-                    "x": 10,
-                    "y": 11,
-                    "z": 12,
-                }
+        "xx": 1,
+        "yy": 2,
+        "zz": 3,
+        "xy": 4,
+        "yz": 5,
+        "zx": 6,
+        "yx": 7,
+        "zy": 8,
+        "xz": 9,
+        "x": 10,
+        "y": 11,
+        "z": 12,
+    }
 
     # Regular expression used to parse field names. It splits the name into three named groups: base_name, component, and integration_point.
     # See "_sort_field_names" method for details.

--- a/packages/seacas/scripts/exomerge3.py
+++ b/packages/seacas/scripts/exomerge3.py
@@ -6948,8 +6948,9 @@ class ExodusModel(object):
             """
 
             match = self._FIELD_NAME_REGEX.match(elem.lower()).groupdict()  # type: ignore
-
             base_name = str(match["base_name"])
+            if base_name == '':
+                return (elem.lower(), 0, 0, 0)
             integration_point_1 = int(match["integration_point_1"]) if match["integration_point_1"] is not None else 0
             integration_point_2 = int(match["integration_point_2"]) if match["integration_point_2"] is not None else 0
 

--- a/packages/seacas/scripts/tests/exomerge_unit_test.py
+++ b/packages/seacas/scripts/tests/exomerge_unit_test.py
@@ -1913,6 +1913,7 @@ class ExomergeUnitTester:
             sorted_names_no_underscores, self.model._sort_field_names(unsorted_names_no_underscores)
         )
 
+        # Cannot sort the field names with two numeric suffices without underscores...
         sorted_ip_ip_names = [
             "_x", "_y", "_z",  # Make sure this isn't a 3D vector with no base name...
             "state_dsa_01_1", "state_dsa_02_1", "state_dsa_03_1", "state_dsa_04_1", "state_dsa_05_1",
@@ -1920,7 +1921,7 @@ class ExomergeUnitTester:
             "state_dsa_01_2", "state_dsa_02_2", "state_dsa_03_2", "state_dsa_04_2", "state_dsa_05_2",
             "state_dsa_06_2", "state_dsa_07_2", "state_dsa_08_2", "state_dsa_09_2", "state_dsa_10_2",
             "state_dsa_01_3", "state_dsa_02_3", "state_dsa_03_3", "state_dsa_04_3", "state_dsa_05_3",
-            "state_dsa_06_3", "state_dsa_07_3", "state_dsa_08_3", "state_dsa_09_3", "state_dsa_10_3"  # Two sets of integration points...
+            "state_dsa_06_3", "state_dsa_07_3", "state_dsa_08_3", "state_dsa_09_3", "state_dsa_10_3"  # Two sets of numeric suffices...
         ]
 
         # Randomly shuffle the names to simulate unsorted input

--- a/packages/seacas/scripts/tests/exomerge_unit_test.py
+++ b/packages/seacas/scripts/tests/exomerge_unit_test.py
@@ -1887,6 +1887,8 @@ class ExomergeUnitTester:
         sorted_names = [
             "Displacement_X", "Displacement_Y", "Displacement_Z",
             "ln_strain_1", "ln_strain_2", "ln_strain_3", "ln_strain_4",  # scalar field defined in integration points
+            "quat_x", "quat_y", "quat_z", "quat_q",  # 3D Quaternion (using IOSS convention.  Not sure why `q` and not `w`
+            "quat_2d_s", "quat_2d_q",  # 2D Quaternion (using IOSS convention)
             "SIGMA_XX", "SIGMA_YY", "SIGMA_ZZ", "SIGMA_XY", "SIGMA_YZ", "SIGMA_ZX", "SIGMA_YX", "SIGMA_ZY", "SIGMA_XZ",  # asymmetric tensor
             "unrotated_stress_xx_1", "unrotated_stress_yy_1", "unrotated_stress_zz_1", "unrotated_stress_xy_1", "unrotated_stress_yz_1", "unrotated_stress_zx_1",  # Symmetric tensor with integration points
             "unrotated_stress_xx_2", "unrotated_stress_yy_2", "unrotated_stress_zz_2", "unrotated_stress_xy_2", "unrotated_stress_yz_2", "unrotated_stress_zx_2",

--- a/packages/seacas/scripts/tests/exomerge_unit_test.py
+++ b/packages/seacas/scripts/tests/exomerge_unit_test.py
@@ -1894,7 +1894,7 @@ class ExomergeUnitTester:
             "unrotated_stress_xx_2", "unrotated_stress_yy_2", "unrotated_stress_zz_2", "unrotated_stress_xy_2", "unrotated_stress_yz_2", "unrotated_stress_zx_2",
             "unrotated_stress_xx_3", "unrotated_stress_yy_3", "unrotated_stress_zz_3", "unrotated_stress_xy_3", "unrotated_stress_yz_3", "unrotated_stress_zx_3",
             "unrotated_stress_xx_12", "unrotated_stress_yy_12", "unrotated_stress_zz_12", "unrotated_stress_xy_12", "unrotated_stress_yz_12", "unrotated_stress_zx_12",  # Try with a number bigger than 9
-            "velocity", # scalar field
+            "velocity",  # scalar field
             "x", "x_1_1", "y", "y_1_1", "z", "z_1_1"  # make sure regex not too greedy (no basename)
         ]
 

--- a/packages/seacas/scripts/tests/exomerge_unit_test.py
+++ b/packages/seacas/scripts/tests/exomerge_unit_test.py
@@ -1894,7 +1894,8 @@ class ExomergeUnitTester:
             "unrotated_stress_xx_2", "unrotated_stress_yy_2", "unrotated_stress_zz_2", "unrotated_stress_xy_2", "unrotated_stress_yz_2", "unrotated_stress_zx_2",
             "unrotated_stress_xx_3", "unrotated_stress_yy_3", "unrotated_stress_zz_3", "unrotated_stress_xy_3", "unrotated_stress_yz_3", "unrotated_stress_zx_3",
             "unrotated_stress_xx_12", "unrotated_stress_yy_12", "unrotated_stress_zz_12", "unrotated_stress_xy_12", "unrotated_stress_yz_12", "unrotated_stress_zx_12",  # Try with a number bigger than 9
-            "velocity"  # scalar field
+            "velocity", # scalar field
+            "x", "x_1_1", "y", "y_1_1", "z", "z_1_1"  # make sure regex not too greedy (no basename)
         ]
 
         # Randomly shuffle the names to simulate unsorted input
@@ -1913,6 +1914,7 @@ class ExomergeUnitTester:
         )
 
         sorted_ip_ip_names = [
+            "_x", "_y", "_z",  # Make sure this isn't a 3D vector with no base name...
             "state_dsa_01_1", "state_dsa_02_1", "state_dsa_03_1", "state_dsa_04_1", "state_dsa_05_1",
             "state_dsa_06_1", "state_dsa_07_1", "state_dsa_08_1", "state_dsa_09_1", "state_dsa_10_1",
             "state_dsa_01_2", "state_dsa_02_2", "state_dsa_03_2", "state_dsa_04_2", "state_dsa_05_2",

--- a/packages/seacas/scripts/tests/exomerge_unit_test.py
+++ b/packages/seacas/scripts/tests/exomerge_unit_test.py
@@ -603,7 +603,7 @@ class ExomergeUnitTester:
     # Tests should return None if successful (no return statement needed)
     # Tests should return False if the test was unable to be run.
     # Tests should raise an exception or exit(1) if unsuccessful.
-    
+
     def _test_calculate_element_volumes(self):
         ids = self.model._get_standard_element_block_ids()
         if not ids:
@@ -1749,7 +1749,7 @@ class ExomergeUnitTester:
         """
         source_code = inspect.getsource(source)
         return bool(
-            re.search("[^A-Za-z0-9_]" + target.__name__ + "[ \t\n\r]*\(", source_code)
+            re.search(r"[^A-Za-z0-9_]" + target.__name__ + r"[ \t\n\r]*\(", source_code)
         )
 
     def test(self):
@@ -1873,7 +1873,6 @@ class ExomergeUnitTester:
         print(("\nRan %d tests in %g seconds." % (tests, time.time() - start_time)))
         print("\nSuccess")
 
-
     # The following functions are unit tests for private functions of exomerge.
     def _test_sort_field_names(self):
         """Unittest for _sort_field_names method.
@@ -1888,7 +1887,7 @@ class ExomergeUnitTester:
         sorted_names = [
             "Displacement_X", "Displacement_Y", "Displacement_Z",
             "ln_strain_1", "ln_strain_2", "ln_strain_3", "ln_strain_4",  # scalar field defined in integration points
-            "SIGMA_XX", "SIGMA_YY", "SIGMA_ZZ", "SIGMA_XY", "SIGMA_YZ", "SIGMA_ZX", "SIGMA_YX", "SIGMA_ZY", "SIGMA_XZ", # asymmetric tensor
+            "SIGMA_XX", "SIGMA_YY", "SIGMA_ZZ", "SIGMA_XY", "SIGMA_YZ", "SIGMA_ZX", "SIGMA_YX", "SIGMA_ZY", "SIGMA_XZ",  # asymmetric tensor
             "unrotated_stress_xx_1", "unrotated_stress_yy_1", "unrotated_stress_zz_1", "unrotated_stress_xy_1", "unrotated_stress_yz_1", "unrotated_stress_zx_1",  # Symmetric tensor with integration points
             "unrotated_stress_xx_2", "unrotated_stress_yy_2", "unrotated_stress_zz_2", "unrotated_stress_xy_2", "unrotated_stress_yz_2", "unrotated_stress_zx_2",
             "unrotated_stress_xx_3", "unrotated_stress_yy_3", "unrotated_stress_zz_3", "unrotated_stress_xy_3", "unrotated_stress_yz_3", "unrotated_stress_zx_3",
@@ -1929,7 +1928,7 @@ class ExomergeUnitTester:
 
 
 # if this module is executed (as opposed to imported), run the tests
-if __name__ == "__main__": 
+if __name__ == "__main__":
 
     if len(sys.argv) > 2:
         sys.stderr.write("Invalid syntax.\n")

--- a/packages/seacas/scripts/tests/exomerge_unit_test.py
+++ b/packages/seacas/scripts/tests/exomerge_unit_test.py
@@ -1922,10 +1922,10 @@ class ExomergeUnitTester:
         ]
 
         # Randomly shuffle the names to simulate unsorted input
-        unsorted_names = sorted_ip_ip_names.copy()
-        random.shuffle(unsorted_names)
-        assert sorted_ip_ip_names == self.model._sort_field_names(unsorted_names), "Failed to sort names with underscores.\nExpected: {}\nGot: {}".format(
-            sorted_names, self.model._sort_field_names(unsorted_names)
+        unsorted_ip_names = sorted_ip_ip_names.copy()
+        random.shuffle(unsorted_ip_names)
+        assert sorted_ip_ip_names == self.model._sort_field_names(unsorted_ip_names), "Failed to sort names with underscores.\nExpected: {}\nGot: {}".format(
+            sorted_ip_ip_names, self.model._sort_field_names(unsorted_ip_names)
         )
 
 

--- a/packages/seacas/scripts/tests/exomerge_unit_test.py
+++ b/packages/seacas/scripts/tests/exomerge_unit_test.py
@@ -2,7 +2,7 @@
 """
 This file performs unit tests of functions within Exomerge.
 
-Copyright 2018, 2021, 2022 National Technology and Engineering
+Copyright 2018, 2021, 2022, 2025 National Technology and Engineering
 Solutions of Sandia.  Under the terms of Contract DE-NA-0003525, there
 is a non-exclusive license for use of this work by or on behalf of the
 U.S. Government.  Export of this program may require a license from
@@ -1909,6 +1909,22 @@ class ExomergeUnitTester:
         random.shuffle(unsorted_names_no_underscores)
         assert sorted_names_no_underscores == self.model._sort_field_names(unsorted_names_no_underscores), "Failed to sort names without underscores. \nExpected: {}\nGot: {}".format(
             sorted_names_no_underscores, self.model._sort_field_names(unsorted_names_no_underscores)
+        )
+
+        sorted_ip_ip_names = [
+            "state_dsa_01_1", "state_dsa_02_1", "state_dsa_03_1", "state_dsa_04_1", "state_dsa_05_1",
+            "state_dsa_06_1", "state_dsa_07_1", "state_dsa_08_1", "state_dsa_09_1", "state_dsa_10_1",
+            "state_dsa_01_2", "state_dsa_02_2", "state_dsa_03_2", "state_dsa_04_2", "state_dsa_05_2",
+            "state_dsa_06_2", "state_dsa_07_2", "state_dsa_08_2", "state_dsa_09_2", "state_dsa_10_2",
+            "state_dsa_01_3", "state_dsa_02_3", "state_dsa_03_3", "state_dsa_04_3", "state_dsa_05_3",
+            "state_dsa_06_3", "state_dsa_07_3", "state_dsa_08_3", "state_dsa_09_3", "state_dsa_10_3"  # Two sets of integration points...
+        ]
+
+        # Randomly shuffle the names to simulate unsorted input
+        unsorted_names = sorted_ip_ip_names.copy()
+        random.shuffle(unsorted_names)
+        assert sorted_ip_ip_names == self.model._sort_field_names(unsorted_names), "Failed to sort names with underscores.\nExpected: {}\nGot: {}".format(
+            sorted_names, self.model._sort_field_names(unsorted_names)
         )
 
 


### PR DESCRIPTION
Add support for field names with two "integration_point" suffices:
```
 field_dsa_29_2
```

Support recognizing the IOSS quaternion suffix convention:
```
   field_x, field_y, field_z, field_q
   fld_s, fld_q
```
