### PR TITLE
Update Intel oneAPI build setup in workflow

### DIFF
--- a/.github/workflows/intel-build.yml
+++ b/.github/workflows/intel-build.yml
@@ -57,8 +57,9 @@ jobs:
       with:
         install-oneapi: true
         oneapi-version: '2025.3'
-        install-mpi: false
+        install-mpi: true
         install-mkl: false
+        install-classic: false
         
     - name: Install System dependencies
       shell: bash -l {0}
@@ -125,8 +126,9 @@ jobs:
         with:
           install-oneapi: true
           oneapi-version: '2025.3'
-          install-mpi: false
+          install-mpi: true
           install-mkl: false
+          install-classic: false
         
       - name: Install System dependencies
         shell: bash -l {0}

--- a/.github/workflows/intel-build.yml
+++ b/.github/workflows/intel-build.yml
@@ -76,7 +76,7 @@ jobs:
       uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: ~/environments/${{ matrix.compiler }}-${{ matrix.hdf5 }}-${{ matrix.netcdf }}-${{ matrix.cgns }}
-        key: TPL-v4intel-${{ runner.os }}-${{ matrix.compiler }}-${{ matrix.hdf5 }}-${{ matrix.netcdf }}-${{ matrix.cgns }}
+        key: TPL-v5intel-${{ runner.os }}-${{ matrix.compiler }}-${{ matrix.hdf5 }}-${{ matrix.netcdf }}-${{ matrix.cgns }}
 
     - name: Build TPL-${{ matrix.compiler }}-${{ matrix.hdf5 }}-${{ matrix.netcdf }}-${{ matrix.cgns }}
       if: steps.cache-TPL.outputs.cache-hit != 'true'
@@ -144,7 +144,7 @@ jobs:
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/environments/${{ matrix.compiler }}-${{ matrix.hdf5 }}-${{ matrix.netcdf }}-${{ matrix.cgns }}
-          key: TPL-v4intel-${{ runner.os }}-${{ matrix.compiler }}-${{ matrix.hdf5 }}-${{ matrix.netcdf }}-${{ matrix.cgns }}
+          key: TPL-v5intel-${{ runner.os }}-${{ matrix.compiler }}-${{ matrix.hdf5 }}-${{ matrix.netcdf }}-${{ matrix.cgns }}
 
       - name: Check Cache
         shell: bash -l {0}

--- a/.github/workflows/intel-build.yml
+++ b/.github/workflows/intel-build.yml
@@ -52,18 +52,13 @@ jobs:
         rm GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
         sudo echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
         sudo apt-get update
-    - name: install
-      run: |
-        sudo apt-get install -y intel-basekit
-        sudo apt-get install -y intel-oneapi-common-vars
-        sudo apt-get install -y intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
-        sudo apt-get install -y intel-oneapi-mpi
-        sudo apt-get install -y intel-oneapi-mpi-devel
-
-    - name: Setup Intel oneAPI Fortran
-      uses: fortran-lang/setup-fortran@v1
+    - name: Install Intel oneAPI compilers
+      uses: NOAA-EMC/ci-install-intel-toolkit@develop
       with:
-        compiler: intel  # use 'intel-classic' for ifort
+        install-oneapi: true
+        oneapi-version: '2025.3'
+        install-mpi: false
+        install-mkl: false
         
     - name: Install System dependencies
       shell: bash -l {0}
@@ -124,17 +119,14 @@ jobs:
           rm GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
           sudo echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
           sudo apt-get update
-      - name: install
-        run: |
-          sudo apt-get install -y intel-basekit
-          sudo apt-get install -y intel-oneapi-common-vars
-          sudo apt-get install -y intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
-          sudo apt-get install -y intel-oneapi-mpi
-          sudo apt-get install -y intel-oneapi-mpi-devel
-      - name: Setup Intel oneAPI Fortran
-        uses: fortran-lang/setup-fortran@v1
+          
+      - name: Install Intel oneAPI compilers
+        uses: NOAA-EMC/ci-install-intel-toolkit@develop
         with:
-          compiler: intel  # use 'intel-classic' for ifort
+          install-oneapi: true
+          oneapi-version: '2025.3'
+          install-mpi: false
+          install-mkl: false
         
       - name: Install System dependencies
         shell: bash -l {0}

--- a/.github/workflows/intel-build.yml
+++ b/.github/workflows/intel-build.yml
@@ -57,10 +57,14 @@ jobs:
         sudo apt-get install -y intel-basekit
         sudo apt-get install -y intel-oneapi-common-vars
         sudo apt-get install -y intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
