### PR TITLE
IOSS: FlushHandler

### DIFF
--- a/packages/seacas/libraries/ioss/src/Ioss_FlushHandler.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_FlushHandler.C
@@ -57,10 +57,10 @@ namespace Ioss {
 #ifdef SEACAS_HAVE_MPI
     if (isParallel) {
       if (Ioss::SerializeIO::isEnabled()) {
-        util.broadcast(iflush);
+        util().broadcast(iflush);
       }
       else {
-        iflush = util.global_minmax(iflush, Ioss::ParallelUtils::DO_MAX);
+        iflush = util().global_minmax(iflush, Ioss::ParallelUtils::DO_MAX);
       }
     }
 #endif

--- a/packages/seacas/libraries/ioss/src/Ioss_FlushHandler.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_FlushHandler.C
@@ -39,12 +39,12 @@ namespace Ioss {
     return allReduce(do_flush);
   }
 
-  bool FlushHandler::isGreaterThanFlushInterval(time_t lastFlushTime, unsigned int flushInterval)
+  bool FlushHandler::isGreaterThanFlushInterval(time_t lastFlushTime, unsigned int interval)
   {
     time_t cur_time = time(nullptr);
     bool   do_flush = false;
 
-    if (std::difftime(cur_time, lastFlushTime) >= flushInterval) {
+    if (std::difftime(cur_time, lastFlushTime) >= interval) {
       timeLastFlush = cur_time;
       do_flush      = true;
     }

--- a/packages/seacas/libraries/ioss/src/Ioss_FlushHandler.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_FlushHandler.h
@@ -10,6 +10,7 @@
 #include "Ioss_ParallelUtils.h"
 #include "ioss_export.h"
 #include <ctime>
+#include <functional>
 
 namespace Ioss {
 
@@ -30,28 +31,27 @@ namespace Ioss {
   class IOSS_EXPORT FlushHandler
   {
   private:
-    int                 flushInterval;
-    bool                isParallel;
-    bool                isFirstOutput;
-    bool                flushOnFirstOutput;
-    unsigned int        timeLastFlushInterval;
-    unsigned int        timeStepBeginFlushInterval;
-    time_t              timeLastFlush;
-    time_t              timeStepBegin;
-    Ioss::ParallelUtils util;
+    int                                               flushInterval;
+    bool                                              isParallel;
+    bool                                              isFirstOutput;
+    bool                                              flushOnFirstOutput;
+    unsigned int                                      timeLastFlushInterval;
+    unsigned int                                      timeStepBeginFlushInterval;
+    time_t                                            timeLastFlush;
+    time_t                                            timeStepBegin;
+    std::reference_wrapper<const Ioss::ParallelUtils> util_;
 
   public:
-    FlushHandler()
+    FlushHandler() = delete;
+
+    explicit FlushHandler(const Ioss::ParallelUtils &util)
+        : flushInterval(-1), isParallel(true), isFirstOutput(true), flushOnFirstOutput(false),
+          timeLastFlushInterval(10), timeStepBeginFlushInterval(10), timeLastFlush(time(nullptr)),
+          timeStepBegin(time(nullptr)), util_(util)
     {
-      flushInterval              = -1;
-      timeLastFlush              = time(nullptr);
-      timeStepBegin              = time(nullptr);
-      isParallel                 = true;
-      isFirstOutput              = true;
-      flushOnFirstOutput         = false;
-      timeLastFlushInterval      = 10;
-      timeStepBeginFlushInterval = 10;
     }
+
+    const Ioss::ParallelUtils &util() const { return util_; }
 
     int getFlushInterval() { return flushInterval; }
 

--- a/packages/seacas/libraries/ioss/src/Ioss_FlushHandler.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_FlushHandler.h
@@ -85,7 +85,7 @@ namespace Ioss {
 
     bool allReduce(bool do_flush);
 
-    bool isGreaterThanFlushInterval(time_t lastFlushTime, unsigned int flushInterval);
+    bool isGreaterThanFlushInterval(time_t lastFlushTime, unsigned int interval);
   };
 
 } // namespace Ioss

--- a/packages/seacas/libraries/ioss/src/exodus/Ioex_BaseDatabaseIO.C
+++ b/packages/seacas/libraries/ioss/src/exodus/Ioex_BaseDatabaseIO.C
@@ -15,6 +15,7 @@
 #include <fmt/format.h>
 #include <fmt/ostream.h>
 #include <map>
+#include <memory>
 #include <sstream>
 #include <string>
 #include <tokenize.h>
@@ -182,6 +183,8 @@ namespace Ioex {
 
     dbState = Ioss::STATE_UNKNOWN;
 
+    flushHandler = std::make_unique<Ioss::FlushHandler>(util());
+
     // Set exodusII warning level.
     if (util().get_environment("EX_DEBUG", isParallel)) {
       fmt::print(
@@ -305,14 +308,14 @@ namespace Ioex {
       }
     }
 
-    flushHandler.setIsParallel(isParallel);
+    flushHandler->setIsParallel(isParallel);
     if (!is_input()) {
       if (properties.exists("FLUSH_INTERVAL")) {
         int interval = properties.get("FLUSH_INTERVAL").get_int();
-        flushHandler.setFlushInterval(interval);
+        flushHandler->setFlushInterval(interval);
       }
       if (properties.exists("FLUSH_ON_FIRST_OUTPUT")) {
-        flushHandler.setFlushOnFirstOutput(true);
+        flushHandler->setFlushOnFirstOutput(true);
       }
     }
 
@@ -1495,7 +1498,7 @@ namespace Ioex {
     a_time /= timeScaleFactor;
 
     if (!is_input()) {
-      flushHandler.resetTimeStepBegin();
+      flushHandler->resetTimeStepBegin();
       if (get_file_per_state()) {
         // Close current file; create new file and output transient metadata...
         open_state_file(state);
@@ -2534,7 +2537,7 @@ namespace Ioex {
     // Update the attribute.
     Ioex::update_last_time_attribute(get_file_pointer(), sim_time);
 
-    if (flushHandler.doFlush(state)) {
+    if (flushHandler->doFlush(state)) {
       flush_database_nl();
     }
   }

--- a/packages/seacas/libraries/ioss/src/exodus/Ioex_BaseDatabaseIO.h
+++ b/packages/seacas/libraries/ioss/src/exodus/Ioex_BaseDatabaseIO.h
@@ -18,11 +18,11 @@
 #include <ctime>
 #include <exodusII.h>
 #include <map>
+#include <memory>
 #include <set>
 #include <sstream>
 #include <string>
 #include <vector>
-#include <memory>
 
 #include "Ioss_CodeTypes.h"
 #include "Ioss_DataSize.h"

--- a/packages/seacas/libraries/ioss/src/exodus/Ioex_BaseDatabaseIO.h
+++ b/packages/seacas/libraries/ioss/src/exodus/Ioex_BaseDatabaseIO.h
@@ -94,6 +94,8 @@ namespace Ioex {
 
     IOSS_NODISCARD std::string get_internal_change_set_name() const override { return m_groupName; }
 
+    IOSS_NODISCARD const Ioss::FlushHandler &get_flush_handler() const { return *flushHandler; }
+
     /** \brief Checks if a database type supports groups
      *
      *  \returns True if successful.

--- a/packages/seacas/libraries/ioss/src/exodus/Ioex_BaseDatabaseIO.h
+++ b/packages/seacas/libraries/ioss/src/exodus/Ioex_BaseDatabaseIO.h
@@ -22,6 +22,7 @@
 #include <sstream>
 #include <string>
 #include <vector>
+#include <memory>
 
 #include "Ioss_CodeTypes.h"
 #include "Ioss_DataSize.h"
@@ -408,7 +409,7 @@ namespace Ioex {
 
     int m_timestepCount{0};
 
-    Ioss::FlushHandler flushHandler;
+    std::unique_ptr<Ioss::FlushHandler> flushHandler;
 
     bool         timeFileOpenCloseFlush{false};
     mutable bool fileExists{false}; // False if file has never been opened/created

--- a/packages/seacas/libraries/ioss/src/unit_tests/UnitTestFlushHandler.C
+++ b/packages/seacas/libraries/ioss/src/unit_tests/UnitTestFlushHandler.C
@@ -21,9 +21,10 @@
 class FlushTest : public ::testing::Test
 {
 protected:
-  Ioss::FlushHandler fh;
-  int                rank;
-  int                size;
+  Ioss::ParallelUtils util_;
+  Ioss::FlushHandler  fh{util_};
+  int                 rank;
+  int                 size;
 
   void verifyFlush(int state)
   {
@@ -132,4 +133,24 @@ TEST_F(FlushTest, DefaultFlushHandlerMultipleRanks)
     std::this_thread::sleep_for(std::chrono::seconds(2));
   }
   verifyFlush(10);
+}
+
+TEST_F(FlushTest, FlushHandlerSplitMPICommunicator)
+{
+  if (size < 2) {
+    GTEST_SKIP() << "Skipping parallel test\n";
+  }
+
+  int color = rank % 2;
+  int key   = rank;
+
+  MPI_Comm sub_comm;
+  MPI_Comm_split(MPI_COMM_WORLD, color, key, &sub_comm);
+
+  Ioss::ParallelUtils util_(sub_comm);
+  fh = Ioss::FlushHandler(util_);
+
+  int cmp = MPI_UNEQUAL;
+  MPI_Comm_compare(fh.util().communicator(), sub_comm, &cmp);
+  EXPECT_TRUE(cmp == MPI_IDENT || cmp == MPI_CONGRUENT);
 }

--- a/packages/seacas/libraries/ioss/src/unit_tests/UnitTestFlushHandler.C
+++ b/packages/seacas/libraries/ioss/src/unit_tests/UnitTestFlushHandler.C
@@ -13,7 +13,10 @@
 #include "mpi.h"
 #endif
 
+#include "Ionit_Initializer.h"
 #include "Ioss_FlushHandler.h"
+#include "Ioss_IOFactory.h"
+#include "exodus/Ioex_BaseDatabaseIO.h"
 #include <chrono>
 #include <gtest/gtest.h>
 #include <thread>
@@ -37,6 +40,25 @@ protected:
     fh.resetTimeStepBegin();
     ASSERT_FALSE(fh.doFlush(state));
   }
+
+#ifdef SEACAS_HAVE_MPI
+  MPI_Comm get_split_comm()
+  {
+    int color = rank % 2;
+    int key   = rank;
+
+    MPI_Comm sub_comm;
+    MPI_Comm_split(MPI_COMM_WORLD, color, key, &sub_comm);
+    return sub_comm;
+  }
+
+  void compare_mpi_comms(MPI_Comm comm1, MPI_Comm comm2)
+  {
+    int cmp = MPI_UNEQUAL;
+    MPI_Comm_compare(comm1, comm2, &cmp);
+    EXPECT_TRUE(cmp == MPI_IDENT || cmp == MPI_CONGRUENT);
+  }
+#endif
 
   void SetUp() override
   {
@@ -142,17 +164,31 @@ TEST_F(FlushTest, FlushHandlerSplitMPICommunicator)
   }
 
 #ifdef SEACAS_HAVE_MPI
-  int color = rank % 2;
-  int key   = rank;
-
-  MPI_Comm sub_comm;
-  MPI_Comm_split(MPI_COMM_WORLD, color, key, &sub_comm);
+  MPI_Comm sub_comm = get_split_comm();
 
   Ioss::ParallelUtils util_(sub_comm);
   fh = Ioss::FlushHandler(util_);
 
-  int cmp = MPI_UNEQUAL;
-  MPI_Comm_compare(fh.util().communicator(), sub_comm, &cmp);
-  EXPECT_TRUE(cmp == MPI_IDENT || cmp == MPI_CONGRUENT);
+  compare_mpi_comms(fh.util().communicator(), sub_comm);
+#endif
+}
+
+TEST_F(FlushTest, FlushHandlerSplitMPICommunicatorDatabase)
+{
+  if (size < 2) {
+    GTEST_SKIP() << "Skipping parallel test\n";
+  }
+
+#ifdef SEACAS_HAVE_MPI
+  MPI_Comm sub_comm = get_split_comm();
+
+  Ioss::Init::Initializer init_db;
+  Ioss::PropertyManager   properties;
+  Ioex::BaseDatabaseIO   *dbi = dynamic_cast<Ioex::BaseDatabaseIO *>(
+      Ioss::IOFactory::create("exodus", "mesh.exo", Ioss::WRITE_RESTART, sub_comm, properties));
+  ASSERT_NE(dbi, nullptr);
+
+  compare_mpi_comms(dbi->get_flush_handler().util().communicator(), sub_comm);
+  delete dbi;
 #endif
 }

--- a/packages/seacas/libraries/ioss/src/unit_tests/UnitTestFlushHandler.C
+++ b/packages/seacas/libraries/ioss/src/unit_tests/UnitTestFlushHandler.C
@@ -141,6 +141,7 @@ TEST_F(FlushTest, FlushHandlerSplitMPICommunicator)
     GTEST_SKIP() << "Skipping parallel test\n";
   }
 
+#ifdef SEACAS_HAVE_MPI
   int color = rank % 2;
   int key   = rank;
 
@@ -153,4 +154,5 @@ TEST_F(FlushTest, FlushHandlerSplitMPICommunicator)
   int cmp = MPI_UNEQUAL;
   MPI_Comm_compare(fh.util().communicator(), sub_comm, &cmp);
   EXPECT_TRUE(cmp == MPI_IDENT || cmp == MPI_CONGRUENT);
+#endif
 }

--- a/packages/seacas/libraries/ioss/src/unit_tests/UnitTestIotmDatabaseIO.C
+++ b/packages/seacas/libraries/ioss/src/unit_tests/UnitTestIotmDatabaseIO.C
@@ -8,9 +8,9 @@
 #include "mpi.h"
 #endif
 #include "gtest/gtest.h"
-#include <future>
 #include <chrono>
 #include <functional>
+#include <future>
 
 #include "Ionit_Initializer.h"
 #include "Ioss_CopyDatabase.h"
@@ -40,23 +40,30 @@
 
 namespace {
 
-  void test_timeout_threaded(int timeout_millisecs, const std::string& functionName, std::function<void()> function)
+  void test_timeout_threaded(int timeout_millisecs, const std::string &functionName,
+                             std::function<void()> function)
   {
     std::promise<bool> completed;
-    auto stmt_future = completed.get_future();
-    std::thread([&function](std::promise<bool>& completed) {
-      function();
-      completed.set_value(true);
-    }, std::ref(completed)).detach();
-    if(stmt_future.wait_for(std::chrono::milliseconds(timeout_millisecs)) == std::future_status::timeout) {
+    auto               stmt_future = completed.get_future();
+    std::thread(
+        [&function](std::promise<bool> &completed) {
+          function();
+          completed.set_value(true);
+        },
+        std::ref(completed))
+        .detach();
+    if (stmt_future.wait_for(std::chrono::milliseconds(timeout_millisecs)) ==
+        std::future_status::timeout) {
       std::ostringstream err;
-      err << "Function `" << functionName << "` hung and timed out (> " << timeout_millisecs << " milliseconds).";
-//      GTEST_FATAL_FAILURE_(err.str().c_str());
+      err << "Function `" << functionName << "` hung and timed out (> " << timeout_millisecs
+          << " milliseconds).";
+      //      GTEST_FATAL_FAILURE_(err.str().c_str());
       EXPECT_TRUE(false) << err.str();
     }
   }
 
-  void test_timeout_non_threaded(int timeout_millisecs, const std::string& functionName, std::function<void()> function)
+  void test_timeout_non_threaded(int timeout_millisecs, const std::string &functionName,
+                                 std::function<void()> function)
   {
     // Run the code asynchronously
     std::future<void> futureResult = std::async(std::launch::async, function);
@@ -66,7 +73,8 @@ namespace {
 
     // Assert that it did NOT time out
     std::ostringstream err;
-    err << "Function `" << functionName << "` hung and timed out (> " << timeout_millisecs << " milliseconds).";
+    err << "Function `" << functionName << "` hung and timed out (> " << timeout_millisecs
+        << " milliseconds).";
     EXPECT_NE(status, std::future_status::timeout) << err.str();
   }
 
@@ -80,7 +88,7 @@ namespace {
   std::vector<int64_t> get_element_ids_from_block_impl(const Ioss::ElementBlock *block)
   {
     std::vector<int64_t> elemIds;
-    std::vector<INT> ids;
+    std::vector<INT>     ids;
 
     block->get_field_data("ids", ids);
 
@@ -102,7 +110,8 @@ namespace {
   }
 
   template <typename INT>
-  bool get_element_conn_from_block_impl(int64_t elemId, const Ioss::ElementBlock *block, std::vector<int64_t> &elemConn)
+  bool get_element_conn_from_block_impl(int64_t elemId, const Ioss::ElementBlock *block,
+                                        std::vector<int64_t> &elemConn)
   {
     const Ioss::ElementTopology *topo = nullptr;
 
@@ -134,27 +143,28 @@ namespace {
   }
 
   template <typename INT>
-  std::vector<int64_t> get_element_conn_impl(Ioss::Region& region, int64_t elemId)
+  std::vector<int64_t> get_element_conn_impl(Ioss::Region &region, int64_t elemId)
   {
     std::vector<int64_t> elemConn;
 
     const Ioss::ElementBlockContainer &elemBlocks = region.get_element_blocks();
 
     for (const Ioss::ElementBlock *block : elemBlocks) {
-      if(get_element_conn_from_block_impl<INT>(elemId, block, elemConn)) {
+      if (get_element_conn_from_block_impl<INT>(elemId, block, elemConn)) {
         return elemConn;
       }
     }
     return std::vector<int64_t>{};
   }
 
-  std::vector<int64_t> get_element_conn(Ioss::Region& region, int64_t elemId)
+  std::vector<int64_t> get_element_conn(Ioss::Region &region, int64_t elemId)
   {
     std::vector<int64_t> elemConn;
 
     if (db_api_int_size(region.get_database()) == 4) {
       return get_element_conn_impl<int>(region, elemId);
-    } else {
+    }
+    else {
       return get_element_conn_impl<int64_t>(region, elemId);
     }
   }
@@ -185,7 +195,7 @@ namespace {
     for (Ioss::ElementBlock *o_eb : o_region.get_element_blocks()) {
       size_t num_elem = o_eb->entity_count();
 
-      std::vector<double> field_data(num_elem);
+      std::vector<double>  field_data(num_elem);
       std::vector<int64_t> elem_ids = get_element_ids_from_block(o_eb);
 
       for (size_t i = 0; i < elem_ids.size(); i++) {
@@ -199,7 +209,8 @@ namespace {
     o_region.end_mode(Ioss::STATE_TRANSIENT);
   }
 
-  Iotm::DatabaseIO *create_input_db_io(const std::string &meshDesc, Ioss_MPI_Comm comm = Ioss::ParallelUtils::comm_world())
+  Iotm::DatabaseIO *create_input_db_io(const std::string &meshDesc,
+                                       Ioss_MPI_Comm      comm = Ioss::ParallelUtils::comm_world())
   {
     Ioss::Init::Initializer init_db;
 
@@ -213,7 +224,8 @@ namespace {
     return db_io;
   }
 
-  Ioss::DatabaseIO *create_output_db_io(const std::string &outputFile, Ioss_MPI_Comm comm = Ioss::ParallelUtils::comm_world())
+  Ioss::DatabaseIO *create_output_db_io(const std::string &outputFile,
+                                        Ioss_MPI_Comm      comm = Ioss::ParallelUtils::comm_world())
   {
     Ioss::DatabaseUsage   db_usage = Ioss::WRITE_RESTART;
     Ioss::PropertyManager properties;
@@ -222,7 +234,8 @@ namespace {
     properties.add(Ioss::Property("INTEGER_SIZE_DB", 8));
     properties.add(Ioss::Property("INTEGER_SIZE_API", 8));
 
-    Ioss::DatabaseIO *db_io = Ioss::IOFactory::create("exodusII", outputFile, db_usage, comm, properties);
+    Ioss::DatabaseIO *db_io =
+        Ioss::IOFactory::create("exodusII", outputFile, db_usage, comm, properties);
     return db_io;
   }
 
@@ -620,7 +633,7 @@ namespace {
     EXPECT_EQ(8u, node_blocks[0]->entity_count());
 
     std::vector<int64_t> elemConn = get_element_conn(region, 1);
-    std::vector<int64_t> goldNodeIds{1,2,3,4,5,6,7,8};
+    std::vector<int64_t> goldNodeIds{1, 2, 3, 4, 5, 6, 7, 8};
     EXPECT_EQ(goldNodeIds, elemConn);
   }
 
@@ -637,9 +650,9 @@ namespace {
     MPI_Comm_split(MPI_COMM_WORLD, color, key, &comm);
 #endif
 
-    std::string meshDesc = "0,1,HEX_8,1,2,3,4,5,6,7,8,block_1"
-                           "|coordinates:   0,0,0, 1,0,0, 1,1,0, 0,1,0, 0,0,1, 1,0,1, 1,1,1, 0,1,1";
-    Iotm::DatabaseIO *db_i = create_input_db_io(meshDesc, comm);
+    std::string       meshDesc = "0,1,HEX_8,1,2,3,4,5,6,7,8,block_1"
+                                 "|coordinates:   0,0,0, 1,0,0, 1,1,0, 0,1,0, 0,0,1, 1,0,1, 1,1,1, 0,1,1";
+    Iotm::DatabaseIO *db_i     = create_input_db_io(meshDesc, comm);
     ASSERT_FALSE(db_i == nullptr || !db_i->ok(true));
 
     Ioss::Region region_i(db_i, "region_i");
@@ -670,7 +683,8 @@ namespace {
 
     const std::string elemFieldName = "elem_id_data";
     define_element_transient(region_o, elemFieldName);
-    write_element_transient(region_o, elemFieldName);   // Remove this line and enable the pre-processor macro below
+    write_element_transient(
+        region_o, elemFieldName); // Remove this line and enable the pre-processor macro below
 
 #if 0
     int timeout_millisecs = 500;

--- a/packages/seacas/libraries/ioss/src/unit_tests/UnitTestIotmDatabaseIO.C
+++ b/packages/seacas/libraries/ioss/src/unit_tests/UnitTestIotmDatabaseIO.C
@@ -8,14 +8,20 @@
 #include "mpi.h"
 #endif
 #include "gtest/gtest.h"
+#include <future>
+#include <chrono>
+#include <functional>
 
 #include "Ionit_Initializer.h"
+#include "Ioss_CopyDatabase.h"
 #include "Ioss_DBUsage.h"
 #include "Ioss_ElementBlock.h"
 #include "Ioss_ElementTopology.h"
 #include "Ioss_Hex8.h"
+#include "Ioss_MeshCopyOptions.h"
 #include "Ioss_NodeBlock.h"
 #include "Ioss_NodeSet.h"
+#include "Ioss_Property.h"
 #include "Ioss_PropertyManager.h"
 #include "Ioss_Region.h"
 #include "Ioss_Shell4.h"
@@ -34,7 +40,166 @@
 
 namespace {
 
-  Iotm::DatabaseIO *create_input_db_io(const std::string &meshDesc)
+  void test_timeout_threaded(int timeout_millisecs, const std::string& functionName, std::function<void()> function)
+  {
+    std::promise<bool> completed;
+    auto stmt_future = completed.get_future();
+    std::thread([&function](std::promise<bool>& completed) {
+      function();
+      completed.set_value(true);
+    }, std::ref(completed)).detach();
+    if(stmt_future.wait_for(std::chrono::milliseconds(timeout_millisecs)) == std::future_status::timeout) {
+      std::ostringstream err;
+      err << "Function `" << functionName << "` hung and timed out (> " << timeout_millisecs << " milliseconds).";
+//      GTEST_FATAL_FAILURE_(err.str().c_str());
+      EXPECT_TRUE(false) << err.str();
+    }
+  }
+
+  void test_timeout_non_threaded(int timeout_millisecs, const std::string& functionName, std::function<void()> function)
+  {
+    // Run the code asynchronously
+    std::future<void> futureResult = std::async(std::launch::async, function);
+
+    // Wait for a maximum of 500 milliseconds
+    auto status = futureResult.wait_for(std::chrono::milliseconds(timeout_millisecs));
+
+    // Assert that it did NOT time out
+    std::ostringstream err;
+    err << "Function `" << functionName << "` hung and timed out (> " << timeout_millisecs << " milliseconds).";
+    EXPECT_NE(status, std::future_status::timeout) << err.str();
+  }
+
+  int db_api_int_size(Ioss::DatabaseIO *db)
+  {
+    assert(db != nullptr);
+    return db->int_byte_size_api();
+  }
+
+  template <typename INT>
+  std::vector<int64_t> get_element_ids_from_block_impl(const Ioss::ElementBlock *block)
+  {
+    std::vector<int64_t> elemIds;
+    std::vector<INT> ids;
+
+    block->get_field_data("ids", ids);
+
+    for (INT id : ids) {
+      elemIds.push_back(static_cast<int64_t>(id));
+    }
+
+    return elemIds;
+  }
+
+  std::vector<int64_t> get_element_ids_from_block(const Ioss::ElementBlock *block)
+  {
+    if (db_api_int_size(block->get_database()) == 4) {
+      return get_element_ids_from_block_impl<int>(block);
+    }
+    else {
+      return get_element_ids_from_block_impl<int64_t>(block);
+    }
+  }
+
+  template <typename INT>
+  bool get_element_conn_from_block_impl(int64_t elemId, const Ioss::ElementBlock *block, std::vector<int64_t> &elemConn)
+  {
+    const Ioss::ElementTopology *topo = nullptr;
+
+    std::vector<INT> connectivity;
+    std::vector<INT> elemIds;
+
+    block->get_field_data("ids", elemIds);
+    block->get_field_data("connectivity", connectivity);
+
+    topo = block->topology();
+
+    size_t elementCount = elemIds.size();
+    int    nodesPerElem = topo->number_nodes();
+
+    for (size_t i = 0; i < elementCount; ++i) {
+      INT *conn = &connectivity[i * nodesPerElem];
+      auto id   = static_cast<int64_t>(elemIds[i]);
+
+      if (id == elemId) {
+        for (int j = 0; j < nodesPerElem; j++) {
+          elemConn.push_back(conn[j]);
+        }
+
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  template <typename INT>
+  std::vector<int64_t> get_element_conn_impl(Ioss::Region& region, int64_t elemId)
+  {
+    std::vector<int64_t> elemConn;
+
+    const Ioss::ElementBlockContainer &elemBlocks = region.get_element_blocks();
+
+    for (const Ioss::ElementBlock *block : elemBlocks) {
+      if(get_element_conn_from_block_impl<INT>(elemId, block, elemConn)) {
+        return elemConn;
+      }
+    }
+    return std::vector<int64_t>{};
+  }
+
+  std::vector<int64_t> get_element_conn(Ioss::Region& region, int64_t elemId)
+  {
+    std::vector<int64_t> elemConn;
+
+    if (db_api_int_size(region.get_database()) == 4) {
+      return get_element_conn_impl<int>(region, elemId);
+    } else {
+      return get_element_conn_impl<int64_t>(region, elemId);
+    }
+  }
+
+  void define_element_transient(Ioss::Region &o_region, const std::string &elemFieldName)
+  {
+    o_region.begin_mode(Ioss::STATE_DEFINE_TRANSIENT);
+
+    for (Ioss::ElementBlock *o_eb : o_region.get_element_blocks()) {
+      size_t      num_elem = o_eb->entity_count();
+      std::string storage  = "scalar";
+
+      Ioss::Field field(elemFieldName, Ioss::Field::REAL, storage, 1, Ioss::Field::Field::TRANSIENT,
+                        num_elem);
+      o_eb->field_add(field);
+    }
+    o_region.end_mode(Ioss::STATE_DEFINE_TRANSIENT);
+  }
+
+  void write_element_transient(Ioss::Region &o_region, const std::string &elemFieldName)
+  {
+    int numTimeSteps = o_region.get_implicit_property("state_count").get_int();
+
+    o_region.begin_mode(Ioss::STATE_TRANSIENT);
+    int step = o_region.add_state((double)numTimeSteps);
+    o_region.begin_state(step);
+
+    for (Ioss::ElementBlock *o_eb : o_region.get_element_blocks()) {
+      size_t num_elem = o_eb->entity_count();
+
+      std::vector<double> field_data(num_elem);
+      std::vector<int64_t> elem_ids = get_element_ids_from_block(o_eb);
+
+      for (size_t i = 0; i < elem_ids.size(); i++) {
+        field_data[i] = (double)elem_ids[i];
+      }
+
+      o_eb->put_field_data(elemFieldName, field_data);
+    }
+
+    o_region.end_state(step);
+    o_region.end_mode(Ioss::STATE_TRANSIENT);
+  }
+
+  Iotm::DatabaseIO *create_input_db_io(const std::string &meshDesc, Ioss_MPI_Comm comm = Ioss::ParallelUtils::comm_world())
   {
     Ioss::Init::Initializer init_db;
 
@@ -44,19 +209,31 @@ namespace {
     properties.add(Ioss::Property("INTEGER_SIZE_DB", 8));
     properties.add(Ioss::Property("INTEGER_SIZE_API", 8));
 
-    auto *db_io = new Iotm::DatabaseIO(nullptr, meshDesc, db_usage,
-                                       Ioss::ParallelUtils::comm_world(), properties);
+    auto *db_io = new Iotm::DatabaseIO(nullptr, meshDesc, db_usage, comm, properties);
     return db_io;
   }
 
-  int get_parallel_size()
+  Ioss::DatabaseIO *create_output_db_io(const std::string &outputFile, Ioss_MPI_Comm comm = Ioss::ParallelUtils::comm_world())
   {
-    return Ioss::ParallelUtils(Ioss::ParallelUtils::comm_world()).parallel_size();
+    Ioss::DatabaseUsage   db_usage = Ioss::WRITE_RESTART;
+    Ioss::PropertyManager properties;
+
+    properties.add(Ioss::Property("FLUSH_INTERVAL", 1));
+    properties.add(Ioss::Property("INTEGER_SIZE_DB", 8));
+    properties.add(Ioss::Property("INTEGER_SIZE_API", 8));
+
+    Ioss::DatabaseIO *db_io = Ioss::IOFactory::create("exodusII", outputFile, db_usage, comm, properties);
+    return db_io;
   }
 
-  int get_parallel_rank()
+  int get_parallel_size(Ioss_MPI_Comm comm = Ioss::ParallelUtils::comm_world())
   {
-    return Ioss::ParallelUtils(Ioss::ParallelUtils::comm_world()).parallel_rank();
+    return Ioss::ParallelUtils(comm).parallel_size();
+  }
+
+  int get_parallel_rank(Ioss_MPI_Comm comm = Ioss::ParallelUtils::comm_world())
+  {
+    return Ioss::ParallelUtils(comm).parallel_rank();
   }
 
   bool include_entity(const Ioss::GroupingEntity *entity)
@@ -80,11 +257,11 @@ namespace {
                            "0,2,HEX_8,5,6,7,8,9,10,11,12,block_2";
 
     Iotm::DatabaseIO *db_io = create_input_db_io(meshDesc);
+    EXPECT_TRUE(nullptr != db_io);
     db_io->set_surface_split_type(Ioss::SPLIT_BY_ELEMENT_BLOCK);
 
     Ioss::Region region(db_io);
 
-    EXPECT_TRUE(nullptr != db_io);
     EXPECT_TRUE(db_io->ok());
     EXPECT_EQ("TextMesh", db_io->get_format());
 
@@ -416,4 +593,99 @@ namespace {
     }
   }
 
+  TEST(TextMesh, inputDuplicateMeshCommSelf)
+  {
+    if (get_parallel_size() != 2) {
+      GTEST_SKIP();
+    }
+
+    std::string meshDesc = "0,1,HEX_8,1,2,3,4,5,6,7,8,block_1";
+
+    Iotm::DatabaseIO *db_io = create_input_db_io(meshDesc, Ioss::ParallelUtils::comm_self());
+    EXPECT_TRUE(nullptr != db_io);
+
+    Ioss::Region region(db_io);
+
+    EXPECT_TRUE(db_io->ok());
+    EXPECT_EQ("TextMesh", db_io->get_format());
+
+    // With COMM_SELF, the mesh should be duplicated on each MPI rank
+    const std::vector<Ioss::ElementBlock *> &element_blocks = region.get_element_blocks();
+    EXPECT_EQ(1u, element_blocks.size());
+    EXPECT_EQ(1u, element_blocks[0]->entity_count());
+    EXPECT_EQ(Ioss::Hex8::name, element_blocks[0]->topology()->name());
+
+    const Ioss::NodeBlockContainer &node_blocks = region.get_node_blocks();
+    EXPECT_EQ(1u, node_blocks.size());
+    EXPECT_EQ(8u, node_blocks[0]->entity_count());
+
+    std::vector<int64_t> elemConn = get_element_conn(region, 1);
+    std::vector<int64_t> goldNodeIds{1,2,3,4,5,6,7,8};
+    EXPECT_EQ(goldNodeIds, elemConn);
+  }
+
+  TEST(TextMesh, outputMeshCommSelf)
+  {
+    if (get_parallel_size() != 4) {
+      GTEST_SKIP();
+    }
+
+    Ioss_MPI_Comm comm = Ioss::ParallelUtils::comm_self();
+#ifdef SEACAS_HAVE_MPI
+    int color = get_parallel_rank() % 2;
+    int key   = get_parallel_rank();
+    MPI_Comm_split(MPI_COMM_WORLD, color, key, &comm);
+#endif
+
+    std::string meshDesc = "0,1,HEX_8,1,2,3,4,5,6,7,8,block_1"
+                           "|coordinates:   0,0,0, 1,0,0, 1,1,0, 0,1,0, 0,0,1, 1,0,1, 1,1,1, 0,1,1";
+    Iotm::DatabaseIO *db_i = create_input_db_io(meshDesc, comm);
+    ASSERT_FALSE(db_i == nullptr || !db_i->ok(true));
+
+    Ioss::Region region_i(db_i, "region_i");
+
+    std::string outputFile;
+    {
+      std::ostringstream os;
+      os << "output_file.e.";
+      os << get_parallel_rank();
+
+      outputFile = os.str();
+    }
+
+    Ioss::DatabaseIO *db_o = create_output_db_io(outputFile, comm);
+    ASSERT_FALSE(db_o == nullptr || !db_o->ok(true));
+
+    // NOTE: 'region_o' owns 'db_o' pointer at this time
+    Ioss::Region region_o(db_o, "region_o");
+
+    Ioss::MeshCopyOptions options{};
+    options.verbose           = true;
+    options.output_summary    = true;
+    options.debug             = false;
+    options.ints_64_bit       = false;
+    options.data_storage_type = 1;
+    options.add_proc_id       = false;
+    Ioss::copy_database(region_i, region_o, options);
+
+    const std::string elemFieldName = "elem_id_data";
+    define_element_transient(region_o, elemFieldName);
+    write_element_transient(region_o, elemFieldName);   // Remove this line and enable the pre-processor macro below
+
+#if 0
+    int timeout_millisecs = 500;
+    auto function = [&region_o, &elemFieldName]() {
+      write_element_transient(region_o, elemFieldName);
+    };
+    const std::string& functionName = "write_element_transient()";
+
+#if 0
+    test_timeout_non_threaded(timeout_millisecs, functionName, function);
+#else
+    test_timeout_threaded(timeout_millisecs, functionName, function);
+#endif
+#endif
+
+    unlink(db_o->decoded_filename().c_str());
+  }
 } // namespace

--- a/packages/seacas/libraries/ioss/src/unit_tests/UnitTestIotmDatabaseIO.C
+++ b/packages/seacas/libraries/ioss/src/unit_tests/UnitTestIotmDatabaseIO.C
@@ -40,44 +40,6 @@
 
 namespace {
 
-  void test_timeout_threaded(int timeout_millisecs, const std::string &functionName,
-                             std::function<void()> function)
-  {
-    std::promise<bool> completed;
-    auto               stmt_future = completed.get_future();
-    std::thread(
-        [&function](std::promise<bool> &completed) {
-          function();
-          completed.set_value(true);
-        },
-        std::ref(completed))
-        .detach();
-    if (stmt_future.wait_for(std::chrono::milliseconds(timeout_millisecs)) ==
-        std::future_status::timeout) {
-      std::ostringstream err;
-      err << "Function `" << functionName << "` hung and timed out (> " << timeout_millisecs
-          << " milliseconds).";
-      //      GTEST_FATAL_FAILURE_(err.str().c_str());
-      EXPECT_TRUE(false) << err.str();
-    }
-  }
-
-  void test_timeout_non_threaded(int timeout_millisecs, const std::string &functionName,
-                                 std::function<void()> function)
-  {
-    // Run the code asynchronously
-    std::future<void> futureResult = std::async(std::launch::async, function);
-
-    // Wait for a maximum of 500 milliseconds
-    auto status = futureResult.wait_for(std::chrono::milliseconds(timeout_millisecs));
-
-    // Assert that it did NOT time out
-    std::ostringstream err;
-    err << "Function `" << functionName << "` hung and timed out (> " << timeout_millisecs
-        << " milliseconds).";
-    EXPECT_NE(status, std::future_status::timeout) << err.str();
-  }
-
   int db_api_int_size(Ioss::DatabaseIO *db)
   {
     assert(db != nullptr);
@@ -637,7 +599,7 @@ namespace {
     EXPECT_EQ(goldNodeIds, elemConn);
   }
 
-  TEST(TextMesh, outputMeshCommSelf)
+  TEST(TextMesh, outputMeshCommSplit)
   {
     if (get_parallel_size() != 4) {
       GTEST_SKIP();
@@ -685,20 +647,6 @@ namespace {
     define_element_transient(region_o, elemFieldName);
     write_element_transient(
         region_o, elemFieldName); // Remove this line and enable the pre-processor macro below
-
-#if 0
-    int timeout_millisecs = 500;
-    auto function = [&region_o, &elemFieldName]() {
-      write_element_transient(region_o, elemFieldName);
-    };
-    const std::string& functionName = "write_element_transient()";
-
-#if 0
-    test_timeout_non_threaded(timeout_millisecs, functionName, function);
-#else
-    test_timeout_threaded(timeout_millisecs, functionName, function);
-#endif
-#endif
 
     unlink(db_o->decoded_filename().c_str());
   }


### PR DESCRIPTION
Changed FlushHandler constructor to accept an instance of ParallelUtils. This was causing an issue when the application used split MPI communicators and not the default of MPI_COMM_WORLD. Added unit test to verify that the split communicator is used by FlushHandler when constructed with it.

Updated Ioex_BaseDatabaseIO to construct FlushHandler with its own instance of ParallelUtils and thus pass in a split communicator if using one.