### PR TITLE
exomerge.py: tetra4 translation

### DIFF
--- a/packages/seacas/scripts/exomerge2.py
+++ b/packages/seacas/scripts/exomerge2.py
@@ -1280,6 +1280,7 @@ class ExodusModel(object):
         translation_list = {'hex': 'hex8',
                             'tet': 'tet4',
                             'tetra': 'tet4',
+                            'tetra4': 'tet4',
                             'tetra10': 'tet10',
                             'tri': 'tri3',
                             'triangle': 'tri3',

--- a/packages/seacas/scripts/exomerge3.py
+++ b/packages/seacas/scripts/exomerge3.py
@@ -1476,6 +1476,7 @@ class ExodusModel(object):
             "hex": "hex8",
             "tet": "tet4",
             "tetra": "tet4",
+            "tetra4": "tet4",
             "tetra10": "tet10",
             "tri": "tri3",
             "triangle": "tri3",


### PR DESCRIPTION
morph and cubit seem to prefer using tetra4, adds this to the translation list.