### PR TITLE
Extend TextMesh to enable usage of NODE topology

### DIFF
--- a/packages/seacas/libraries/ioss/src/text_mesh/Iotm_TextMesh.C
+++ b/packages/seacas/libraries/ioss/src/text_mesh/Iotm_TextMesh.C
@@ -785,7 +785,7 @@ namespace Iotm {
     }
 
     Topology nodeTopology = m_topologyMapping.topology("NODE");
-    for (const auto &nodeData : m_data.disconnectedNodeDataVec) {
+    for (const auto &nodeData : m_data.nodeDataVec) {
       auto iter = m_partToTopology.find(nodeData.partName);
       if (iter == m_partToTopology.end()) {
         m_partToTopology[nodeData.partName] = nodeTopology;

--- a/packages/seacas/libraries/ioss/src/text_mesh/Iotm_TextMesh.C
+++ b/packages/seacas/libraries/ioss/src/text_mesh/Iotm_TextMesh.C
@@ -134,6 +134,8 @@ namespace Iotm {
 
   void TextMesh::initialize()
   {
+    m_topologyMapping.initialize_topology_map();
+
     build_part_to_topology_map();
     build_block_partition_map();
     build_element_connectivity_map();
@@ -779,6 +781,21 @@ namespace Iotm {
                             << elementData.identifier << " in part named: " << elementData.partName
                             << " is attempting to reset the part topology: " << iter->second
                             << " with: " << elementData.topology.name());
+      }
+    }
+
+    Topology nodeTopology = m_topologyMapping.topology("NODE");
+    for (const auto &nodeData : m_data.disconnectedNodeDataVec) {
+      auto iter = m_partToTopology.find(nodeData.partName);
+      if (iter == m_partToTopology.end()) {
+        m_partToTopology[nodeData.partName] = nodeTopology;
+      }
+      else {
+        ThrowRequireMsg(iter->second == nodeTopology,
+                        "Node with id: "
+                            << nodeData.identifier << " in part named: " << nodeData.partName
+                            << " is attempting to reset the part topology: " << iter->second
+                            << " with: " << nodeTopology.name());
       }
     }
   }

--- a/packages/seacas/libraries/ioss/src/text_mesh/Iotm_TextMesh.h
+++ b/packages/seacas/libraries/ioss/src/text_mesh/Iotm_TextMesh.h
@@ -342,6 +342,8 @@ namespace Iotm {
 
     ErrorHandler m_errorHandler;
 
+    IossTopologyMapping m_topologyMapping;
+
     std::unordered_map<std::string, Topology> m_partToTopology;
 
     std::unordered_map<EntityId, BlockPartition> m_blockPartition;

--- a/packages/seacas/libraries/ioss/src/text_mesh/Iotm_TextMeshDataTypes.h
+++ b/packages/seacas/libraries/ioss/src/text_mesh/Iotm_TextMeshDataTypes.h
@@ -306,17 +306,16 @@ namespace Iotm {
 
     template <typename EntityId> struct NodeData
     {
-      int                   proc;
-      EntityId              identifier;
-      std::string           partName = "";
+      int         proc;
+      EntityId    identifier;
+      std::string partName = "";
 
       operator EntityId() const { return identifier; }
     };
 
     template <typename EntityId> struct NodeDataLess
     {
-      bool operator()(const NodeData<EntityId> &lhs,
-                      const NodeData<EntityId> &rhs)
+      bool operator()(const NodeData<EntityId> &lhs, const NodeData<EntityId> &rhs)
       {
         return lhs.identifier < rhs.identifier;
       };

--- a/packages/seacas/libraries/ioss/src/text_mesh/Iotm_TextMeshDataTypes.h
+++ b/packages/seacas/libraries/ioss/src/text_mesh/Iotm_TextMeshDataTypes.h
@@ -304,6 +304,36 @@ namespace Iotm {
       bool operator()(const EntityId lhs, const EntityId rhs) { return lhs < rhs; };
     };
 
+    template <typename EntityId> struct DisconnectedNodeData
+    {
+      int                   proc;
+      EntityId              identifier;
+      std::string           partName = "";
+
+      operator EntityId() const { return identifier; }
+    };
+
+    template <typename EntityId> struct DisconnectedNodeDataLess
+    {
+      bool operator()(const DisconnectedNodeData<EntityId> &lhs,
+                      const DisconnectedNodeData<EntityId> &rhs)
+      {
+        return lhs.identifier < rhs.identifier;
+      };
+
+      bool operator()(const DisconnectedNodeData<EntityId> &lhs, const EntityId rhs)
+      {
+        return lhs.identifier < rhs;
+      };
+
+      bool operator()(const EntityId lhs, const DisconnectedNodeData<EntityId> &rhs)
+      {
+        return lhs < rhs.identifier;
+      };
+
+      bool operator()(const EntityId lhs, const EntityId rhs) { return lhs < rhs; };
+    };
+
     template <typename EntityId, typename Topology> class Sidesets;
 
     template <typename EntityId> class Nodesets;
@@ -314,6 +344,7 @@ namespace Iotm {
     {
       unsigned                                     spatialDim{0};
       std::vector<ElementData<EntityId, Topology>> elementDataVec{};
+      std::vector<DisconnectedNodeData<EntityId>>  disconnectedNodeDataVec{};
       PartIdMapping                                partIds;
       std::set<EntityId>                           nodeIds{};
       Coordinates<EntityId>                        coords;
@@ -330,6 +361,14 @@ namespace Iotm {
           nodeIds.insert(nodeId);
           associate_node_with_proc(nodeId, elem.proc);
         }
+      }
+
+      void add_disconnected_node(const DisconnectedNodeData<EntityId> &node)
+      {
+        disconnectedNodeDataVec.push_back(node);
+
+        nodeIds.insert(node.identifier);
+        associate_node_with_proc(node.identifier, node.proc);
       }
 
       const std::set<EntityId> &nodes_on_proc(int proc) const

--- a/packages/seacas/libraries/ioss/src/text_mesh/Iotm_TextMeshDataTypes.h
+++ b/packages/seacas/libraries/ioss/src/text_mesh/Iotm_TextMeshDataTypes.h
@@ -304,7 +304,7 @@ namespace Iotm {
       bool operator()(const EntityId lhs, const EntityId rhs) { return lhs < rhs; };
     };
 
-    template <typename EntityId> struct DisconnectedNodeData
+    template <typename EntityId> struct NodeData
     {
       int                   proc;
       EntityId              identifier;
@@ -313,20 +313,20 @@ namespace Iotm {
       operator EntityId() const { return identifier; }
     };
 
-    template <typename EntityId> struct DisconnectedNodeDataLess
+    template <typename EntityId> struct NodeDataLess
     {
-      bool operator()(const DisconnectedNodeData<EntityId> &lhs,
-                      const DisconnectedNodeData<EntityId> &rhs)
+      bool operator()(const NodeData<EntityId> &lhs,
+                      const NodeData<EntityId> &rhs)
       {
         return lhs.identifier < rhs.identifier;
       };
 
-      bool operator()(const DisconnectedNodeData<EntityId> &lhs, const EntityId rhs)
+      bool operator()(const NodeData<EntityId> &lhs, const EntityId rhs)
       {
         return lhs.identifier < rhs;
       };
 
-      bool operator()(const EntityId lhs, const DisconnectedNodeData<EntityId> &rhs)
+      bool operator()(const EntityId lhs, const NodeData<EntityId> &rhs)
       {
         return lhs < rhs.identifier;
       };
@@ -344,7 +344,7 @@ namespace Iotm {
     {
       unsigned                                     spatialDim{0};
       std::vector<ElementData<EntityId, Topology>> elementDataVec{};
-      std::vector<DisconnectedNodeData<EntityId>>  disconnectedNodeDataVec{};
+      std::vector<NodeData<EntityId>>              nodeDataVec{};
       PartIdMapping                                partIds;
       std::set<EntityId>                           nodeIds{};
       Coordinates<EntityId>                        coords;
@@ -363,9 +363,9 @@ namespace Iotm {
         }
       }
 
-      void add_disconnected_node(const DisconnectedNodeData<EntityId> &node)
+      void add_node(const NodeData<EntityId> &node)
       {
-        disconnectedNodeDataVec.push_back(node);
+        nodeDataVec.push_back(node);
 
         nodeIds.insert(node.identifier);
         associate_node_with_proc(node.identifier, node.proc);

--- a/packages/seacas/libraries/ioss/src/text_mesh/Iotm_TextMeshUtils.h
+++ b/packages/seacas/libraries/ioss/src/text_mesh/Iotm_TextMeshUtils.h
@@ -602,6 +602,7 @@ namespace Iotm {
         };
         set_error_handler(errorHandler);
         m_topologyMapping.initialize_topology_map();
+        m_nodeTopology = m_topologyMapping.topology("NODE");
       }
 
       void initialize_connectivity_parse(const std::string &meshDescription)
@@ -621,12 +622,10 @@ namespace Iotm {
 
       void parse_description()
       {
-        Topology nodeTopology = m_topologyMapping.topology("NODE");
-
         while (m_lexer.has_token()) {
           ElementData<EntityId, Topology> elemData = parse_element();
 
-          if(nodeTopology == elemData.topology) {
+          if(m_nodeTopology == elemData.topology) {
             for(EntityId node : elemData.nodeIds) {
               if(node != elemData.identifier) {
                 std::ostringstream errmsg;
@@ -637,8 +636,8 @@ namespace Iotm {
               }
             }
 
-            DisconnectedNodeData<EntityId> nodeData{elemData.proc, elemData.identifier, elemData.partName};
-            m_data.add_disconnected_node(nodeData);
+            NodeData<EntityId> nodeData{elemData.proc, elemData.identifier, elemData.partName};
+            m_data.add_node(nodeData);
           } else {
             m_data.add_element(elemData);
           }
@@ -649,8 +648,8 @@ namespace Iotm {
 
         std::sort(m_data.elementDataVec.begin(), m_data.elementDataVec.end(),
                   ElementDataLess<EntityId, Topology>());
-        std::sort(m_data.disconnectedNodeDataVec.begin(), m_data.disconnectedNodeDataVec.end(),
-                  DisconnectedNodeDataLess<EntityId>());
+        std::sort(m_data.nodeDataVec.begin(), m_data.nodeDataVec.end(),
+                  NodeDataLess<EntityId>());
       }
 
       ElementData<EntityId, Topology> parse_element()
@@ -775,6 +774,17 @@ namespace Iotm {
 
       void validate_node_count(const Topology &topology, size_t numNodes)
       {
+        if(topology == m_nodeTopology) {
+          if ((numNodes != 0) && (numNodes != 1)) {
+            std::ostringstream errmsg;
+            errmsg << "Error!  The input line appears to contain " << numNodes
+                   << " nodes, but the topology " << topology << " needs 0 or 1 listed"
+                   << " nodes on line " << m_lineNumber << ".";
+            m_errorHandler(errmsg);
+          }
+          return;
+        }
+
         size_t numTopologyNodes = topology.num_nodes();
         if (numNodes != numTopologyNodes) {
           std::ostringstream errmsg;
@@ -789,6 +799,7 @@ namespace Iotm {
       TextMeshData<EntityId, Topology> m_data;
       TextMeshLexer                    m_lexer;
       TopologyMapping                  m_topologyMapping;
+      Topology                         m_nodeTopology;
 
       ErrorHandler m_errorHandler;
 

--- a/packages/seacas/libraries/ioss/src/text_mesh/Iotm_TextMeshUtils.h
+++ b/packages/seacas/libraries/ioss/src/text_mesh/Iotm_TextMeshUtils.h
@@ -621,9 +621,27 @@ namespace Iotm {
 
       void parse_description()
       {
+        Topology nodeTopology = m_topologyMapping.topology("NODE");
+
         while (m_lexer.has_token()) {
           ElementData<EntityId, Topology> elemData = parse_element();
-          m_data.add_element(elemData);
+
+          if(nodeTopology == elemData.topology) {
+            for(EntityId node : elemData.nodeIds) {
+              if(node != elemData.identifier) {
+                std::ostringstream errmsg;
+                errmsg
+                    << "Reference node id:  " << node << " does not match NODE entity id: "
+                    << elemData.identifier << ".  Error on line " << m_lineNumber << ".";
+                m_errorHandler(errmsg);
+              }
+            }
+
+            DisconnectedNodeData<EntityId> nodeData{elemData.proc, elemData.identifier, elemData.partName};
+            m_data.add_disconnected_node(nodeData);
+          } else {
+            m_data.add_element(elemData);
+          }
 
           validate_no_extra_fields();
           parse_newline();
@@ -631,6 +649,8 @@ namespace Iotm {
 
         std::sort(m_data.elementDataVec.begin(), m_data.elementDataVec.end(),
                   ElementDataLess<EntityId, Topology>());
+        std::sort(m_data.disconnectedNodeDataVec.begin(), m_data.disconnectedNodeDataVec.end(),
+                  DisconnectedNodeDataLess<EntityId>());
       }
 
       ElementData<EntityId, Topology> parse_element()

--- a/packages/seacas/libraries/ioss/src/text_mesh/Iotm_TextMeshUtils.h
+++ b/packages/seacas/libraries/ioss/src/text_mesh/Iotm_TextMeshUtils.h
@@ -625,20 +625,21 @@ namespace Iotm {
         while (m_lexer.has_token()) {
           ElementData<EntityId, Topology> elemData = parse_element();
 
-          if(m_nodeTopology == elemData.topology) {
-            for(EntityId node : elemData.nodeIds) {
-              if(node != elemData.identifier) {
+          if (m_nodeTopology == elemData.topology) {
+            for (EntityId node : elemData.nodeIds) {
+              if (node != elemData.identifier) {
                 std::ostringstream errmsg;
-                errmsg
-                    << "Reference node id:  " << node << " does not match NODE entity id: "
-                    << elemData.identifier << ".  Error on line " << m_lineNumber << ".";
+                errmsg << "Reference node id:  " << node
+                       << " does not match NODE entity id: " << elemData.identifier
+                       << ".  Error on line " << m_lineNumber << ".";
                 m_errorHandler(errmsg);
               }
             }
 
             NodeData<EntityId> nodeData{elemData.proc, elemData.identifier, elemData.partName};
             m_data.add_node(nodeData);
-          } else {
+          }
+          else {
             m_data.add_element(elemData);
           }
 
@@ -648,8 +649,7 @@ namespace Iotm {
 
         std::sort(m_data.elementDataVec.begin(), m_data.elementDataVec.end(),
                   ElementDataLess<EntityId, Topology>());
-        std::sort(m_data.nodeDataVec.begin(), m_data.nodeDataVec.end(),
-                  NodeDataLess<EntityId>());
+        std::sort(m_data.nodeDataVec.begin(), m_data.nodeDataVec.end(), NodeDataLess<EntityId>());
       }
 
       ElementData<EntityId, Topology> parse_element()
@@ -774,7 +774,7 @@ namespace Iotm {
 
       void validate_node_count(const Topology &topology, size_t numNodes)
       {
-        if(topology == m_nodeTopology) {
+        if (topology == m_nodeTopology) {
           if ((numNodes != 0) && (numNodes != 1)) {
             std::ostringstream errmsg;
             errmsg << "Error!  The input line appears to contain " << numNodes

--- a/packages/seacas/libraries/ioss/src/unit_tests/UnitTestIotmTextMeshFixture.h
+++ b/packages/seacas/libraries/ioss/src/unit_tests/UnitTestIotmTextMeshFixture.h
@@ -652,7 +652,7 @@ namespace Iotm {
         const Ioss::NodeBlockContainer &nodeBlocks = m_region->get_node_blocks();
         assert(nodeBlocks.size() == 1);
 
-        size_t                             count   = 0;
+        size_t count = 0;
 
         for (const Ioss::NodeBlock *block : nodeBlocks) {
           count += block->entity_count();

--- a/packages/seacas/libraries/ioss/src/unit_tests/UnitTestIotmTextMeshFixture.h
+++ b/packages/seacas/libraries/ioss/src/unit_tests/UnitTestIotmTextMeshFixture.h
@@ -259,6 +259,12 @@ namespace Iotm {
         }
       }
 
+      void verify_num_nodes(size_t goldCount)
+      {
+        size_t count = get_node_count();
+        EXPECT_EQ(goldCount, count);
+      }
+
       void verify_num_elements(size_t goldCount)
       {
         size_t count = get_element_count();
@@ -623,9 +629,7 @@ namespace Iotm {
         size_t                             count      = 0;
 
         for (const Ioss::ElementBlock *block : elemBlocks) {
-          std::vector<INT> elemIds;
-          block->get_field_data("ids", elemIds);
-          count += elemIds.size();
+          count += block->entity_count();
         }
 
         return count;
@@ -638,6 +642,32 @@ namespace Iotm {
         }
         else {
           return get_element_count_impl<int64_t>();
+        }
+      }
+
+      template <typename INT> size_t get_node_count_impl() const
+      {
+        ThrowRequireWithMsg(m_region != nullptr, "Ioss region has not been created");
+
+        const Ioss::NodeBlockContainer &nodeBlocks = m_region->get_node_blocks();
+        assert(nodeBlocks.size() == 1);
+
+        size_t                             count   = 0;
+
+        for (const Ioss::NodeBlock *block : nodeBlocks) {
+          count += block->entity_count();
+        }
+
+        return count;
+      }
+
+      size_t get_node_count() const
+      {
+        if (db_api_int_size() == 4) {
+          return get_node_count_impl<int>();
+        }
+        else {
+          return get_node_count_impl<int64_t>();
         }
       }
 
@@ -980,7 +1010,7 @@ namespace Iotm {
         std::unordered_map<EntityId, std::vector<double>> m_nodalCoords;
       };
 
-      unsigned              m_spatialDimension = 3;
+      unsigned              m_spatialDimension{3};
       Ioss::PropertyManager m_propertyManager;
       Ioss::DatabaseIO     *m_database = nullptr;
       Ioss::Region         *m_region   = nullptr;

--- a/packages/seacas/libraries/ioss/src/unit_tests/UnitTestTextMesh.C
+++ b/packages/seacas/libraries/ioss/src/unit_tests/UnitTestTextMesh.C
@@ -777,17 +777,16 @@ namespace {
     if (get_parallel_size() != 1)
       return;
 
-    std::string         meshDesc        = "0,1,NODE,";
+    std::string meshDesc = "0,1,NODE,";
     EXPECT_NO_THROW(setup_text_mesh(meshDesc));
   }
-
 
   TEST_F(TestTextMesh, nodeWithNoReferenceVersion2)
   {
     if (get_parallel_size() != 1)
       return;
 
-    std::string         meshDesc        = "0,1,NODE";
+    std::string meshDesc = "0,1,NODE";
     EXPECT_NO_THROW(setup_text_mesh(meshDesc));
   }
 
@@ -796,7 +795,7 @@ namespace {
     if (get_parallel_size() != 1)
       return;
 
-    std::string         meshDesc        = "0,1,NODE,2";
+    std::string meshDesc = "0,1,NODE,2";
     EXPECT_THROW(setup_text_mesh(meshDesc), std::logic_error);
   }
 
@@ -805,8 +804,8 @@ namespace {
     if (get_parallel_size() != 1)
       return;
 
-    std::string         meshDesc        = "0,1,NODE,\n"
-                                          "0,5,NODE,";
+    std::string meshDesc = "0,1,NODE,\n"
+                           "0,5,NODE,";
     EXPECT_NO_THROW(setup_text_mesh(meshDesc));
   }
 
@@ -815,8 +814,8 @@ namespace {
     if (get_parallel_size() != 1)
       return;
 
-    std::string         meshDesc        = "0,1,NODE\n"
-                                          "0,5,NODE,";
+    std::string meshDesc = "0,1,NODE\n"
+                           "0,5,NODE,";
     EXPECT_NO_THROW(setup_text_mesh(meshDesc));
   }
 
@@ -825,8 +824,8 @@ namespace {
     if (get_parallel_size() != 1)
       return;
 
-    std::string         meshDesc        = "0,1,NODE,\n"
-                                          "0,5,NODE";
+    std::string meshDesc = "0,1,NODE,\n"
+                           "0,5,NODE";
     EXPECT_NO_THROW(setup_text_mesh(meshDesc));
   }
 
@@ -835,8 +834,8 @@ namespace {
     if (get_parallel_size() != 1)
       return;
 
-    std::string         meshDesc        = "0,1,NODE\n"
-                                          "0,5,NODE";
+    std::string meshDesc = "0,1,NODE\n"
+                           "0,5,NODE";
     EXPECT_NO_THROW(setup_text_mesh(meshDesc));
   }
 
@@ -845,8 +844,8 @@ namespace {
     if (get_parallel_size() != 1)
       return;
 
-    std::string         meshDesc        = "0,1,NODE,1\n"
-                                          "0,5,NODE";
+    std::string meshDesc = "0,1,NODE,1\n"
+                           "0,5,NODE";
     EXPECT_NO_THROW(setup_text_mesh(meshDesc));
   }
 
@@ -855,8 +854,8 @@ namespace {
     if (get_parallel_size() != 1)
       return;
 
-    std::string         meshDesc        = "0,1,NODE\n"
-                                          "0,5,NODE,5";
+    std::string meshDesc = "0,1,NODE\n"
+                           "0,5,NODE,5";
     EXPECT_NO_THROW(setup_text_mesh(meshDesc));
   }
 
@@ -865,9 +864,9 @@ namespace {
     if (get_parallel_size() != 1)
       return;
 
-    std::string         meshDesc        = "0,1,NODE,1\n"
-                                          "0,2,NODE,2\n"
-                                          "0,3,NODE,3";
+    std::string meshDesc = "0,1,NODE,1\n"
+                           "0,2,NODE,2\n"
+                           "0,3,NODE,3";
     EXPECT_NO_THROW(setup_text_mesh(meshDesc));
 
     verify_num_elements(0);

--- a/packages/seacas/libraries/ioss/src/unit_tests/UnitTestTextMesh.C
+++ b/packages/seacas/libraries/ioss/src/unit_tests/UnitTestTextMesh.C
@@ -772,6 +772,72 @@ namespace {
     EXPECT_THROW(setup_text_mesh(meshDesc), std::logic_error);
   }
 
+  TEST_F(TestTextMesh, nodeWithInvalidReference)
+  {
+    if (get_parallel_size() != 1)
+      return;
+
+    std::string         meshDesc        = "0,1,NODE,2";
+    EXPECT_THROW(setup_text_mesh(meshDesc), std::logic_error);
+  }
+
+  TEST_F(TestTextMesh, threeNodes)
+  {
+    if (get_parallel_size() != 1)
+      return;
+
+    std::string         meshDesc        = "0,1,NODE,1\n"
+                                          "0,2,NODE,2\n"
+                                          "0,3,NODE,3";
+    EXPECT_NO_THROW(setup_text_mesh(meshDesc));
+
+    verify_num_elements(0);
+    verify_num_nodes(3);
+  }
+
+  TEST_F(TestTextMesh, nodeWithCoordinates)
+  {
+    if (get_parallel_size() != 1)
+      return;
+
+    std::string         meshDesc        = "0,1,NODE,1|coordinates:2,0,0";
+    std::vector<double> goldCoordinates = {2, 0, 0};
+    EntityIdVector      nodeIds         = EntityIdVector{1};
+    EXPECT_NO_THROW(setup_text_mesh(meshDesc));
+
+    verify_num_elements(0);
+    verify_num_nodes(1);
+    verify_coordinates(nodeIds, goldCoordinates);
+  }
+
+  TEST_F(TestTextMesh, nodeDisconnectedFromHex)
+  {
+    if (get_parallel_size() != 1)
+      return;
+
+    std::string meshDesc = "0,1,NODE,1\n"
+                           "0,2,HEX_8,2,3,4,5,6,7,8,9";
+    EXPECT_NO_THROW(setup_text_mesh(meshDesc));
+
+    verify_num_elements(1);
+    verify_num_nodes(9);
+    verify_single_element(2u, "HEX_8", EntityIdVector{2, 3, 4, 5, 6, 7, 8, 9});
+  }
+
+  TEST_F(TestTextMesh, nodeOnHex)
+  {
+    if (get_parallel_size() != 1)
+      return;
+
+    std::string meshDesc = "0,1,NODE,1\n"
+                           "0,2,HEX_8,1,2,3,4,5,6,7,8";
+    EXPECT_NO_THROW(setup_text_mesh(meshDesc));
+
+    verify_num_elements(1);
+    verify_num_nodes(8);
+    verify_single_element(2u, "HEX_8", EntityIdVector{1, 2, 3, 4, 5, 6, 7, 8});
+  }
+
   TEST_F(TestTextMesh, particleWithCoordinates)
   {
     if (get_parallel_size() != 1)
@@ -1938,6 +2004,7 @@ namespace {
     setup_text_mesh(meshDesc);
 
     verify_num_elements(1);
+    verify_num_nodes(2);
     verify_single_element(1u, "LINE_2_1D", EntityIdVector{1, 2});
   }
 

--- a/packages/seacas/libraries/ioss/src/unit_tests/UnitTestTextMesh.C
+++ b/packages/seacas/libraries/ioss/src/unit_tests/UnitTestTextMesh.C
@@ -772,6 +772,25 @@ namespace {
     EXPECT_THROW(setup_text_mesh(meshDesc), std::logic_error);
   }
 
+  TEST_F(TestTextMesh, nodeWithNoReference)
+  {
+    if (get_parallel_size() != 1)
+      return;
+
+    std::string         meshDesc        = "0,1,NODE,";
+    EXPECT_NO_THROW(setup_text_mesh(meshDesc));
+  }
+
+
+  TEST_F(TestTextMesh, nodeWithNoReferenceVersion2)
+  {
+    if (get_parallel_size() != 1)
+      return;
+
+    std::string         meshDesc        = "0,1,NODE";
+    EXPECT_NO_THROW(setup_text_mesh(meshDesc));
+  }
+
   TEST_F(TestTextMesh, nodeWithInvalidReference)
   {
     if (get_parallel_size() != 1)
@@ -779,6 +798,66 @@ namespace {
 
     std::string         meshDesc        = "0,1,NODE,2";
     EXPECT_THROW(setup_text_mesh(meshDesc), std::logic_error);
+  }
+
+  TEST_F(TestTextMesh, twoNodesWithNoReference)
+  {
+    if (get_parallel_size() != 1)
+      return;
+
+    std::string         meshDesc        = "0,1,NODE,\n"
+                                          "0,5,NODE,";
+    EXPECT_NO_THROW(setup_text_mesh(meshDesc));
+  }
+
+  TEST_F(TestTextMesh, twoNodesWithNoReferenceVersion2)
+  {
+    if (get_parallel_size() != 1)
+      return;
+
+    std::string         meshDesc        = "0,1,NODE\n"
+                                          "0,5,NODE,";
+    EXPECT_NO_THROW(setup_text_mesh(meshDesc));
+  }
+
+  TEST_F(TestTextMesh, twoNodesWithNoReferenceVersion3)
+  {
+    if (get_parallel_size() != 1)
+      return;
+
+    std::string         meshDesc        = "0,1,NODE,\n"
+                                          "0,5,NODE";
+    EXPECT_NO_THROW(setup_text_mesh(meshDesc));
+  }
+
+  TEST_F(TestTextMesh, twoNodesWithNoReferenceVersion4)
+  {
+    if (get_parallel_size() != 1)
+      return;
+
+    std::string         meshDesc        = "0,1,NODE\n"
+                                          "0,5,NODE";
+    EXPECT_NO_THROW(setup_text_mesh(meshDesc));
+  }
+
+  TEST_F(TestTextMesh, twoNodesWithOneReference)
+  {
+    if (get_parallel_size() != 1)
+      return;
+
+    std::string         meshDesc        = "0,1,NODE,1\n"
+                                          "0,5,NODE";
+    EXPECT_NO_THROW(setup_text_mesh(meshDesc));
+  }
+
+  TEST_F(TestTextMesh, twoNodesWithOneReferenceVersion2)
+  {
+    if (get_parallel_size() != 1)
+      return;
+
+    std::string         meshDesc        = "0,1,NODE\n"
+                                          "0,5,NODE,5";
+    EXPECT_NO_THROW(setup_text_mesh(meshDesc));
   }
 
   TEST_F(TestTextMesh, threeNodes)


### PR DESCRIPTION
This allows the creation of node only meshes

Added unit tests

Caveats include:
	Reference node can now be optional (see unit tests)
        Reference node must match the node entity identifier if provided
	Node entity can reference node connectivity from an element
	Reference block part is ignored for now ... may be used later