### PR TITLE
Fix filesystem api

### DIFF
--- a/.github/workflows/docker-exodus.yml
+++ b/.github/workflows/docker-exodus.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           context: docker/exodus
           push: true
-          tags: mrbuche/exodus:latest
+          tags: gdsjaar/exodus:latest
       - name: Delay before pull
         run: sleep 234s
   test-latest:

--- a/.github/workflows/docker-seacas.yml
+++ b/.github/workflows/docker-seacas.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           context: docker/seacas
           push: true
-          tags: mrbuche/seacas:latest
+          tags: gdsjaar/seacas:latest
       - name: Delay before pull
         run: sleep 234s
   test-latest:

--- a/cmake/tribits/common_tpls/FindTPLCGNS.cmake
+++ b/cmake/tribits/common_tpls/FindTPLCGNS.cmake
@@ -41,7 +41,7 @@ set(CNGS_ALLOW_MODERN FALSE CACHE BOOL "Allow finding CGNS as a modern CMake con
 
 if ((CGNS_ALLOW_MODERN AND HDF5_FOUND_MODERN_CONFIG_FILE) OR CGNS_FORCE_MODERN)
 
-  set(minimum_modern_CGNS_version 4.0)
+  set(minimum_modern_CGNS_version 3.9)
   print_var(CGNS_ALLOW_MODERN)
   print_var(CGNS_FORCE_MODERN)
   message("-- Using find_package(CGNS ${minimum_modern_CGNS_version} CONFIG) ...")

--- a/docker/exodus/Dockerfile
+++ b/docker/exodus/Dockerfile
@@ -39,6 +39,6 @@ RUN ../cmake-exodus && \
     make && \
     make install
 ENV PATH="${PATH}:/seacas/bin/"
-ENV PYTHONPATH="${PYTHONPATH}:/seacas/lib/"
-ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/seacas/lib/"
+ENV PYTHONPATH="${PYTHONPATH:""}:/seacas/lib/"
+ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH:""}:/seacas/lib/"
 CMD ["/bin/bash"]

--- a/docker/exodus/Dockerfile
+++ b/docker/exodus/Dockerfile
@@ -38,7 +38,7 @@ WORKDIR /seacas/build
 RUN ../cmake-exodus && \
     make && \
     make install
-ENV PATH "${PATH}:/seacas/bin/"
-ENV PYTHONPATH "${PYTHONPATH}:/seacas/lib/"
-ENV LD_LIBRARY_PATH "${LD_LIBRARY_PATH}:/seacas/lib/"
+ENV PATH="${PATH}:/seacas/bin/"
+ENV PYTHONPATH="${PYTHONPATH}:/seacas/lib/"
+ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/seacas/lib/"
 CMD ["/bin/bash"]

--- a/docker/seacas/Dockerfile
+++ b/docker/seacas/Dockerfile
@@ -38,7 +38,7 @@ WORKDIR /seacas/build
 RUN ../cmake-config && \
     make && \
     make install
-ENV PATH "${PATH}:/seacas/bin/"
-ENV PYTHONPATH "${PYTHONPATH}:/seacas/lib/"
-ENV LD_LIBRARY_PATH "${LD_LIBRARY_PATH}:/seacas/lib/"
+ENV PATH="${PATH}:/seacas/bin/"
+ENV PYTHONPATH="${PYTHONPATH:""}:/seacas/lib/"
+ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH:""}:/seacas/lib/"
 CMD ["/bin/bash"]

--- a/install-tpl.sh
+++ b/install-tpl.sh
@@ -609,7 +609,7 @@ if [ "$CGNS" == "YES" ] && [ "$HDF5" == "YES" ]
 then
     if [ "$FORCE" == "YES" ] || [ "$FORCE_CGNS" == "YES" ] || ! [ -e $INSTALL_PATH/lib/libcgns.${LD_EXT} ]
     then
-        cgns_version="v4.5.0"
+        cgns_version="v4.5.1"
         echo "${txtgrn}+++ CGNS ${cgns_version} ${txtrst}"
         cd $ACCESS || exit
         cd TPL/cgns || exit

--- a/install-tpl.sh
+++ b/install-tpl.sh
@@ -556,7 +556,8 @@ if [ "$FORCE" == "YES" ] || [ "$FORCE_NETCDF" == "YES" ] || ! [ -e $INSTALL_PATH
 then
 #   netcdf_version="v4.9.1"
 #    netcdf_version="v4.9.2"
-    netcdf_version="v4.9.3"
+#    netcdf_version="v4.9.3"
+    netcdf_version="v4.10.0"
 #   netcdf_version="v4.8.1"
 #   netcdf_version="main"
 
@@ -570,7 +571,7 @@ then
         git clone --depth 1 --branch ${netcdf_version} https://github.com/Unidata/netcdf-c netcdf-c
     fi
 
-    if [ "$netcdf_version" == "v4.9.3" ]
+    if [ "$netcdf_version" == "v4.9.3" ] || [ "$netcdf_version" == "v4.10.0" ]
     then
         PREFIX="NETCDF_"
     fi

--- a/packages/seacas/libraries/ioss/src/Ioss_FileInfo.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_FileInfo.C
@@ -168,7 +168,7 @@ namespace Ioss {
     return false;
   }
 
-  std::string_view FileInfo::filesystem_type() const
+  std::string FileInfo::filesystem_type() const
   {
 #if !defined(__IOSS_WINDOWS__)
     auto tmp_path = pathname();

--- a/packages/seacas/libraries/ioss/src/Ioss_FileInfo.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_FileInfo.h
@@ -74,7 +74,8 @@ namespace Ioss {
 
     IOSS_NODISCARD off_t size() const; //!< File size in bytes. Only if is_file() == true
 
-    IOSS_NODISCARD std::string filesystem_type() const; //!< Best guess at filesystem type (nfs, lustre, gpfs, unknown)
+    IOSS_NODISCARD std::string
+    filesystem_type() const; //!< Best guess at filesystem type (nfs, lustre, gpfs, unknown)
     IOSS_NODISCARD std::string filename() const;  //!< Complete filename including path
     IOSS_NODISCARD std::string basename() const;  //!< strip path and extension
     IOSS_NODISCARD std::string tailname() const;  //!< basename() + extension()

--- a/packages/seacas/libraries/ioss/src/Ioss_FileInfo.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_FileInfo.h
@@ -74,8 +74,7 @@ namespace Ioss {
 
     IOSS_NODISCARD off_t size() const; //!< File size in bytes. Only if is_file() == true
 
-    IOSS_NODISCARD std::string_view
-    filesystem_type() const; //!< Best guess at filesystem type (nfs, lustre, gpfs, unknown)
+    IOSS_NODISCARD std::string filesystem_type() const; //!< Best guess at filesystem type (nfs, lustre, gpfs, unknown)
     IOSS_NODISCARD std::string filename() const;  //!< Complete filename including path
     IOSS_NODISCARD std::string basename() const;  //!< strip path and extension
     IOSS_NODISCARD std::string tailname() const;  //!< basename() + extension()


### PR DESCRIPTION
The use of `string_view` as the return type is ok for the linux implementation, but for the Mac, it is returning a value from the stack which is not good.  See #804 

Returning a `std::string` fixes this, but could potentially break a client using the function.  However, I don't think this function is being used much if at all and changing the API is hopefuly the easiest solution instead of deprecating and adding a new function...