### PR TITLE
Compsimhd 18606 ioss flush

### DIFF
--- a/packages/seacas/libraries/ioss/src/Ioss_FlushHandler.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_FlushHandler.C
@@ -1,0 +1,70 @@
+// Copyright(C) 1999-2025 National Technology & Engineering Solutions
+// of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
+// NTESS, the U.S. Government retains certain rights in this software.
+//
+// See packages/seacas/LICENSE for details
+
+#include "Ioss_FlushHandler.h"
+#include "Ioss_SerializeIO.h"
+
+namespace Ioss {
+  bool FlushHandler::doFlush(int state)
+  {
+    bool do_flush = false;
+    if (flushOnFirstOutput && isFirstOutput) {
+      do_flush = true;
+    }
+    else if (flushInterval == 1) {
+      do_flush = true;
+    }
+    else if (flushInterval < 0) {
+      do_flush = isGreaterThanFlushInterval(timeLastFlush, timeLastFlushInterval);
+    }
+    else if (flushInterval > 1) {
+      if (state % flushInterval == 0) {
+        do_flush = true;
+      }
+    }
+
+    if (flushInterval != 0 && !do_flush) {
+      // One last check -- if output took more than timeStepBeginFlushInterval (seconds)
+      // then flush since the relative flush cost is outweighted by the time
+      // it took to do the output (Basically, we have a lot of data being output...)
+      do_flush = isGreaterThanFlushInterval(timeStepBegin, timeStepBeginFlushInterval);
+    }
+
+    if (isFirstOutput) {
+      isFirstOutput = false;
+    }
+    return allReduce(do_flush);
+  }
+
+  bool FlushHandler::isGreaterThanFlushInterval(time_t lastFlushTime, unsigned int flushInterval)
+  {
+    time_t cur_time = time(nullptr);
+    bool   do_flush = false;
+
+    if (std::difftime(cur_time, lastFlushTime) >= flushInterval) {
+      timeLastFlush = cur_time;
+      do_flush      = true;
+    }
+    return do_flush;
+  }
+
+  bool FlushHandler::allReduce(bool do_flush)
+  {
+    int iflush = do_flush ? 1 : 0;
+#ifdef SEACAS_HAVE_MPI
+    if (isParallel) {
+      if (Ioss::SerializeIO::isEnabled()) {
+        util.broadcast(iflush);
+      }
+      else {
+        iflush = util.global_minmax(iflush, Ioss::ParallelUtils::DO_MAX);
+      }
+    }
+#endif
+    return iflush == 1;
+  }
+
+} // namespace Ioss

--- a/packages/seacas/libraries/ioss/src/Ioss_FlushHandler.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_FlushHandler.h
@@ -1,0 +1,91 @@
+// Copyright(C) 1999-2020, 2022, 2024, 2025 National Technology & Engineering Solutions
+// of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
+// NTESS, the U.S. Government retains certain rights in this software.
+//
+// See packages/seacas/LICENSE for details
+
+#pragma once
+
+#include "Ioss_CodeTypes.h"
+#include "Ioss_ParallelUtils.h"
+#include "ioss_export.h"
+#include <ctime>
+
+namespace Ioss {
+
+  // Flush the files buffer to disk...
+  // If:
+  //  flushInterval == -1 (default) -- flush if there is more
+  // than 10 seconds since the last flush to avoid
+  // the flush eating up cpu time for small fast jobs...
+  //
+  //  flushInterval == 0 -- do not flush until file is closed.
+  //
+  //  flushInterval == 1 -- flush every step
+  //
+  //  flushInterval > 1 -- flush if step % flushInterval == 0
+  //
+  //  if time between begin_state and end_state is > 10 seconds,
+
+  class IOSS_EXPORT FlushHandler
+  {
+  private:
+    int                 flushInterval;
+    bool                isParallel;
+    bool                isFirstOutput;
+    bool                flushOnFirstOutput;
+    unsigned int        timeLastFlushInterval;
+    unsigned int        timeStepBeginFlushInterval;
+    time_t              timeLastFlush;
+    time_t              timeStepBegin;
+    Ioss::ParallelUtils util;
+
+  public:
+    FlushHandler()
+    {
+      flushInterval              = -1;
+      timeLastFlush              = time(nullptr);
+      timeStepBegin              = time(nullptr);
+      isParallel                 = true;
+      isFirstOutput              = true;
+      flushOnFirstOutput         = false;
+      timeLastFlushInterval      = 10;
+      timeStepBeginFlushInterval = 10;
+    }
+
+    int getFlushInterval() { return flushInterval; }
+
+    void setFlushInterval(int interval) { flushInterval = interval; }
+
+    bool getIsParallel() const { return isParallel; }
+
+    void setIsParallel(bool parallel) { isParallel = parallel; }
+
+    bool getFlushOnFirstOutput() const { return flushOnFirstOutput; }
+
+    void setFlushOnFirstOutput(bool flush) { flushOnFirstOutput = flush; }
+
+    unsigned int getTimeLastFlushInterval() { return timeLastFlushInterval; }
+
+    void setTimeLastFlushInterval(unsigned int timeInterval)
+    {
+      timeLastFlushInterval = timeInterval;
+    }
+
+    unsigned int getTimeStepBeginFlushInterval() { return timeStepBeginFlushInterval; }
+
+    void setTimeStepBeginFlushInterval(unsigned int timeInterval)
+    {
+      timeStepBeginFlushInterval = timeInterval;
+    }
+
+    void resetTimeStepBegin() { timeStepBegin = time(nullptr); }
+
+    bool doFlush(int state);
+
+    bool allReduce(bool do_flush);
+
+    bool isGreaterThanFlushInterval(time_t lastFlushTime, unsigned int flushInterval);
+  };
+
+} // namespace Ioss

