### PR TITLE
Fix library dependencies causing exodus_cpp build failures

### DIFF
--- a/cmake/tribits/common_tpls/FindTPLCGNS.cmake
+++ b/cmake/tribits/common_tpls/FindTPLCGNS.cmake
@@ -37,7 +37,7 @@
 # ************************************************************************
 # @HEADER
 
-set(CNGS_ALLOW_MODERN FALSE CACHE BOOL "Allow finding CGNS as a modern CMake config file with exported targets (and only this way)")
+set(CGNS_ALLOW_MODERN FALSE CACHE BOOL "Allow finding CGNS as a modern CMake config file with exported targets (and only this way)")
 
 if ((CGNS_ALLOW_MODERN AND HDF5_FOUND_MODERN_CONFIG_FILE) OR CGNS_FORCE_MODERN)
 

--- a/packages/seacas/libraries/exodus_cpp/CMakeLists.txt
+++ b/packages/seacas/libraries/exodus_cpp/CMakeLists.txt
@@ -33,7 +33,7 @@ if (SEACASExodus_ENABLE_SHARED)
               ${SOURCES} ${DEP_SOURCES}
       )
       target_include_directories(exodus_cpp_shared PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
-      target_link_libraries(exodus_cpp_shared PUBLIC exodus_shared suplib_cpp)
+      target_link_libraries(exodus_cpp_shared PUBLIC SEACASExodus::all_libs suplib_cpp)
       target_link_libraries(exodus_cpp_shared PUBLIC Netcdf::all_libs)
       set_property(TARGET exodus_cpp_shared PROPERTY C_STANDARD 99)
       # This keeps the library out of the `all_libs` targets...
@@ -53,7 +53,7 @@ if (SEACASExodus_ENABLE_STATIC AND SEACASExodus_ENABLE_SHARED)
            ${SOURCES} ${DEP_SOURCES}
    )
    target_include_directories(exodus_cpp_static PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
-   target_link_libraries(exodus_cpp_static PUBLIC exodus_static suplib_cpp)
+   target_link_libraries(exodus_cpp_static PUBLIC SEACASExodus::all_libs suplib_cpp)
    target_link_libraries(exodus_cpp_static PUBLIC Netcdf::all_libs)
    set_property(TARGET exodus_cpp_static PROPERTY C_STANDARD 99)
    # This keeps the library out of the `all_libs` targets...

--- a/packages/seacas/libraries/exodus_cpp/CMakeLists.txt
+++ b/packages/seacas/libraries/exodus_cpp/CMakeLists.txt
@@ -33,6 +33,7 @@ if (SEACASExodus_ENABLE_SHARED)
               ${SOURCES} ${DEP_SOURCES}
       )
       target_include_directories(exodus_cpp_shared PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+      target_link_libraries(exodus_cpp_shared PUBLIC exodus_shared suplib_cpp)
       target_link_libraries(exodus_cpp_shared PUBLIC Netcdf::all_libs)
       set_property(TARGET exodus_cpp_shared PROPERTY C_STANDARD 99)
       # This keeps the library out of the `all_libs` targets...
@@ -52,6 +53,7 @@ if (SEACASExodus_ENABLE_STATIC AND SEACASExodus_ENABLE_SHARED)
            ${SOURCES} ${DEP_SOURCES}
    )
    target_include_directories(exodus_cpp_static PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+   target_link_libraries(exodus_cpp_static PUBLIC exodus_static suplib_cpp)
    target_link_libraries(exodus_cpp_static PUBLIC Netcdf::all_libs)
    set_property(TARGET exodus_cpp_static PROPERTY C_STANDARD 99)
    # This keeps the library out of the `all_libs` targets...


### PR DESCRIPTION
Also fix a small CNGS --> CGNS typo.

@tokusanya 