-        sudo apt-get install -y intel-oneapi-compiler-fortran
         sudo apt-get install -y intel-oneapi-mpi
         sudo apt-get install -y intel-oneapi-mpi-devel
 
+    - name: Setup Intel oneAPI Fortran
+      uses: fortran-lang/setup-fortran@v1
+      with:
+        compiler: intel  # use 'intel-classic' for ifort
+        
     - name: Install System dependencies
       shell: bash -l {0}
       run: sudo apt update && sudo apt install -y libaec-dev zlib1g-dev automake autoconf libcurl4-openssl-dev libjpeg-dev wget curl bzip2 m4 flex bison cmake libzip-dev  libx11-dev
@@ -125,10 +129,13 @@ jobs:
           sudo apt-get install -y intel-basekit
           sudo apt-get install -y intel-oneapi-common-vars
           sudo apt-get install -y intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
-          sudo apt-get install -y intel-oneapi-compiler-fortran
           sudo apt-get install -y intel-oneapi-mpi
           sudo apt-get install -y intel-oneapi-mpi-devel
-
+      - name: Setup Intel oneAPI Fortran
+        uses: fortran-lang/setup-fortran@v1
+        with:
+          compiler: intel  # use 'intel-classic' for ifort
+        
       - name: Install System dependencies
         shell: bash -l {0}
         run: sudo apt update && sudo apt install -y libaec-dev zlib1g-dev automake autoconf libcurl4-openssl-dev libjpeg-dev wget curl bzip2 m4 flex bison cmake libzip-dev  libx11-dev

--- a/.github/workflows/intel-build.yml
+++ b/.github/workflows/intel-build.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   build-deps:
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:
@@ -52,6 +52,7 @@ jobs:
         rm GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
         sudo echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
         sudo apt-get update
+  
     - name: Install Intel oneAPI compilers
       uses: NOAA-EMC/ci-install-intel-toolkit@develop
       with:
@@ -60,7 +61,9 @@ jobs:
         install-mpi: true
         install-mkl: false
         install-classic: false
-        
+        env-update: true
+        compiler-setup: 'oneapi'
+
     - name: Install System dependencies
       shell: bash -l {0}
       run: sudo apt update && sudo apt install -y libaec-dev zlib1g-dev automake autoconf libcurl4-openssl-dev libjpeg-dev wget curl bzip2 m4 flex bison cmake libzip-dev  libx11-dev
@@ -88,7 +91,7 @@ jobs:
   seacas-build:
 
     needs: build-deps
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:
@@ -129,6 +132,8 @@ jobs:
           install-mpi: true
           install-mkl: false
           install-classic: false
+          env-update: true
+          compiler-setup: 'oneapi'
         
       - name: Install System dependencies
         shell: bash -l {0}

--- a/.github/workflows/intel-build.yml
+++ b/.github/workflows/intel-build.yml
@@ -39,7 +39,7 @@ jobs:
       uses: easimon/maximize-build-space@fc881a613ad2a34aca9c9624518214ebc21dfc0c # master
       with:
         root-reserve-mb: 30000
-        temp-reserve-mb: 20000
+        temp-reserve-mb: 30000
         remove-dotnet: 'true'
         remove-android: 'true'
         remove-haskell: 'true'
@@ -111,7 +111,7 @@ jobs:
         uses: easimon/maximize-build-space@fc881a613ad2a34aca9c9624518214ebc21dfc0c # master
         with:
           root-reserve-mb: 30000
-          temp-reserve-mb: 20000
+          temp-reserve-mb: 30000
           remove-dotnet: 'true'
           remove-android: 'true'
           remove-haskell: 'true'

--- a/.github/workflows/intel-build.yml
+++ b/.github/workflows/intel-build.yml
@@ -39,7 +39,7 @@ jobs:
       uses: easimon/maximize-build-space@fc881a613ad2a34aca9c9624518214ebc21dfc0c # master
       with:
         root-reserve-mb: 30000
-        temp-reserve-mb: 30000
+        temp-reserve-mb: 20000
         remove-dotnet: 'true'
         remove-android: 'true'
         remove-haskell: 'true'
@@ -111,7 +111,7 @@ jobs:
         uses: easimon/maximize-build-space@fc881a613ad2a34aca9c9624518214ebc21dfc0c # master
         with:
           root-reserve-mb: 30000
-          temp-reserve-mb: 30000
+          temp-reserve-mb: 20000
           remove-dotnet: 'true'
           remove-android: 'true'
           remove-haskell: 'true'


### PR DESCRIPTION
Removed installation of intel-oneapi-compiler-fortran and added setup for Intel oneAPI Fortran using fortran-lang/setup-fortran.

See if this fixes the currently failing intel-oneapi build...