### PR TITLE
F2C(EXINQ) initialize float return to avoid IEEE_DENORMAL in mapvar

### DIFF
--- a/packages/seacas/libraries/exodus_for/src/exo_jack-windows.c
+++ b/packages/seacas/libraries/exodus_for/src/exo_jack-windows.c
@@ -1919,7 +1919,7 @@ void F2C(EXINQ)(int *idexo, int *req_info, void_int *ret_int, float *ret_float, 
                 int *ierr, int ret_charlen)
 {
   *ret_float = 0.0f;
-  *ierr = ex_inquire(*idexo, (ex_inquiry)*req_info, ret_int, ret_float, ret_char);
+  *ierr      = ex_inquire(*idexo, (ex_inquiry)*req_info, ret_int, ret_float, ret_char);
 }
 
 /*

--- a/packages/seacas/libraries/exodus_for/src/exo_jack-windows.c
+++ b/packages/seacas/libraries/exodus_for/src/exo_jack-windows.c
@@ -1921,7 +1921,6 @@ void F2C(EXINQ)(int *idexo, int *req_info, void_int *ret_int, float *ret_float, 
 {
   if (ex_int64_status(*idexo) & EX_INQ_INT64_API) {
     *((int64_t *)ret_int) = 0;
-    ;
   }
   else {
     *((int *)ret_int) = 0;

--- a/packages/seacas/libraries/exodus_for/src/exo_jack-windows.c
+++ b/packages/seacas/libraries/exodus_for/src/exo_jack-windows.c
@@ -23,7 +23,9 @@
 #include "exodusII.h"
 #include "exodusII_int.h"
 #include "netcdf.h"
+#include <cstdint>
 #include <ctype.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -1918,8 +1920,13 @@ void F2C(EXGATM)(int *idexo, real *time_values, int *ierr)
 void F2C(EXINQ)(int *idexo, int *req_info, void_int *ret_int, float *ret_float, char *ret_char,
                 int *ierr, int ret_charlen)
 {
-  *ret_float = 0.0f;
-  *ierr      = ex_inquire(*idexo, (ex_inquiry)*req_info, ret_int, ret_float, ret_char);
+  if (ex_int64_status(*idexo) & EX_INQ_INT64_API) {
+     *((int64_t *)ret_int) = 0;;
+  } else {
+     *((int *)ret_int) = 0;
+  }
+  *ret_float      = 0.0f;
+  *ierr           = ex_inquire(*idexo, (ex_inquiry)*req_info, ret_int, ret_float, ret_char);
 }
 
 /*

--- a/packages/seacas/libraries/exodus_for/src/exo_jack-windows.c
+++ b/packages/seacas/libraries/exodus_for/src/exo_jack-windows.c
@@ -23,7 +23,6 @@
 #include "exodusII.h"
 #include "exodusII_int.h"
 #include "netcdf.h"
-#include <cstdint>
 #include <ctype.h>
 #include <stdint.h>
 #include <stdio.h>

--- a/packages/seacas/libraries/exodus_for/src/exo_jack-windows.c
+++ b/packages/seacas/libraries/exodus_for/src/exo_jack-windows.c
@@ -1918,6 +1918,7 @@ void F2C(EXGATM)(int *idexo, real *time_values, int *ierr)
 void F2C(EXINQ)(int *idexo, int *req_info, void_int *ret_int, float *ret_float, char *ret_char,
                 int *ierr, int ret_charlen)
 {
+  *ret_float = 0.0f;
   *ierr = ex_inquire(*idexo, (ex_inquiry)*req_info, ret_int, ret_float, ret_char);
 }
 

--- a/packages/seacas/libraries/exodus_for/src/exo_jack-windows.c
+++ b/packages/seacas/libraries/exodus_for/src/exo_jack-windows.c
@@ -1921,12 +1921,14 @@ void F2C(EXINQ)(int *idexo, int *req_info, void_int *ret_int, float *ret_float, 
                 int *ierr, int ret_charlen)
 {
   if (ex_int64_status(*idexo) & EX_INQ_INT64_API) {
-     *((int64_t *)ret_int) = 0;;
-  } else {
-     *((int *)ret_int) = 0;
+    *((int64_t *)ret_int) = 0;
+    ;
   }
-  *ret_float      = 0.0f;
-  *ierr           = ex_inquire(*idexo, (ex_inquiry)*req_info, ret_int, ret_float, ret_char);
+  else {
+    *((int *)ret_int) = 0;
+  }
+  *ret_float = 0.0f;
+  *ierr      = ex_inquire(*idexo, (ex_inquiry)*req_info, ret_int, ret_float, ret_char);
 }
 
 /*

--- a/packages/seacas/libraries/exodus_for/src/exo_jack.c
+++ b/packages/seacas/libraries/exodus_for/src/exo_jack.c
@@ -2440,8 +2440,13 @@ void F2C(exgatm, EXGATM)(int *idexo, real *time_values, int *ierr)
 void F2C(exinq, EXINQ)(int *idexo, int *req_info, void_int *ret_int, float *ret_float,
                        char *ret_char, int *ierr, int ret_charlen)
 {
-  *ret_float = 0.0f;
-  *ierr      = ex_inquire(*idexo, (ex_inquiry)*req_info, ret_int, ret_float, ret_char);
+  if (ex_int64_status(*idexo) & EX_INQ_INT64_API) {
+     *((int64_t *)ret_int) = 0;;
+  } else {
+     *((int *)ret_int) = 0;
+  }
+  *ret_float      = 0.0f;
+  *ierr           = ex_inquire(*idexo, (ex_inquiry)*req_info, ret_int, ret_float, ret_char);
   EX_UNUSED(ret_charlen);
 }
 

--- a/packages/seacas/libraries/exodus_for/src/exo_jack.c
+++ b/packages/seacas/libraries/exodus_for/src/exo_jack.c
@@ -2441,12 +2441,14 @@ void F2C(exinq, EXINQ)(int *idexo, int *req_info, void_int *ret_int, float *ret_
                        char *ret_char, int *ierr, int ret_charlen)
 {
   if (ex_int64_status(*idexo) & EX_INQ_INT64_API) {
-     *((int64_t *)ret_int) = 0;;
-  } else {
-     *((int *)ret_int) = 0;
+    *((int64_t *)ret_int) = 0;
+    ;
   }
-  *ret_float      = 0.0f;
-  *ierr           = ex_inquire(*idexo, (ex_inquiry)*req_info, ret_int, ret_float, ret_char);
+  else {
+    *((int *)ret_int) = 0;
+  }
+  *ret_float = 0.0f;
+  *ierr      = ex_inquire(*idexo, (ex_inquiry)*req_info, ret_int, ret_float, ret_char);
   EX_UNUSED(ret_charlen);
 }
 

--- a/packages/seacas/libraries/exodus_for/src/exo_jack.c
+++ b/packages/seacas/libraries/exodus_for/src/exo_jack.c
@@ -2440,6 +2440,7 @@ void F2C(exgatm, EXGATM)(int *idexo, real *time_values, int *ierr)
 void F2C(exinq, EXINQ)(int *idexo, int *req_info, void_int *ret_int, float *ret_float,
                        char *ret_char, int *ierr, int ret_charlen)
 {
+  *ret_float = 0.0f;
   *ierr = ex_inquire(*idexo, (ex_inquiry)*req_info, ret_int, ret_float, ret_char);
   EX_UNUSED(ret_charlen);
 }

--- a/packages/seacas/libraries/exodus_for/src/exo_jack.c
+++ b/packages/seacas/libraries/exodus_for/src/exo_jack.c
@@ -2441,7 +2441,7 @@ void F2C(exinq, EXINQ)(int *idexo, int *req_info, void_int *ret_int, float *ret_
                        char *ret_char, int *ierr, int ret_charlen)
 {
   *ret_float = 0.0f;
-  *ierr = ex_inquire(*idexo, (ex_inquiry)*req_info, ret_int, ret_float, ret_char);
+  *ierr      = ex_inquire(*idexo, (ex_inquiry)*req_info, ret_int, ret_float, ret_char);
   EX_UNUSED(ret_charlen);
 }
 

--- a/packages/seacas/libraries/exodus_for/src/exo_jack.c
+++ b/packages/seacas/libraries/exodus_for/src/exo_jack.c
@@ -2442,7 +2442,6 @@ void F2C(exinq, EXINQ)(int *idexo, int *req_info, void_int *ret_int, float *ret_
 {
   if (ex_int64_status(*idexo) & EX_INQ_INT64_API) {
     *((int64_t *)ret_int) = 0;
-    ;
   }
   else {
     *((int *)ret_int) = 0;


### PR DESCRIPTION
Mapvar seems to trigger IEEE_DENORMAL with the RELEASE build type because an unused float is uninitialized but used in the EXINQ routine.

This happens on line 282 in mapvar.f

Here is the small test case I was using:

[mapvar_test.tar.gz](https://github.com/user-attachments/files/21124212/mapvar_test.tar.gz)

It is also fixed if you initialize it before the wrapper call if you would rather do it there.

This was with GCC15 with or without mpi.
