### PR TITLE
Iocgns: Fix ctx_cgio C linkage with GCC 15

### DIFF
--- a/packages/seacas/libraries/ioss/src/cgns/Iocgns_DatabaseIO.C
+++ b/packages/seacas/libraries/ioss/src/cgns/Iocgns_DatabaseIO.C
@@ -78,9 +78,8 @@
 
 // extern char hdf5_access[64];
 
-namespace {
-  extern "C" {
-  // From private CGNS header: `cgio_internal_type.h`
+extern "C" {
+// From private CGNS header: `cgio_internal_type.h`
   typedef struct _cgns_io_ctx_t
   {
     /* Flag indicating if HDF5 file accesses is PARALLEL or NATIVE */
@@ -97,8 +96,10 @@ namespace {
 #endif
   } cgns_io_ctx_t;
 
-  extern cgns_io_ctx_t ctx_cgio; /* located in cgns_io.c */
-  }
+extern cgns_io_ctx_t ctx_cgio; /* located in cgns_io.c */
+}
+
+namespace {
 
   // There is a bug in the CGNS library (4.4.0 and before) where it
   // has a global symbol `ctx_cgio` which controls whether


### PR DESCRIPTION
## Summary

Fix the linkage of the CGNS-internal `ctx_cgio` symbol in `Iocgns_DatabaseIO.C`.

The declaration was inside an unnamed namespace. Although it was declared within an `extern "C"` block, membership in the unnamed namespace gave the variable internal linkage. With GCC 15, this results in a reference to the C++ anonymous-namespace symbol instead of the plain C symbol exported by CGNS.

Move the declaration and its associated type to global scope while retaining the `extern "C"` language linkage. The unnamed namespace now begins after the declaration.

## Problem

When building SEACAS/Iocgns with GCC 15, linking fails because the generated reference is effectively to: `(anonymous namespace)::ctx_cgio`

CGNS exports the symbol as: `ctx_cgio`

This results in an undefined-reference error during linking.

## Fix

Declare `cgns_io_ctx_t` and `ctx_cgio` in an `extern "C"` block at global
scope. This preserves external C linkage for `ctx_cgio`.

No runtime behavior is changed.

## Testing

Before this change, the Iocgns link failed due to the unresolved/mismatched
`ctx_cgio` symbol. After this change, Iocgns builds and links successfully.

Fixes #889

Assisted-by: GPT-5.6 Sol