### PR TITLE
Snishant0/add truss element type in exomerge

### DIFF
--- a/packages/seacas/scripts/exomerge2.py
+++ b/packages/seacas/scripts/exomerge2.py
@@ -1283,6 +1283,7 @@ class ExodusModel(object):
                             'tetra10': 'tet10',
                             'tri': 'tri3',
                             'triangle': 'tri3',
+                            'truss': 'line2',
                             'quad': 'quad4',
                             'shell4': 'quad4',
                             'wedge': 'wedge6'}

--- a/packages/seacas/scripts/exomerge3.py
+++ b/packages/seacas/scripts/exomerge3.py
@@ -1463,6 +1463,7 @@ class ExodusModel(object):
             "tetra10": "tet10",
             "tri": "tri3",
             "triangle": "tri3",
+            "truss": "line2",
             "quad": "quad4",
             "shell4": "quad4",
             "wedge": "wedge6",


### PR DESCRIPTION
## PR Description: Add truss element type translation to exomerge2.py and exomerge3.py

### Problem
The exomerge mesh manipulation scripts lack support for `truss` element types. When mesh operations (such as `reflect_element_blocks`) encounter truss elements, they fail with:

```
ERROR: Unknown inversion algorithm.
Message: The required numbering to invert an element of type "truss" is not defined.
```

This causes failures when processing meshes that contain truss elements during reflection and transformation operations, particularly in:
- Mesh reflection operations (e.g., creating 3D meshes from 2D cross-sections)
- Half-to-full mesh conversions (e.g., reflecting about a symmetry plane)

### Solution
Add `"truss": "line2"` to the `translation_list` dictionary in the `_get_standard_element_type()` method in both exomerge2.py and exomerge3.py (around line 1470).

This maps truss elements to line2 elements, allowing the exomerge scripts to handle them using the existing line2 element logic, including:
- **Inversion algorithms** (required for reflection operations)
- **Volume/length calculations** (for element quality metrics)
- **Face mappings** (for side set operations)
- **Connectivity operations** (for mesh transformations)

### Technical Details

**Modified files:**
```
packages/seacas/scripts/exomerge2.py (Python 2 version)
packages/seacas/scripts/exomerge3.py (Python 3 version)
```

**Change location:** Line ~1470 in the `translation_list` dictionary within `_get_standard_element_type()` method

**Why this works:** 
Truss elements are structurally equivalent to line2 (2-node line) elements:
- Both are 1-dimensional elements
- Both have exactly 2 nodes
- Both use the same connectivity pattern
- Both support the same topological operations

The translation allows all existing line2 algorithms to handle truss elements transparently without code duplication.

### Code Change
```python
translation_list = {
    "hex": "hex8",
    "tet": "tet4",
    "tetra": "tet4",
    "tetra10": "tet10",
    "tri": "tri3",
    "triangle": "tri3",
    "truss": "line2",        # <-- Added
    "quad": "quad4",
    "shell4": "quad4",
    "wedge": "wedge6",
}
```

### Testing
This fix enables the following operations to work correctly with meshes containing truss elements:

1. **Mesh reflection operations**
   - Reflects 2D meshes about symmetry planes
   - Requires element inversion after reflection to maintain proper element orientation
   
Truss elements are handled correctly through the line2 translation during mesh reflection.

### Impact
- **Backward compatible:** Does not affect existing meshes without truss elements
- **No performance impact:** Translation is a simple dictionary lookup
- **Consistent behavior:** Truss elements now behave identically to line2 elements across all operations

### Use Case
Truss elements are commonly used in:
- Structural analysis meshes for beam/truss structures
- Reinforcement modeling in composite materials
- Simplified representations of 1D features in complex geometries

This fix ensures that meshes containing truss elements can be processed by all exomerge operations that work with other standard element types.

### Notes
- The change is consistent with the naming convention used in the existing `translation_list`
- The fix leverages existing, well-tested line2 element handling code
- Both Python 2 and Python 3 versions are updated for consistency