### PR TITLE
EXODUS: Fix incorrect use of exi_redef

### DIFF
--- a/packages/seacas/libraries/exodus/src/ex_open_par.c
+++ b/packages/seacas/libraries/exodus/src/ex_open_par.c
@@ -325,7 +325,7 @@ int ex_open_par_int(const char *path, int mode, int *comp_ws, int *io_ws, float 
   if (mode & EX_WRITE) { /* Appending */
     /* turn off automatic filling of netCDF variables */
     if (is_pnetcdf) {
-      if ((status = exi_redef(exoid, __func__)) != EX_NOERR) {
+      if ((status = nc_redef(exoid)) != EX_NOERR) {
         snprintf(errmsg, MAX_ERR_LENGTH, "ERROR: failed to put file id %d into define mode", exoid);
         ex_err_fn(exoid, __func__, errmsg, status);
         free(canon_path);


### PR DESCRIPTION
At the point that this function was calle in `ex_open_par`, the exodus `file_item` struct has not yet be initialized, so cannot use the `exi_redef` and have to use the `nc_redef`.

This should fix #805