### PR TITLE
Kluge to fix Ut_ioad test

### DIFF
--- a/packages/seacas/libraries/ioss/src/utest/Ut_ioad.C
+++ b/packages/seacas/libraries/ioss/src/utest/Ut_ioad.C
@@ -420,7 +420,9 @@ template <typename T> const std::string get_entity_type_test()
 {
   // Use "node" as default entity type to enable factory to create object.
   std::unique_ptr<T> entity(Ioad::NewEntity<T>(nullptr, "", "node", 0));
-  return entity->type_string();
+  // This should not be needed, but just returning `entity->type_string()` is causing errors.
+  auto retval = entity->type_string();
+  return retval;
 }
 
 // NodeBlock has a different constructor...


### PR DESCRIPTION
Return value from type_string() is stored in retval to avoid errors.

Should not be needed, but it looks like something is causing an incorrect optimization or build...