--- a/packages/seacas/libraries/ioss/src/exodus/Ioex_BaseDatabaseIO.C
+++ b/packages/seacas/libraries/ioss/src/exodus/Ioex_BaseDatabaseIO.C
@@ -180,8 +180,6 @@ namespace Ioex {
       isParallel = false;
     }
 
-    timeLastFlush = time(nullptr);
-
     dbState = Ioss::STATE_UNKNOWN;
 
     // Set exodusII warning level.
@@ -307,10 +305,14 @@ namespace Ioex {
       }
     }
 
+    flushHandler.setIsParallel(isParallel);
     if (!is_input()) {
       if (properties.exists("FLUSH_INTERVAL")) {
-        int interval  = properties.get("FLUSH_INTERVAL").get_int();
-        flushInterval = interval;
+        int interval = properties.get("FLUSH_INTERVAL").get_int();
+        flushHandler.setFlushInterval(interval);
+      }
+      if (properties.exists("FLUSH_ON_FIRST_OUTPUT")) {
+        flushHandler.setFlushOnFirstOutput(true);
       }
     }
 
@@ -1493,7 +1495,7 @@ namespace Ioex {
     a_time /= timeScaleFactor;
 
     if (!is_input()) {
-      timeBeginStep = time(nullptr);
+      flushHandler.resetTimeStepBegin();
       if (get_file_per_state()) {
         // Close current file; create new file and output transient metadata...
         open_state_file(state);
@@ -2532,69 +2534,7 @@ namespace Ioex {
     // Update the attribute.
     Ioex::update_last_time_attribute(get_file_pointer(), sim_time);
 
-    // Flush the files buffer to disk...
-    // If:
-    //  flushInterval == -1 (default) -- flush if there is more
-    // than 10 seconds since the last flush to avoid
-    // the flush eating up cpu time for small fast jobs...
-    //
-    //  flushInterval == 0 -- do not flush until file is closed.
-    //
-    //  flushInterval == 1 -- flush every step
-    //
-    //  flushInterval > 1 -- flush if step % flushInterval == 0
-    //
-    //  if time between begin_state and end_state is > 10 seconds,
-
-    bool do_flush = true;
-    if (flushInterval == 1) {
-      do_flush = true;
-    }
-    else if (flushInterval == 0) {
-      do_flush = false;
-    }
-    else if (flushInterval < 0) {
-      time_t cur_time = time(nullptr);
-      if (cur_time - timeLastFlush >= 10) {
-        timeLastFlush = cur_time;
-        do_flush      = true;
-      }
-      else {
-        do_flush = false;
-      }
-#ifdef SEACAS_HAVE_MPI
-      if (isParallel) {
-        int iflush = do_flush ? 1 : 0;
-        util().broadcast(iflush);
-        do_flush = iflush == 1;
-      }
-#endif
-    }
-    else if (flushInterval > 1) {
-      if (state % flushInterval == 0) {
-        do_flush = true;
-      }
-    }
-
-    if (flushInterval != 0 && !do_flush) {
-      // One last check -- if output took more than 10 seconds (arbitrary)
-      // then flush since the relative flush cost is outweighted by the time
-      // it took to do the output (Basically, we have a lot of data being output...)
-      time_t cur_time = time(nullptr);
-      if (cur_time - timeBeginStep >= 10) {
-        timeLastFlush = cur_time;
-        do_flush      = true;
-      }
-#ifdef SEACAS_HAVE_MPI
-      if (isParallel) {
-        int iflush = do_flush ? 1 : 0;
-        util().broadcast(iflush);
-        do_flush = iflush == 1;
-      }
-#endif
-    }
-
-    if (do_flush) {
+    if (flushHandler.doFlush(state)) {
       flush_database_nl();
     }
   }

--- a/packages/seacas/libraries/ioss/src/exodus/Ioex_BaseDatabaseIO.h
+++ b/packages/seacas/libraries/ioss/src/exodus/Ioex_BaseDatabaseIO.h
@@ -10,6 +10,7 @@
 #include "Ioss_DBUsage.h"
 #include "Ioss_DatabaseIO.h"
 #include "Ioss_Field.h"
+#include "Ioss_FlushHandler.h"
 #include "Ioss_Map.h"
 #include "Ioss_Utils.h"
 #include <algorithm>
@@ -405,10 +406,9 @@ namespace Ioex {
     // empty, then some nodes on that nodeset are only connected to omitted elements.
     mutable std::map<std::string, Ioss::Int64Vector> activeNodeSetNodesIndex;
 
-    time_t timeLastFlush{0};
-    time_t timeBeginStep{0};
-    int    flushInterval{-1};
-    int    m_timestepCount{0};
+    int m_timestepCount{0};
+
+    Ioss::FlushHandler flushHandler;
 
     bool         timeFileOpenCloseFlush{false};
     mutable bool fileExists{false}; // False if file has never been opened/created

--- a/packages/seacas/libraries/ioss/src/unit_tests/CMakeLists.txt
+++ b/packages/seacas/libraries/ioss/src/unit_tests/CMakeLists.txt
@@ -24,6 +24,11 @@ TRIBITS_ADD_EXECUTABLE(
  SOURCES unitMain.C UnitTestGeneratedMesh.C
 )
 
+TRIBITS_ADD_EXECUTABLE(
+ Utst_flushhandler
+ SOURCES unitMain.C UnitTestFlushHandler.C
+)
+
 TRIBITS_ADD_TEST(
         Utst_generatedmesh
         NAME Utst_generatedmesh
@@ -88,6 +93,18 @@ TRIBITS_ADD_TEST(
         Utst_iotm
         NAME Utst_iotm
         NUM_MPI_PROCS 2
+)
+
+TRIBITS_ADD_TEST(
+        Utst_flushhandler
+        NAME  Utst_flushhandler
+        NUM_MPI_PROCS 1
+)
+
+TRIBITS_ADD_TEST(
+        Utst_flushhandler
+        NAME  Utst_flushhandler
+        NUM_MPI_PROCS 4
 )
 
 TRIBITS_INCLUDE_DIRECTORIES(

--- a/packages/seacas/libraries/ioss/src/unit_tests/UnitTestFlushHandler.C
+++ b/packages/seacas/libraries/ioss/src/unit_tests/UnitTestFlushHandler.C
@@ -1,0 +1,135 @@
+// Copyright(C) 2024, 2025 National Technology & Engineering Solutions
+// of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
+// NTESS, the U.S. Government retains certain rights in this software.
+//
+// See packages/seacas/LICENSE for details
+
+#include "Ioss_CodeTypes.h"
+#include <memory>
+#include <string>
+#include <vector>
+
+#ifdef SEACAS_HAVE_MPI
+#include "mpi.h"
+#endif
+
+#include "Ioss_FlushHandler.h"
+#include <chrono>
+#include <gtest/gtest.h>
+#include <thread>
+
+class FlushTest : public ::testing::Test
+{
+protected:
+  Ioss::FlushHandler fh;
+  int                                 rank;
+  int                                 size;
+
+  void verifyFlush(int state)
+  {
+    fh.resetTimeStepBegin();
+    ASSERT_TRUE(fh.doFlush(state));
+  }
+
+  void verifyNoFlush(int state)
+  {
+    fh.resetTimeStepBegin();
+    ASSERT_FALSE(fh.doFlush(state));
+  }
+
+  void SetUp() override
+  {
+    rank = 0;
+    size = 1;
+#ifdef SEACAS_HAVE_MPI
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+#endif
+  }
+
+  void TearDown() override {}
+};
+
+TEST_F(FlushTest, EmptyTest) {}
+
+TEST_F(FlushTest, DefaultFlushHandler)
+{
+  ASSERT_EQ(-1, fh.getFlushInterval());
+  ASSERT_TRUE(fh.getIsParallel());
+  ASSERT_FALSE(fh.getFlushOnFirstOutput());
+  ASSERT_EQ(10, fh.getTimeLastFlushInterval());
+  ASSERT_EQ(10, fh.getTimeStepBeginFlushInterval());
+}
+
+TEST_F(FlushTest, DefaultFlushHandlerDoFlush)
+{
+  fh.setTimeLastFlushInterval(1);
+  std::this_thread::sleep_for(std::chrono::seconds(2));
+  verifyFlush(0);
+  verifyNoFlush(20);
+}
+
+TEST_F(FlushTest, FlushIntervalOneDoFlush)
+{
+  fh.setFlushInterval(1);
+  verifyFlush(0);
+  verifyFlush(10);
+}
+
+TEST_F(FlushTest, FlushIntervalZeroDoFlush)
+{
+  fh.setFlushInterval(0);
+  verifyNoFlush(0);
+  verifyNoFlush(10);
+}
+
+TEST_F(FlushTest, FlushIntervalStepDoFlush)
+{
+  fh.setFlushInterval(20);
+  verifyFlush(0);
+  verifyNoFlush(10);
+  verifyFlush(20);
+  verifyNoFlush(35);
+  verifyFlush(100);
+}
+
+TEST_F(FlushTest, FlushIntervalStepTimeBeginStepDoFlush)
+{
+  fh.setFlushInterval(10);
+  fh.setTimeStepBeginFlushInterval(1);
+  fh.resetTimeStepBegin();
+  std::this_thread::sleep_for(std::chrono::seconds(2));
+  ASSERT_TRUE(fh.doFlush(15));
+}
+
+TEST_F(FlushTest, DefaultFlushHandlerTimeBeginStepDoFlush)
+{
+  fh.setTimeStepBeginFlushInterval(1);
+  fh.resetTimeStepBegin();
+  std::this_thread::sleep_for(std::chrono::seconds(2));
+  ASSERT_TRUE(fh.doFlush(0));
+}
+
+TEST_F(FlushTest, DefaultFlushHandlerFlushOnFirstOutput)
+{
+  fh.setTimeStepBeginFlushInterval(1);
+  fh.setFlushOnFirstOutput(true);
+  fh.resetTimeStepBegin();
+  ASSERT_TRUE(fh.doFlush(0));
+  ASSERT_FALSE(fh.doFlush(10));
+  std::this_thread::sleep_for(std::chrono::seconds(2));
+  ASSERT_TRUE(fh.doFlush(20));
+}
+
+TEST_F(FlushTest, DefaultFlushHandlerMultipleRanks)
+{
+  if (size < 2) {
+    GTEST_SKIP() << "Skipping parallel test\n";
+  }
+
+  fh.setTimeLastFlushInterval(1);
+  if (rank != 0) {
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+  }
+  verifyFlush(10);
+}

--- a/packages/seacas/libraries/ioss/src/unit_tests/UnitTestFlushHandler.C
+++ b/packages/seacas/libraries/ioss/src/unit_tests/UnitTestFlushHandler.C
@@ -22,8 +22,8 @@ class FlushTest : public ::testing::Test
 {
 protected:
   Ioss::FlushHandler fh;
-  int                                 rank;
-  int                                 size;
+  int                rank;
+  int                size;
 
   void verifyFlush(int state)
   {


### PR DESCRIPTION
    IOSS: exodus output disk flush
    
    Moved code to handle disk flushing for file per rank
    Exodus output into separate class with unit testing. Added
    new IOSS property FLUSH_ON_FIRST_OUTPUT that will trigger
    a flush to disk on the first time output is called.