### PR TITLE
Remove "o" typo from #!/bin/bash string

### DIFF
--- a/packages/seacas/scripts/pconjoin.in
+++ b/packages/seacas/scripts/pconjoin.in
@@ -1,4 +1,4 @@
-o#!/bin/bash
+#!/bin/bash
 # Copyright(C) 1999-2025 National Technology & Engineering Solutions
 # of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
 # NTESS, the U.S. Government retains certain rights in this software.


### PR DESCRIPTION
This was added as a typo when the Copyright numbers were bumped and provides warnings for users.